### PR TITLE
Add deep interactive exploration mode for researcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ out/
 # Example folder
 example/
 
+# Knowledge (may contain credentials)
+knowledge/
+
 # Output directories
 output/
 output/logs/

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -35,6 +35,7 @@ interface ExplorbotConfig {
   test: TestConfig;
   html?: HtmlConfig;
   action?: ActionConfig;
+  research?: ResearchConfig;
   dirs?: DirsConfig;
 }
 ```
@@ -139,6 +140,47 @@ interface TestConfig {
   workers: number;
 }
 ```
+
+### Research Configuration
+
+Controls the Researcher agent's interactive exploration during `/research --deep`.
+
+```typescript
+interface ResearchConfig {
+  skipElements?: string[];
+  includeElements?: string[];
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `skipElements` | `string[]` | Patterns or selectors for elements to skip during exploration. |
+| `includeElements` | `string[]` | Patterns or selectors for elements to always explore (overrides skipElements). |
+
+**Pattern types (both arrays support):**
+- **Name patterns** - plain text, partial match, case-insensitive (e.g., `'more'`, `'cookie'`)
+- **CSS selectors** - starts with `[`, `.`, or `#` (e.g., `'[aria-haspopup="true"]'`, `'.menu-btn'`)
+- **XPath selectors** - starts with `//` (e.g., `'//button[@data-action]'`)
+
+**Recommended starting values:**
+- `skipElements`: `['close', 'cancel', 'dismiss', 'x', 'back', 'previous', 'escape', 'exit']`
+- `includeElements`: `['more', 'options', 'actions', 'kebab', 'ellipsis', 'dots', 'overflow', '[aria-haspopup="true"]']`
+
+**Filtering priority:**
+1. `includeElements` patterns/selectors always get explored (highest priority)
+2. `skipElements` patterns/selectors are never explored
+
+Example:
+```typescript
+research: {
+  skipElements: ['cookie', 'consent', 'newsletter', '.chat-widget'],
+  includeElements: ['edit', 'delete', 'settings', '[aria-haspopup="true"]', '[data-testid="menu-btn"]'],
+}
+```
+
+**Workflow:** Run `/research --deep`, inspect output, then update config to skip unwanted elements or include missed ones.
+
+**Implementation:** `src/ai/researcher.ts` (`performInteractiveExploration` method)
 
 ## Example Configuration
 

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -546,8 +546,8 @@ export class Tester extends TaskAgent implements Agent {
     const schema = z.object({
       assessment: z.string().describe('Short review of current progress toward the main scenario goal'),
       suggestion: z.string().describe('Specific next action recommendation'),
-      recommendReset: z.boolean().optional().describe('Recommend reset() if persistent failures suggest navigation issues'),
-      recommendStop: z.boolean().optional().describe('Recommend stop() if test is fundamentally incompatible or cannot proceed'),
+      recommendReset: z.boolean().describe('Recommend reset() if persistent failures suggest navigation issues'),
+      recommendStop: z.boolean().describe('Recommend stop() if test is fundamentally incompatible or cannot proceed'),
     });
 
     let problemContext = '';
@@ -664,7 +664,7 @@ export class Tester extends TaskAgent implements Agent {
     const schema = z.object({
       summary: z.string().describe('Concise overview of the test findings'),
       scenarioAchieved: z.boolean().describe('Indicates if the scenario goal appears satisfied'),
-      recommendation: z.string().optional().describe('Follow-up suggestion if needed'),
+      recommendation: z.string().describe('Follow-up suggestion if needed'),
     });
 
     const model = this.provider.getModelForAgent('tester');

--- a/src/commands/research-command.ts
+++ b/src/commands/research-command.ts
@@ -6,7 +6,8 @@ export class ResearchCommand extends BaseCommand {
 
   async execute(args: string): Promise<void> {
     const includeData = args.includes('--data');
-    const target = args.replace('--data', '').trim();
+    const includeDeep = args.includes('--deep');
+    const target = args.replace('--data', '').replace('--deep', '').trim();
 
     if (target) {
       await this.explorBot.getExplorer().visit(target);
@@ -21,6 +22,7 @@ export class ResearchCommand extends BaseCommand {
       screenshot: true,
       force: true,
       data: includeData,
+      deep: includeDeep,
     });
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,6 +90,7 @@ interface ActionConfig {
 
 interface ResearchConfig {
   skipElements?: string[];
+  includeElements?: string[];
 }
 
 interface ExplorbotConfig {
@@ -323,11 +324,14 @@ export class ConfigParser {
     const defaults = {
       playwright: {
         browser: 'chromium',
-        show: false, // we need headless
       },
       action: {
         delay: 1000,
         retries: 3,
+      },
+      research: {
+        skipElements: ['close', 'cancel', 'dismiss', 'x', 'back', 'previous', 'escape', 'exit'],
+        includeElements: ['more', 'options', 'actions', 'kebab', 'ellipsis', 'dots', 'overflow', '[aria-haspopup="true"]'],
       },
       dirs: {
         knowledge: 'knowledge',

--- a/src/config.ts
+++ b/src/config.ts
@@ -88,11 +88,16 @@ interface ActionConfig {
   retries?: number;
 }
 
+interface ResearchConfig {
+  skipElements?: string[];
+}
+
 interface ExplorbotConfig {
   playwright: PlaywrightConfig;
   ai: AIConfig;
   html?: HtmlConfig;
   action?: ActionConfig;
+  research?: ResearchConfig;
   dirs?: {
     knowledge: string;
     experience: string;
@@ -112,7 +117,7 @@ const config: ExplorbotConfig = {
   },
 };
 
-export type { ExplorbotConfig, PlaywrightConfig, AIConfig, HtmlConfig, ActionConfig, AgentConfig, AgentsConfig };
+export type { ExplorbotConfig, PlaywrightConfig, AIConfig, HtmlConfig, ActionConfig, AgentConfig, AgentsConfig, ResearchConfig };
 
 export class ConfigParser {
   private static instance: ConfigParser;

--- a/src/config.ts
+++ b/src/config.ts
@@ -324,14 +324,15 @@ export class ConfigParser {
     const defaults = {
       playwright: {
         browser: 'chromium',
+        show: false, // we need headless
       },
       action: {
         delay: 1000,
         retries: 3,
       },
       research: {
-        skipElements: ['close', 'cancel', 'dismiss', 'x', 'back', 'previous', 'escape', 'exit'],
-        includeElements: ['more', 'options', 'actions', 'kebab', 'ellipsis', 'dots', 'overflow', '[aria-haspopup="true"]'],
+        skipElements: [],
+        includeElements: [],
       },
       dirs: {
         knowledge: 'knowledge',


### PR DESCRIPTION
performInteractiveExploration() purpose: Discover what each button/link actually DOES when clicked. 
This could be baseline  logic, after proof that it researches better

Algorithm:
1. Collect all interactive elements from ARIA snapshot
   - No AI call needed - direct parsing
2. For each element:
   - Click it
   - Detect result (navigation, modal, content change)
   - Record outcome
   - Return to original state
3. Generate structured report
 
Flow:
/research --deep

1. performDeepAnalysis() runs first:
   └── Expands hidden menus, dropdowns, accordions
   └── Documents what's inside them
2. performInteractiveExploration() runs after:
   └── Clicks visible buttons/links
   └── Documents what each one does
3. Combined output:
   └── Complete picture of page structure AND behavior