### PR TITLE
Before hook playwright script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,10 @@ dist/
 build/
 out/
 
-# Example folder
+# App specific folders
 example/
+browser-scripts/
+knowledge/
 
 # Output directories
 output/

--- a/explorbot.config.example.ts
+++ b/explorbot.config.example.ts
@@ -117,10 +117,6 @@ const config: ExplorbotConfig = {
       height: 900,
     },
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-accelerated-2d-canvas', '--no-first-run', '--no-zygote', '--disable-gpu'],
-
-    setupScripts: [
-      './browser-scripts/auto-accept-cookies.setup.js',
-    ],
   },
 
   app: {

--- a/explorbot.config.example.ts
+++ b/explorbot.config.example.ts
@@ -19,6 +19,7 @@ interface PlaywrightConfig {
     height: number;
   };
   args: string[];
+  setupScripts?: string[];
 }
 
 interface AppConfig {
@@ -116,6 +117,10 @@ const config: ExplorbotConfig = {
       height: 900,
     },
     args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage', '--disable-accelerated-2d-canvas', '--no-first-run', '--no-zygote', '--disable-gpu'],
+
+    setupScripts: [
+      './browser-scripts/auto-accept-cookies.setup.js',
+    ],
   },
 
   app: {

--- a/src/action.ts
+++ b/src/action.ts
@@ -36,13 +36,15 @@ class Action {
   private expectation: string | null = null;
   public lastError: Error | null = null;
   public playwrightHelper: any;
+  private explorer: any;
 
-  constructor(actor: CodeceptJS.I, stateManager: StateManager) {
+  constructor(actor: CodeceptJS.I, stateManager: StateManager, explorer?: any) {
     this.actor = actor;
     this.stateManager = stateManager;
     this.experienceTracker = stateManager.getExperienceTracker();
     this.config = ConfigParser.getInstance().getConfig();
     this.playwrightHelper = container.helpers('Playwright');
+    this.explorer = explorer;
   }
 
   async caputrePageWithScreenshot(): Promise<ActionResult> {
@@ -193,6 +195,10 @@ class Action {
 
       await recorder.add(() => sleep(this.config.action?.delay || 500)); // wait for the action to be executed
       await recorder.promise();
+
+      if (this.explorer?.waitForPendingSetupScripts) {
+        await this.explorer.waitForPendingSetupScripts();
+      }
 
       const pageState = await this.capturePageState();
       if (executedSteps.length > 0) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ interface PlaywrightConfig {
     height: number;
   };
   args?: string[];
+  setupScripts?: string[];
 }
 
 interface AgentConfig {

--- a/src/page-setup-manager.ts
+++ b/src/page-setup-manager.ts
@@ -1,0 +1,100 @@
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { ExplorbotConfig } from './config.js';
+import type Explorer from './explorer.js';
+import type { KnowledgeTracker } from './knowledge-tracker.js';
+import type { StateManager } from './state-manager.js';
+import { createDebug, tag } from './utils/logger.js';
+
+const debugLog = createDebug('explorbot:page-setup');
+
+export interface SetupScriptContext {
+  page: any;
+  context: any;
+  explorer: Explorer;
+  stateManager: StateManager;
+  knowledgeTracker: KnowledgeTracker;
+  config: ExplorbotConfig;
+  log: (...args: any[]) => void;
+}
+
+interface SetupScriptModule {
+  setup: (context: SetupScriptContext) => Promise<void>;
+}
+
+export class PageSetupManager {
+  private scripts: SetupScriptModule[] = [];
+  private explorer: Explorer;
+  private config: ExplorbotConfig;
+  private isLoaded = false;
+
+  constructor(explorer: Explorer, config: ExplorbotConfig) {
+    this.explorer = explorer;
+    this.config = config;
+  }
+
+  async loadSetupScripts(): Promise<void> {
+    if (this.isLoaded) return;
+
+    const scriptPaths = this.config.playwright?.setupScripts || [];
+    if (scriptPaths.length === 0) {
+      debugLog('No setup scripts configured');
+      this.isLoaded = true;
+      return;
+    }
+
+    for (const scriptPath of scriptPaths) {
+      try {
+        const fullPath = resolve(scriptPath);
+
+        if (!existsSync(fullPath)) {
+          tag('warning').log(`Setup script not found: ${scriptPath}`);
+          continue;
+        }
+
+        const module = await import(fullPath);
+
+        if (typeof module.setup !== 'function') {
+          tag('warning').log(`Setup script ${scriptPath} does not export a setup() function`);
+          continue;
+        }
+
+        this.scripts.push(module);
+        debugLog(`Loaded setup script: ${scriptPath}`);
+        tag('substep').log(`Loaded setup script: ${scriptPath}`);
+      } catch (error) {
+        tag('error').log(`Failed to load setup script ${scriptPath}: ${error}`);
+      }
+    }
+
+    this.isLoaded = true;
+  }
+
+  async executeAfterNavigation(page: any, url: string): Promise<void> {
+    if (this.scripts.length === 0) return;
+
+    debugLog(`Executing ${this.scripts.length} setup scripts after navigation to ${url}`);
+
+    const context = this.createContext(page);
+
+    for (const script of this.scripts) {
+      try {
+        await script.setup(context);
+      } catch (error) {
+        debugLog(`Setup script error: ${error}`);
+      }
+    }
+  }
+
+  private createContext(page: any): SetupScriptContext {
+    return {
+      page,
+      context: page.context(),
+      explorer: this.explorer,
+      stateManager: this.explorer.getStateManager(),
+      knowledgeTracker: this.explorer.getKnowledgeTracker(),
+      config: this.config,
+      log: (...args: any[]) => tag('setup').log(...args),
+    };
+  }
+}


### PR DESCRIPTION
## **User description**
Adding before hook script with Playwright API called after navigation, before capturing the page state. Allows to execute general prepare state preconditions as resolve login page redirect, removing the cookie banner, API login, etc..

```
Execution diagram:
Action.execute(I.amOnPage(...))
  ├─> Navigation starts
  ├─> recorder.promise() waits for navigation
  ├─> Navigation completes
  ├─> framenavigated event fires ────────┐
  ├─> WAIT for pendingSetupScripts ──────┤
  │                                       ▼
  │                              Setup scripts run:
  │                              ├─> Dismiss cookie banner
  │                              └─> Fill login form & submit
  │                                       │
  ├─< Setup scripts complete ◄───────────┘
  │
  └─> capturePageState()
      (Now captures AFTER login completes!)

```  
Scripts can be placed in "browser-scripts" folder. Here is an example of a simple script:

```
 export async function setup({ page, log }) {
  await page.waitForLoadState('networkidle');
  const isCookieBarPresent = await page.locator('baner').isVisible();

  if (isCookieBarPresent) {
    try {
      await page.locator('[reject').click({ timeout: 2000 });
      await page.locator('baner').waitFor({ state: 'hidden', timeout: 5000 });
      log('Cookie banner dismissed');
    } catch {
      log('Cookie banner not found or already dismissed');
    }
  }

  if (!page.url().includes('/SignIn') && !page.url().includes('/login')) {
    return;
  }

  const isEmailInputPresent = await page.locator('email-input').isVisible();

  if (!isEmailInputPresent) {
    return;
  }

  try {
    log('Sign-in form detected, filling email');
    await page.locator('email-input').fill(process.env.EMAIL);
    await page.locator('confirm-btn').click();

    log('Login complete, redirected successfully');
  } catch (error) {
    log('Auto-login failed:', error.message);
  }
}

```

___

## **CodeAnt-AI Description**
**Run optional Playwright setup scripts after navigation to prepare page state**

### What Changed
- New config option to list setup scripts that run after each navigation so pages can be prepared (examples: dismiss cookie banners, complete sign-in redirects, perform API logins).
- The explorer loads configured scripts from disk and executes them after navigation and before capturing the page state or continuing actions.
- The explorer waits for those scripts to finish, ensuring captured snapshots and subsequent actions reflect the post-setup page state rather than transient pre-login/consent UI.

### Impact
`✅ Captures reflect post-login and post-consent`
`✅ Fewer flaky captures from cookie banners or navigation redirects`
`✅ Less manual setup needed to reproduce state-dependent issues`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
