### PR TITLE
Add agent hooks and knowledge code execution

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,8 @@ agents: {
     model: 'gpt-oss-20b',          // Override default model
     enabled: true,                  // Enable/disable agent
     systemPrompt: '...',           // Append to system prompt
+    beforeHook: { /* ... */ },     // Run before agent executes
+    afterHook: { /* ... */ },      // Run after agent completes
   },
 }
 ```
@@ -172,6 +174,10 @@ agents: {
 | `model` | `string` | Model to use for this agent (overrides default) |
 | `enabled` | `boolean` | Enable or disable the agent |
 | `systemPrompt` | `string` | Additional instructions appended to the agent's system prompt |
+| `beforeHook` | `Hook \| HookPatternMap` | Code to run before agent execution |
+| `afterHook` | `Hook \| HookPatternMap` | Code to run after agent execution |
+
+See [Agent Hooks](./hooks.md) for detailed hook configuration.
 
 ### Researcher Agent Options
 
@@ -396,6 +402,7 @@ export default {
 
 - [AI Providers](./providers.md) - Provider setup examples
 - [Agents](./agents.md) - Agent descriptions and workflows
+- [Agent Hooks](./hooks.md) - Custom code before/after agent execution
 - [Researcher Agent](./researcher.md) - Researcher configuration and usage
 - [Knowledge Files](./knowledge.md) - Domain knowledge format
 - [Observability](./observability.md) - Langfuse integration

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,238 @@
+# Agent Hooks
+
+Hooks allow you to execute custom code before or after specific agents run. They provide fine-grained control over page preparation and cleanup on a per-agent basis.
+
+> [!NOTE]
+> For simple page automation (waiting, clicking cookie banners), prefer using [Knowledge Files](./knowledge.md) with `wait`, `waitForElement`, or `code` fields. Hooks are best when you need different behavior for different agents.
+
+## When to Use Hooks vs Knowledge
+
+| Use Case | Solution |
+|----------|----------|
+| Wait for element on all page visits | Knowledge: `waitForElement` |
+| Dismiss cookie banner on page load | Knowledge: `code` |
+| Wait for network idle only during research | Hook: `researcher.beforeHook` |
+| Clean up test data after each test | Hook: `tester.afterHook` |
+| Different waits for navigation vs testing | Hooks for each agent |
+
+## Configuration
+
+Hooks are configured per-agent in `explorbot.config.js`:
+
+```javascript
+export default {
+  ai: {
+    provider: myProvider,
+    model: 'gpt-4o',
+    agents: {
+      navigator: {
+        beforeHook: {
+          type: 'playwright',
+          hook: async ({ page, url }) => {
+            await page.waitForLoadState('networkidle');
+          }
+        }
+      },
+      tester: {
+        afterHook: {
+          type: 'codeceptjs',
+          hook: async ({ I, url }) => {
+            await I.executeScript(() => localStorage.clear());
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Hook Types
+
+### Playwright Hooks
+
+Direct access to Playwright page object:
+
+```javascript
+beforeHook: {
+  type: 'playwright',
+  hook: async ({ page, url }) => {
+    await page.waitForLoadState('networkidle');
+    await page.locator('.loading').waitFor({ state: 'hidden' });
+  }
+}
+```
+
+### CodeceptJS Hooks
+
+Use familiar CodeceptJS `I` actor:
+
+```javascript
+beforeHook: {
+  type: 'codeceptjs',
+  hook: async ({ I, url }) => {
+    await I.waitForElement('.page-ready');
+    await I.wait(1);
+  }
+}
+```
+
+## URL Pattern Matching
+
+Apply different hooks based on URL patterns:
+
+```javascript
+researcher: {
+  beforeHook: {
+    '/login': {
+      type: 'codeceptjs',
+      hook: async ({ I }) => await I.waitForElement('#login-form')
+    },
+    '/admin/*': {
+      type: 'playwright',
+      hook: async ({ page }) => await page.waitForLoadState('networkidle')
+    },
+    '/api/*': {
+      type: 'codeceptjs',
+      hook: async ({ I }) => await I.wait(2)
+    }
+  }
+}
+```
+
+### Pattern Syntax
+
+| Pattern | Matches |
+|---------|---------|
+| `/login` | Exact path `/login` |
+| `/admin/*` | `/admin` and any path starting with `/admin/` |
+| `*` | All URLs (fallback) |
+| `^/users/\d+$` | Regex: `/users/` followed by digits |
+| `**/*.html` | Glob: any `.html` file |
+
+## Supported Agents
+
+| Agent | beforeHook | afterHook | Description |
+|-------|------------|-----------|-------------|
+| `navigator` | After navigation | After page capture | Browser navigation |
+| `researcher` | After navigation | After research complete | Page analysis |
+| `tester` | Before test loop | After test loop | Test execution |
+| `captain` | Before handling command | After command complete | User commands |
+
+> [!WARNING]
+> The `planner` agent does not support hooks as it doesn't interact with the browser.
+
+## Examples
+
+### Wait for SPA to Load
+
+```javascript
+navigator: {
+  beforeHook: {
+    type: 'playwright',
+    hook: async ({ page }) => {
+      await page.waitForFunction(() => {
+        return window.__APP_READY__ === true;
+      });
+    }
+  }
+}
+```
+
+### Dismiss Modals Before Research
+
+```javascript
+researcher: {
+  beforeHook: {
+    type: 'codeceptjs',
+    hook: async ({ I }) => {
+      const modalVisible = await I.grabNumberOfVisibleElements('.modal-overlay');
+      if (modalVisible > 0) {
+        await I.click('.modal-close');
+        await I.wait(0.5);
+      }
+    }
+  }
+}
+```
+
+### Clean Up After Tests
+
+```javascript
+tester: {
+  afterHook: {
+    type: 'playwright',
+    hook: async ({ page }) => {
+      await page.evaluate(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+      });
+    }
+  }
+}
+```
+
+### Different Behavior per URL
+
+```javascript
+tester: {
+  beforeHook: {
+    '/checkout': {
+      type: 'codeceptjs',
+      hook: async ({ I }) => {
+        // Ensure cart has items before checkout tests
+        await I.executeScript(() => {
+          if (!localStorage.getItem('cart')) {
+            localStorage.setItem('cart', JSON.stringify([{ id: 1, qty: 1 }]));
+          }
+        });
+      }
+    },
+    '/admin/*': {
+      type: 'codeceptjs',
+      hook: async ({ I }) => {
+        // Ensure admin session
+        await I.waitForElement('.admin-header', 5);
+      }
+    }
+  }
+}
+```
+
+## Error Handling
+
+Hook errors are logged but don't stop agent execution:
+
+```javascript
+beforeHook: {
+  type: 'codeceptjs',
+  hook: async ({ I }) => {
+    try {
+      await I.waitForElement('.optional-banner', 2);
+      await I.click('.dismiss');
+    } catch {
+      // Banner not present, continue
+    }
+  }
+}
+```
+
+## Execution Flow
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Agent Execution                       │
+├─────────────────────────────────────────────────────────┤
+│  1. Agent starts                                         │
+│  2. Navigate to URL (if applicable)                      │
+│  3. ▶ beforeHook executes                               │
+│  4. Agent performs main work                             │
+│  5. ▶ afterHook executes                                │
+│  6. Agent completes                                      │
+└─────────────────────────────────────────────────────────┘
+```
+
+## See Also
+
+- [Knowledge Files](./knowledge.md) - Page-level automation with `wait`, `waitForElement`, `code`
+- [Configuration](./configuration.md) - Full configuration reference
+- [Agents](./agents.md) - Agent descriptions and workflows

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -120,6 +120,33 @@ code: |
 App pages need cookie consent dismissed and loading complete.
 ```
 
+### CodeceptJS Effects
+
+Knowledge code has access to CodeceptJS effects for error handling and retries:
+
+| Effect | Purpose |
+|--------|---------|
+| `tryTo(fn)` | Execute without failing - returns `true`/`false` |
+| `retryTo(fn, maxTries, interval)` | Retry on failure with polling |
+| `within(context, fn)` | Execute within a specific element context |
+| `hopeThat(fn)` | Soft assertion - logs failure but continues |
+
+**Example with effects:**
+
+```markdown
+---
+url: /dashboard
+code: |
+  await tryTo(() => I.click('.cookie-dismiss'));
+  await retryTo(() => I.waitForElement('.data-loaded'), 5, 500);
+---
+
+Dashboard may show cookie banner. Data loads asynchronously.
+```
+
+> [!NOTE]
+> Effects are async - use `await` when calling them in knowledge code.
+
 ### SPA Navigation
 
 For single-page apps where full page reload breaks state:

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -81,6 +81,70 @@ Notes:
 | `title` | Human-readable title (optional) |
 | Custom fields | Any additional metadata for agents |
 
+## Page Automation
+
+Knowledge files can include automation commands that execute when navigating to matching pages. This is useful for handling loading states, cookie banners, or page-specific setup.
+
+### Available Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `wait` | `number` | Wait for specified seconds after page load |
+| `waitForElement` | `string` | Wait for element to appear (CSS selector) |
+| `code` | `string` | Execute CodeceptJS code after navigation |
+| `statePush` | `boolean` | Use `history.pushState` instead of full navigation |
+
+### Wait for Page Load
+
+```markdown
+---
+url: /dashboard
+wait: 2
+waitForElement: '.dashboard-loaded'
+---
+
+Dashboard requires data to load before interaction.
+```
+
+### Execute Custom Code
+
+```markdown
+---
+url: /app/*
+code: |
+  I.waitForElement('.app-ready');
+  I.click('.cookie-accept');
+  I.wait(1);
+---
+
+App pages need cookie consent dismissed and loading complete.
+```
+
+### SPA Navigation
+
+For single-page apps where full page reload breaks state:
+
+```markdown
+---
+url: /settings/*
+statePush: true
+---
+
+Settings uses client-side routing. Use pushState to preserve app state.
+```
+
+> [!TIP]
+> Use knowledge automation for page-specific behaviors. For agent-specific logic (like running code only during testing), use [Agent Hooks](./hooks.md) instead.
+
+### Execution Order
+
+When navigating to a page, automation executes in this order:
+
+1. Navigation (`I.amOnPage()` or `history.pushState`)
+2. `wait` (if specified)
+3. `waitForElement` (if specified)
+4. `code` (if specified)
+
 ## What to Document
 
 ### Authentication
@@ -161,3 +225,9 @@ When an agent operates on a page, it receives relevant knowledge based on URL ma
 ```
 
 Files are named based on URL pattern. Multiple entries for the same URL are appended to the same file.
+
+## See Also
+
+- [Agent Hooks](./hooks.md) - Per-agent custom code execution
+- [Configuration](./configuration.md) - Full configuration reference
+- [Page Interaction](./page-interaction.md) - How agents interact with pages

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -138,10 +138,13 @@ Knowledge code has access to CodeceptJS effects for error handling and retries:
 url: /dashboard
 code: |
   await tryTo(() => I.click('.cookie-dismiss'));
-  await retryTo(() => I.waitForElement('.data-loaded'), 5, 500);
+  await retryTo(() => {
+    I.click('Reload Data');
+    I.waitForElement('.data-loaded');
+  }, 5, 500);
 ---
 
-Dashboard may show cookie banner. Data loads asynchronously.
+Dashboard may show cookie banner. Data loads asynchronously - retry reload if needed.
 ```
 
 > [!NOTE]

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -129,7 +129,6 @@ Knowledge code has access to CodeceptJS effects for error handling and retries:
 | `tryTo(fn)` | Execute without failing - returns `true`/`false` |
 | `retryTo(fn, maxTries, interval)` | Retry on failure with polling |
 | `within(context, fn)` | Execute within a specific element context |
-| `hopeThat(fn)` | Soft assertion - logs failure but continues |
 
 **Example with effects:**
 

--- a/docs/page-interaction.md
+++ b/docs/page-interaction.md
@@ -40,6 +40,45 @@ Processed HTML provides detailed attributes:
 
 Used for: Precise locator construction, form field identification, state verification.
 
+#### HTML Filtering
+
+Agents primarily use the `combined` HTML snapshot, which can be configured to exclude noisy elements:
+
+```javascript
+// explorbot.config.js
+html: {
+  combined: {
+    include: ['*'],
+    exclude: ['script', 'style', 'svg', '.cookie-banner', '.analytics-tracker']
+  }
+}
+```
+
+| Snapshot Type | Purpose | Config Key |
+|---------------|---------|------------|
+| `combined` | Main HTML for agents (interactive + semantic elements) | `html.combined` |
+| `minimal` | Focused on interactive elements only | `html.minimal` |
+| `text` | Text content extraction | `html.text` |
+
+> [!TIP]
+> Filter out noisy elements like cookie banners, analytics widgets, and ads to reduce token usage and improve agent focus.
+
+**Common exclusions:**
+
+```javascript
+html: {
+  combined: {
+    exclude: [
+      'script', 'style', 'svg', 'noscript',
+      '.cookie-consent', '.cookie-banner',
+      '.chat-widget', '.intercom-*',
+      '.analytics-*', '.tracking-*',
+      '[data-testid="ads"]'
+    ]
+  }
+}
+```
+
 ### Screenshots (Vision Model)
 
 Visual analysis adds spatial awareness:
@@ -295,4 +334,8 @@ On subsequent runs, agents load relevant experience to:
 - Anticipate state changes
 - Apply learned recovery strategies
 
-See [docs/knowledge.md](knowledge.md) for more on teaching Explorbot.
+## See Also
+
+- [Knowledge Files](knowledge.md) - Teach Explorbot about your app
+- [Agent Hooks](hooks.md) - Custom code before/after agent execution
+- [Configuration](configuration.md) - Full configuration reference

--- a/src/action.ts
+++ b/src/action.ts
@@ -4,6 +4,7 @@ import { context, trace } from '@opentelemetry/api';
 import { highlight } from 'cli-highlight';
 import { container, recorder } from 'codeceptjs';
 import * as codeceptjs from 'codeceptjs';
+import { tryTo, retryTo, within, hopeThat } from 'codeceptjs/lib/effects.js';
 import dedent from 'dedent';
 import { ActionResult } from './action-result.js';
 import { clearActivity, setActivity } from './activity.ts';
@@ -188,8 +189,8 @@ class Action {
     try {
       debugLog('Executing action:', codeString);
 
-      const codeFunction = new Function('I', codeString);
-      codeFunction(this.actor);
+      const codeFunction = new Function('I', 'tryTo', 'retryTo', 'within', 'hopeThat', codeString);
+      codeFunction(this.actor, tryTo, retryTo, within, hopeThat);
 
       await recorder.add(() => sleep(this.config.action?.delay || 500)); // wait for the action to be executed
       await recorder.promise();
@@ -231,9 +232,9 @@ class Action {
       if (typeof codeOrFunction === 'function') {
         codeFunction = codeOrFunction;
       } else {
-        codeFunction = new Function('I', codeString);
+        codeFunction = new Function('I', 'tryTo', 'retryTo', 'within', 'hopeThat', codeString);
       }
-      codeFunction(this.actor);
+      codeFunction(this.actor, tryTo, retryTo, within, hopeThat);
       await recorder.promise();
       debugLog('Expectation executed successfully');
 

--- a/src/ai/captain.ts
+++ b/src/ai/captain.ts
@@ -6,6 +6,7 @@ import { ExperienceTracker } from '../experience-tracker.js';
 import type { ExplorBot } from '../explorbot.ts';
 import type { WebPageState } from '../state-manager.ts';
 import { Task, Test } from '../test-plan.ts';
+import { HooksRunner } from '../utils/hooks-runner.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { loop } from '../utils/loop.js';
 import type { Agent } from './agent.js';
@@ -28,11 +29,20 @@ export class Captain extends TaskAgent implements Agent {
   private experienceTracker: ExperienceTracker;
   private awaitingSave = false;
   private pendingExperience: { state: ActionResult; intent: string; summary: string; code: string } | null = null;
+  private hooksRunner: HooksRunner | null = null;
 
   constructor(explorBot: ExplorBot) {
     super();
     this.explorBot = explorBot;
     this.experienceTracker = new ExperienceTracker();
+  }
+
+  private getHooksRunner(): HooksRunner {
+    if (!this.hooksRunner) {
+      const explorer = this.explorBot.getExplorer();
+      this.hooksRunner = new HooksRunner(explorer, explorer.getConfig());
+    }
+    return this.hooksRunner;
   }
 
   protected getNavigator(): Navigator {
@@ -352,7 +362,8 @@ export class Captain extends TaskAgent implements Agent {
     const pageContext = await this.getPageContext();
     const planContext = this.planSummary();
 
-    // Clean up old page context from previous inputs when continuing conversation
+    await this.getHooksRunner().runBeforeHook('captain', startUrl);
+
     if (!options.reset && this.conversation) {
       conversation.cleanupTag('page_aria', '...cleaned...', 1);
       conversation.cleanupTag('page_html', '...cleaned...', 1);
@@ -434,6 +445,9 @@ export class Captain extends TaskAgent implements Agent {
         },
       }
     );
+
+    const finalUrl = stateManager.getCurrentState()?.url || startUrl;
+    await this.getHooksRunner().runAfterHook('captain', finalUrl);
 
     if (finalSummary) {
       tag('success').log(this.emoji, finalSummary);

--- a/src/ai/captain.ts
+++ b/src/ai/captain.ts
@@ -359,10 +359,11 @@ export class Captain extends TaskAgent implements Agent {
     };
 
     const tools = this.tools(task, onDone);
-    const pageContext = await this.getPageContext();
-    const planContext = this.planSummary();
 
     await this.getHooksRunner().runBeforeHook('captain', startUrl);
+
+    const pageContext = await this.getPageContext();
+    const planContext = this.planSummary();
 
     if (!options.reset && this.conversation) {
       conversation.cleanupTag('page_aria', '...cleaned...', 1);

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -10,11 +10,12 @@ import type Explorer from '../explorer.ts';
 import { Observability } from '../observability.ts';
 import type { StateManager } from '../state-manager.js';
 import { WebPageState } from '../state-manager.js';
+import { collectInteractiveNodes, diffAriaSnapshots } from '../utils/aria.ts';
 import { extractCodeBlocks } from '../utils/code-extractor.ts';
+import { HooksRunner } from '../utils/hooks-runner.ts';
 import { type HtmlDiffResult, htmlDiff } from '../utils/html-diff.ts';
 import { codeToMarkdown, isBodyEmpty } from '../utils/html.ts';
 import { createDebug, pluralize, tag } from '../utils/logger.js';
-import { collectInteractiveNodes, diffAriaSnapshots } from '../utils/aria.ts';
 import { loop } from '../utils/loop.ts';
 import type { Agent } from './agent.js';
 import type { Conversation } from './conversation.js';
@@ -46,12 +47,14 @@ export class Researcher implements Agent {
   private experienceTracker: ExperienceTracker;
   private hasScreenshotToAnalyze = false;
   private actionResult?: ActionResult;
+  private hooksRunner: HooksRunner;
 
   constructor(explorer: Explorer, provider: Provider) {
     this.explorer = explorer;
     this.provider = provider;
     this.stateManager = explorer.getStateManager();
     this.experienceTracker = this.stateManager.getExperienceTracker();
+    this.hooksRunner = new HooksRunner(explorer, explorer.getConfig());
   }
 
   static getCachedResearch(state: WebPageState): string {
@@ -107,6 +110,7 @@ export class Researcher implements Agent {
 
       const isOnCurrentState = this.actionResult!.getStateHash() === this.stateManager.getCurrentState()?.hash;
       await this.ensureNavigated(state.url, screenshot && this.provider.hasVision());
+      await this.hooksRunner.runBeforeHook('researcher', state.url);
 
       debugLog('Researching web page:', this.actionResult!.url);
 
@@ -156,6 +160,7 @@ export class Researcher implements Agent {
       tag('multiline').log(researchText);
       tag('success').log(`Research complete! ${researchText.length} characters`);
 
+      await this.hooksRunner.runAfterHook('researcher', state.url);
       return researchText;
     });
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,29 @@ interface PlaywrightConfig {
   args?: string[];
 }
 
-interface AgentConfig {
+type PlaywrightHookFn = (ctx: { page: any; url: string }) => Promise<void> | void;
+type CodeceptJSHookFn = (ctx: { I: any; url: string }) => Promise<void> | void;
+
+interface PlaywrightHook {
+  type: 'playwright';
+  hook: PlaywrightHookFn;
+}
+
+interface CodeceptJSHook {
+  type: 'codeceptjs';
+  hook: CodeceptJSHookFn;
+}
+
+type Hook = PlaywrightHook | CodeceptJSHook;
+type HookPatternMap = Record<string, Hook>;
+type HookConfig = Hook | HookPatternMap;
+
+interface HooksConfig {
+  beforeHook?: HookConfig;
+  afterHook?: HookConfig;
+}
+
+interface AgentConfig extends HooksConfig {
   model?: string;
   enabled?: boolean;
   systemPrompt?: string;
@@ -120,7 +142,7 @@ const config: ExplorbotConfig = {
   },
 };
 
-export type { ExplorbotConfig, PlaywrightConfig, AIConfig, HtmlConfig, ActionConfig, AgentConfig, AgentsConfig, ResearcherAgentConfig };
+export type { ExplorbotConfig, PlaywrightConfig, AIConfig, HtmlConfig, ActionConfig, AgentConfig, AgentsConfig, ResearcherAgentConfig, Hook, HookConfig, HooksConfig, PlaywrightHook, CodeceptJSHook, HookPatternMap };
 
 export class ConfigParser {
   private static instance: ConfigParser;

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -202,9 +202,9 @@ class Explorer {
 
     const serializedUrl = JSON.stringify(url);
     const currentState = this.stateManager.getCurrentState();
-    const actionResult = currentState ? ActionResult.fromState(currentState) : null;
+    const actionResult = currentState ? ActionResult.fromState(currentState) : new ActionResult({ url });
 
-    const { statePush = false, wait, waitForElement, code } = this.knowledgeTracker.getStateParameters(actionResult!, ['statePush', 'wait', 'waitForElement', 'code']);
+    const { statePush = false, wait, waitForElement, code } = this.knowledgeTracker.getStateParameters(actionResult, ['statePush', 'wait', 'waitForElement', 'code']);
 
     const action = this.createAction();
 

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -204,7 +204,7 @@ class Explorer {
     const currentState = this.stateManager.getCurrentState();
     const actionResult = currentState ? ActionResult.fromState(currentState) : null;
 
-    const { statePush = false, wait, waitForElement } = this.knowledgeTracker.getStateParameters(actionResult!, ['statePush', 'wait', 'waitForElement']);
+    const { statePush = false, wait, waitForElement, code } = this.knowledgeTracker.getStateParameters(actionResult!, ['statePush', 'wait', 'waitForElement', 'code']);
 
     const action = this.createAction();
 
@@ -215,12 +215,17 @@ class Explorer {
     }
 
     if (wait !== undefined) {
-      console.log('Waiting for', wait);
+      debugLog('Waiting for', wait);
       await action.execute(`I.wait(${wait})`);
     }
 
     if (waitForElement) {
       await action.execute(`I.waitForElement(${JSON.stringify(waitForElement)})`);
+    }
+
+    if (code) {
+      debugLog('Executing knowledge code:', code);
+      await action.execute(code);
     }
 
     return action;

--- a/src/utils/hooks-runner.ts
+++ b/src/utils/hooks-runner.ts
@@ -37,10 +37,17 @@ export class HooksRunner {
     if (this.isSingleHook(config)) return config as Hook;
 
     const urlPath = this.extractPath(url);
-    for (const [pattern, hook] of Object.entries(config)) {
+    const entries = Object.entries(config).sort(([a], [b]) => this.patternSpecificity(b) - this.patternSpecificity(a));
+    for (const [pattern, hook] of entries) {
       if (this.matchesPattern(pattern, urlPath)) return hook as Hook;
     }
     return null;
+  }
+
+  private patternSpecificity(pattern: string): number {
+    if (pattern === '*') return 0;
+    if (pattern.includes('*')) return pattern.length;
+    return pattern.length + 1000;
   }
 
   private async executeHook(hook: Hook, url: string): Promise<void> {

--- a/src/utils/hooks-runner.ts
+++ b/src/utils/hooks-runner.ts
@@ -1,0 +1,92 @@
+import micromatch from 'micromatch';
+import type { ExplorbotConfig, Hook, HookConfig } from '../config.ts';
+import type Explorer from '../explorer.ts';
+import { createDebug } from './logger.ts';
+
+const debugLog = createDebug('explorbot:hooks');
+
+export class HooksRunner {
+  constructor(
+    private explorer: Explorer,
+    private config: ExplorbotConfig
+  ) {}
+
+  async runBeforeHook(agentName: string, url: string): Promise<void> {
+    await this.runHook(agentName, 'beforeHook', url);
+  }
+
+  async runAfterHook(agentName: string, url: string): Promise<void> {
+    await this.runHook(agentName, 'afterHook', url);
+  }
+
+  private async runHook(agentName: string, hookType: 'beforeHook' | 'afterHook', url: string): Promise<void> {
+    const agentConfig = this.config.ai?.agents?.[agentName as keyof typeof this.config.ai.agents];
+    if (!agentConfig) return;
+
+    const hookConfig = agentConfig[hookType];
+    if (!hookConfig) return;
+
+    const hook = this.findMatchingHook(hookConfig, url);
+    if (!hook) return;
+
+    debugLog(`Running ${hookType} for ${agentName} at ${url}`);
+    await this.executeHook(hook, url);
+  }
+
+  private findMatchingHook(config: HookConfig, url: string): Hook | null {
+    if (this.isSingleHook(config)) return config as Hook;
+
+    const urlPath = this.extractPath(url);
+    for (const [pattern, hook] of Object.entries(config)) {
+      if (this.matchesPattern(pattern, urlPath)) return hook as Hook;
+    }
+    return null;
+  }
+
+  private async executeHook(hook: Hook, url: string): Promise<void> {
+    try {
+      if (hook.type === 'playwright') {
+        const page = this.explorer.playwrightHelper.page;
+        await hook.hook({ page, url });
+      } else {
+        const I = this.explorer.actor;
+        await hook.hook({ I, url });
+      }
+    } catch (error) {
+      debugLog(`Hook error: ${error}`);
+    }
+  }
+
+  private isSingleHook(config: HookConfig): boolean {
+    return 'type' in config && 'hook' in config;
+  }
+
+  private extractPath(url: string): string {
+    if (url.startsWith('/')) return url;
+    try {
+      return new URL(url).pathname;
+    } catch {
+      return url;
+    }
+  }
+
+  private matchesPattern(pattern: string, path: string): boolean {
+    if (pattern === '*') return true;
+    if (pattern.toLowerCase() === path.toLowerCase()) return true;
+
+    if (pattern.endsWith('/*')) {
+      const base = pattern.slice(0, -2);
+      if (path === base || path.startsWith(`${base}/`)) return true;
+    }
+
+    if (pattern.startsWith('^')) {
+      try {
+        return new RegExp(pattern.slice(1)).test(path);
+      } catch {
+        return false;
+      }
+    }
+
+    return micromatch.isMatch(path, pattern);
+  }
+}


### PR DESCRIPTION
## **User description**
## Summary

- Add `beforeHook` and `afterHook` support for Navigator, Researcher, Tester, and Captain agents
- Hooks can execute either Playwright or CodeceptJS code before/after agent execution
- Support URL pattern matching (exact, wildcard, glob, regex) for conditional hook execution
- Add `code` property to knowledge files for executing CodeceptJS code on page navigation
- Add `tryTo` and `retryTo` effects support in knowledge code for error handling and retries

## Features

### Agent Hooks

Configure hooks per-agent in `explorbot.config.js`:

```javascript
agents: {
  navigator: {
    beforeHook: {
      type: 'playwright',
      hook: async ({ page }) => await page.waitForLoadState('networkidle')
    }
  },
  researcher: {
    beforeHook: {
      '/login': { type: 'codeceptjs', hook: async ({ I }) => await I.waitForElement('#form') },
      '/admin/*': { type: 'playwright', hook: async ({ page }) => await page.locator('.loaded').waitFor() }
    }
  }
}
```

### Knowledge Code Execution

Execute CodeceptJS code when navigating to matching pages:

```markdown
---
url: /app/*
code: |
  I.waitForElement('.app-ready');
  I.click('.cookie-accept');
---
```

### CodeceptJS Effects

Use `tryTo` and `retryTo` for robust page automation:

```markdown
---
url: /dashboard
code: |
  await tryTo(() => I.click('.cookie-dismiss'));
  await retryTo(() => {
    I.click('Reload Data');
    I.waitForElement('.data-loaded');
  }, 5, 500);
---
```

| Effect | Purpose |
|--------|---------|
| `tryTo(fn)` | Execute without failing - returns `true`/`false` |
| `retryTo(fn, maxTries, interval)` | Retry on failure with polling |
| `within(context, fn)` | Execute within a specific element context |

## Files Changed

- `src/config.ts` - Hook type definitions
- `src/utils/hooks-runner.ts` - New utility for hook execution
- `src/action.ts` - CodeceptJS effects support
- `src/ai/navigator.ts` - Hook integration
- `src/ai/researcher.ts` - Hook integration
- `src/ai/tester.ts` - Hook integration
- `src/ai/captain.ts` - Hook integration
- `src/explorer.ts` - Knowledge `code` execution
- `docs/hooks.md` - New documentation
- `docs/knowledge.md` - Page automation and effects docs
- `docs/page-interaction.md` - HTML filtering docs
- `docs/configuration.md` - Hook options reference

## Test plan

- [ ] Configure beforeHook for navigator agent, verify it runs after navigation
- [ ] Configure afterHook for tester agent, verify it runs after test completion
- [ ] Test URL pattern matching with wildcards and regex
- [ ] Test knowledge file with `code` property, verify execution on page visit
- [ ] Test `tryTo` effect - verify it catches errors and returns false
- [ ] Test `retryTo` effect - verify it retries failed actions
- [ ] Verify Playwright hooks receive `{ page, url }` context
- [ ] Verify CodeceptJS hooks receive `{ I, url }` context

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Run per-agent before/after hooks and execute page-level CodeceptJS code on navigation**

### What Changed
- Agents (navigator, researcher, tester, captain) now run configurable beforeHook and afterHook code around their main work; hooks can be Playwright or CodeceptJS and can be scoped to URL patterns (exact, wildcard, glob, regex)
- Knowledge files may include a new code field that runs CodeceptJS commands when navigating to matching pages; those knowledge scripts can use CodeceptJS effects (tryTo, retryTo, within, hopeThat) for safe retries and non-fatal attempts
- Hooks and knowledge code errors are logged but do not stop agent execution; hooks match the most specific URL pattern first
- Documentation added and updated: configuration reference, hook examples, knowledge file usage, and pattern matching behavior

### Impact
`✅ Fewer flaky navigations due to agent-specific preconditions`
`✅ Shorter test setup by automating page preparation (e.g., dismiss banners)`
`✅ More robust page automation with retryable knowledge scripts`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
