### PR TITLE
add --verify flag to audit research coverage

### DIFF
--- a/.claude/skills/research-audit/SKILL.md
+++ b/.claude/skills/research-audit/SKILL.md
@@ -1,0 +1,233 @@
+# Research Audit
+
+Audit Explorbot research output against the actual ARIA tree to find missed interactive elements and classify root causes.
+
+## When to Use
+
+After running `/research` or `explorbot research <url>`, use this skill to understand:
+- Which interactive elements the researcher missed
+- Whether the cause is a code filter (PR material) or site-specific (knowledge file)
+
+## Step 1: Acquire Data
+
+### Option A: Use --verify flag (recommended)
+
+Run research with the `--verify` flag to get an inline audit report:
+
+```bash
+# TUI
+/research --deep --verify
+
+# CLI
+explorbot research <url> --deep --verify
+```
+
+This calls `Researcher.auditResearch()` which compares the research output against the ARIA tree automatically.
+
+### Option B: Manual analysis of past sessions
+
+Find the latest research output and ARIA snapshot:
+
+```bash
+ls -lt output/research/*.md | head -n 5
+ls -lt output/*.aria.yaml | head -n 5
+```
+
+Match files by state hash (the hash prefix in filenames).
+
+Read both files:
+- Research file: `output/research/{hash}.md`
+- ARIA snapshot: `output/{hash}*.aria.yaml`
+
+## Step 2: Parse Both Sources
+
+### Research output
+
+Extract elements from the `| Element | ARIA | CSS | XPath |` tables:
+
+```bash
+rg '\|.*\|.*role.*\|' output/research/{hash}.md
+```
+
+### ARIA snapshot
+
+The `.aria.yaml` file contains the raw Playwright ARIA tree. Interactive roles to look for:
+
+```
+button, link, textbox, searchbox, checkbox, radio, switch,
+combobox, listbox, menuitem, tab, slider, spinbutton,
+treeitem, gridcell, option
+```
+
+Count interactive elements:
+
+```bash
+rg '- (button|link|textbox|checkbox|radio|switch|combobox|menuitem|tab|slider|option|treeitem)' output/{hash}*.aria.yaml | wc -l
+```
+
+## Step 3: Classify Missed Elements
+
+For each ARIA interactive element NOT found in the research output, check these code filters **in order**:
+
+### Filter 1: Unnamed button/link
+
+**Check**: Element has a role (button, link) but no name/text.
+
+**Code location**: `src/utils/aria.ts:81` — `buildInteractiveEntry()` marks unnamed buttons with `unnamed: true` flag. Previously these were dropped entirely.
+
+**Impact**: Icon buttons (ellipsis menus, plus buttons, filter icons, SVG-only buttons).
+
+**Fix type**: CODE — PR to `src/utils/aria.ts`
+- These are a universal web pattern, not site-specific
+- Explorbot should handle unnamed buttons by falling back to CSS position
+- The `performInteractiveExploration` method now handles unnamed elements
+
+### Filter 2: Role not in CLICKABLE_ROLES
+
+**Check**: Element's role is not in the set used by `performInteractiveExploration`.
+
+**Code location**: `src/ai/researcher.ts:40`
+
+```
+CLICKABLE_ROLES: button, link, menuitem, tab, option, combobox, switch,
+                 checkbox, radio, slider, textbox, treeitem
+```
+
+**Impact**: Any interactive element with a role not in this list is skipped during exploration.
+
+**Fix type**: CODE — PR to `src/ai/researcher.ts`
+- Add the missing role to `CLICKABLE_ROLES`
+- Compare against `INTERACTIVE_ROLES` in `src/utils/aria.ts` (37 roles)
+
+### Filter 3: Name matches stop word
+
+**Check**: Element name matches one of `DEFAULT_STOP_WORDS`.
+
+**Code location**: `src/ai/researcher.ts:38`
+
+```
+DEFAULT_STOP_WORDS: close, cancel, dismiss, exit, back, cookie, consent,
+                    gdpr, privacy, accept all, decline all, reject all,
+                    share, print, download
+```
+
+**Impact**: Legitimate buttons like "Close" in a modal workflow, "Back" navigation.
+
+**Fix type**: CODE — PR to `src/ai/researcher.ts`
+- Stop words should be context-aware (don't skip "Close" inside a modal)
+- Or make stop words configurable per-project in `explorbot.config`
+
+### Filter 4: Inside ignored navigation container
+
+**Check**: Element is inside a `<nav>` or element with `role="navigation"`.
+
+**Code location**: `src/utils/aria.ts:40` — `IGNORED_CONTAINER_ROLES`
+
+**Impact**: Navigation buttons lose their container context (children are still visited but hierarchy is flattened).
+
+**Fix type**: CODE — PR to `src/utils/aria.ts`
+
+### Filter 5: AI prompt behavior (no code filter matched)
+
+**Check**: Element passed all code filters but AI did not include it in the research output.
+
+**Possible causes**:
+- `src/ai/researcher.ts:459` — "Group similar interactive elements" instruction tells AI to collapse duplicates
+- AI considered the element "decorative" or low-priority
+- AI ran out of context or truncated output
+
+**Fix type**: PROMPT — PR to `src/ai/researcher.ts`
+- Remove or soften grouping instruction
+- Add completeness constraint: "You MUST include all interactive elements from the ARIA tree"
+- Inject the interactive nodes list as a checklist
+
+### Filter 6: Site-specific (last resort)
+
+**Check**: None of the above filters matched AND the element uses a non-standard role or custom widget.
+
+**Fix type**: KNOWLEDGE FILE
+- Only suggest a knowledge file if no code-level cause was found
+- Document the custom widget and its interaction pattern
+
+## Step 4: Generate Report
+
+Structure the report in three sections:
+
+### CODE FILTER ISSUES (PR material)
+
+For each code filter that dropped elements:
+- Which filter (file and line number)
+- How many elements affected
+- List of affected elements with role and name
+- Suggested code change
+
+### PROMPT ISSUES (PR material)
+
+For elements the AI skipped:
+- List of elements with role and name
+- Whether they might have been grouped (multiple elements with same name)
+- Reference to the prompt instruction causing it
+
+### SITE-SPECIFIC (knowledge file)
+
+Only for truly custom widgets:
+- Element description
+- Suggested knowledge file content
+- URL pattern for the knowledge file
+
+## Step 5: Suggest Next Action
+
+Based on the report:
+
+1. **Code filter fix** — Identify the most impactful filter (most elements affected). Suggest the exact file, line, and change. This is PR material for the Explorbot project.
+
+2. **Prompt fix** — If AI is the main cause, suggest prompt modifications in `src/ai/researcher.ts` (the `buildResearchTaskPrompt()` or `buildResearchPrompt()` methods).
+
+3. **Knowledge file** — Only as last resort. Generate the file content with proper URL pattern.
+
+## Quick Reference: Code Locations
+
+| Filter | File | Line | What to Change |
+|--------|------|------|----------------|
+| Unnamed buttons | `src/utils/aria.ts` | 81 | `buildInteractiveEntry()` |
+| Clickable roles | `src/ai/researcher.ts` | 40 | `CLICKABLE_ROLES` set |
+| Stop words | `src/ai/researcher.ts` | 38 | `DEFAULT_STOP_WORDS` array |
+| Navigation ignore | `src/utils/aria.ts` | 40 | `IGNORED_CONTAINER_ROLES` set |
+| Grouping prompt | `src/ai/researcher.ts` | 459 | "Group similar" instruction |
+| Max elements | `src/ai/researcher.ts` | 963 | `maxElementsToExplore` default |
+| Link name length | `src/utils/aria.ts` | 84 | Was 30 chars, now removed |
+
+## Example Audit Output
+
+```
+# Research Audit Report
+
+URL: /Commander/*/Settings/Cashiers/Dashboard
+Total ARIA interactive elements: 47
+Found in research output: 23
+Missing: 24
+
+## CODE FILTER ISSUES (PR material)
+
+### [src/utils/aria.ts:81] 8x Unnamed button/link (icon-only element without aria-label)
+  - button "unnamed button"
+  - button "unnamed button"
+  - button "unnamed button"
+  ...
+
+### [src/ai/researcher.ts:40] 5x Role "checkbox" not in CLICKABLE_ROLES
+  - checkbox "Active"
+  - checkbox "Visible"
+  ...
+
+### [src/ai/researcher.ts:38] 2x Name matches DEFAULT_STOP_WORDS
+  - button "Close"
+  - link "Back"
+
+## PROMPT ISSUES (PR material)
+
+Elements passed all code filters but AI did not include them:
+  - button "Refresh"
+  - link "Help"
+  - button "Export"
+```

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -367,6 +367,7 @@ program
   .option('-s, --show', 'Show browser window')
   .option('--headless', 'Run browser in headless mode')
   .option('--data', 'Include data extraction in research')
+  .option('--verify', 'Audit research coverage against ARIA tree')
   .action(async (url, options) => {
     try {
       const mainOptions: ExplorBotOptions = {
@@ -386,11 +387,16 @@ program
         throw new Error('No active page to research');
       }
 
-      await explorBot.agentResearcher().research(state, {
+      const researchResult = await explorBot.agentResearcher().research(state, {
         screenshot: true,
         force: true,
         data: options.data || false,
       });
+
+      if (options.verify) {
+        const report = explorBot.agentResearcher().auditResearch(state, researchResult);
+        console.log(report);
+      }
 
       await explorBot.stop();
       await showStatsAndExit(0);

--- a/src/commands/research-command.ts
+++ b/src/commands/research-command.ts
@@ -2,12 +2,13 @@ import { BaseCommand } from './base-command.js';
 
 export class ResearchCommand extends BaseCommand {
   name = 'research';
-  description = 'Research current page or navigate to URI and research';
-  suggestions = ['/navigate <page> - to go to another page', '/plan <feature> - to plan testing'];
+  description = 'Research current page or navigate to URI and research. Use --verify to audit research coverage.';
+  suggestions = ['/research --verify - audit element coverage', '/navigate <page> - to go to another page', '/plan <feature> - to plan testing'];
 
   async execute(args: string): Promise<void> {
     const includeData = args.includes('--data');
-    const target = args.replace('--data', '').trim();
+    const enableVerify = args.includes('--verify');
+    const target = args.replace('--data', '').replace('--verify', '').trim();
 
     if (target) {
       await this.explorBot.getExplorer().visit(target);
@@ -18,10 +19,16 @@ export class ResearchCommand extends BaseCommand {
       throw new Error('No active page to research');
     }
 
-    await this.explorBot.agentResearcher().research(state, {
+    const researchResult = await this.explorBot.agentResearcher().research(state, {
       screenshot: true,
       force: true,
       data: includeData,
     });
+
+    if (enableVerify) {
+      const report = this.explorBot.agentResearcher().auditResearch(state, researchResult);
+      const { tag } = await import('../utils/logger.js');
+      tag('multiline').log(report);
+    }
   }
 }


### PR DESCRIPTION
## **User description**
Add auditResearch() method that compares research output against ARIA tree and classifies missed elements by root cause (code filter, prompt issue, or site-specific). Adds --verify flag to /research TUI command and CLI. Includes research-audit skill for manual analysis.


___

## **CodeAnt-AI Description**
Add --verify research audit to compare research output with the ARIA tree

### What Changed
- CLI and TUI research command accept a new --verify flag that runs an audit after research and prints a plain-text report
- Research now generates a structured audit report showing total interactive ARIA elements, how many were found, and which are missing grouped by root cause:
  - Code filter issues (unnamed/icon-only elements, roles excluded from clickable set, names matching stop words) with file references
  - Prompt issues (elements that passed filters but the AI omitted)
- Audit output is displayed inline in the CLI/TUI session; a user skill document ("Research Audit") explains how to run and interpret the audit and triage fixes

### Impact
`✅ Clearer ARIA coverage reports`
`✅ Faster root-cause identification for missed interactive elements`
`✅ In-session audit available via --verify flag`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
