### PR TITLE
wire performInteractiveExploration into --deep mode

### DIFF
--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -367,6 +367,7 @@ program
   .option('-s, --show', 'Show browser window')
   .option('--headless', 'Run browser in headless mode')
   .option('--data', 'Include data extraction in research')
+  .option('--deep', 'Enable deep analysis (expand hidden elements)')
   .action(async (url, options) => {
     try {
       const mainOptions: ExplorBotOptions = {
@@ -390,6 +391,7 @@ program
         screenshot: true,
         force: true,
         data: options.data || false,
+        deep: options.deep || false,
       });
 
       await explorBot.stop();

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -37,7 +37,7 @@ const POSSIBLE_SECTIONS = {
 
 const DEFAULT_STOP_WORDS = ['close', 'cancel', 'dismiss', 'exit', 'back', 'cookie', 'consent', 'gdpr', 'privacy', 'accept all', 'decline all', 'reject all', 'share', 'print', 'download'];
 
-const CLICKABLE_ROLES = new Set(['button', 'link', 'menuitem', 'tab', 'option', 'combobox', 'switch']);
+const CLICKABLE_ROLES = new Set(['button', 'link', 'menuitem', 'tab', 'option', 'combobox', 'switch', 'checkbox', 'radio', 'slider', 'textbox', 'treeitem']);
 
 export class Researcher implements Agent {
   emoji = '🔍';
@@ -131,13 +131,16 @@ export class Researcher implements Agent {
 
       this.hasScreenshotToAnalyze = screenshot && this.provider.hasVision() && isOnCurrentState;
 
-      const prompt = await this.buildResearchPrompt();
-
       const conversation = this.provider.startConversation(this.getSystemMessage(), 'researcher');
-      conversation.addUserText(prompt);
 
       if (this.hasScreenshotToAnalyze) {
         this.actionResult = await this.explorer.createAction().caputrePageWithScreenshot();
+      }
+
+      const prompt = await this.buildResearchPrompt();
+      conversation.addUserText(prompt);
+
+      if (this.hasScreenshotToAnalyze) {
         const screenshotAnalysis = await this.analyzeScreenshotForUIElements();
         if (screenshotAnalysis) {
           this.addScreenshotPrompt(conversation, screenshotAnalysis);
@@ -153,6 +156,8 @@ export class Researcher implements Agent {
 
       if (deep) {
         researchText += await this.performDeepAnalysis(conversation, state, state.html ?? '');
+        researchText += '\n\n## Interactive Elements Exploration\n\n';
+        researchText += await this.performInteractiveExploration(state, { maxElements: 50 });
       }
 
       if (data) {
@@ -950,12 +955,12 @@ export class Researcher implements Agent {
     }
   }
 
-  async performInteractiveExploration(state: WebPageState): Promise<string> {
+  async performInteractiveExploration(state: WebPageState, opts: { maxElements?: number } = {}): Promise<string> {
     const config = this.getResearcherConfig();
     const stopWords = config?.stopWords ?? DEFAULT_STOP_WORDS;
     const excludeSelectors = config?.excludeSelectors || [];
     const includeSelectors = config?.includeSelectors || [];
-    const maxElements = config?.maxElementsToExplore ?? 10;
+    const maxElements = opts.maxElements ?? config?.maxElementsToExplore ?? 10;
 
     const interactiveNodes = collectInteractiveNodes(state.ariaSnapshot || '');
     const originalUrl = state.url;
@@ -969,12 +974,7 @@ export class Researcher implements Agent {
         return false;
       }
 
-      if (!name) {
-        debugLog(`Skipping unnamed ${role} element`);
-        return false;
-      }
-
-      if (name.length > 50) {
+      if (name.length > 80) {
         debugLog(`Skipping "${name.slice(0, 30)}..." - name too long`);
         return false;
       }
@@ -1011,22 +1011,24 @@ export class Researcher implements Agent {
       const role = String(node.role || '');
       const name = String(node.name || '').trim();
 
-      tag('substep').log(`[${i + 1}/${targets.length}] Exploring: "${name}" (${role})`);
+      const label = name || `unnamed ${role}`;
+      tag('substep').log(`[${i + 1}/${targets.length}] Exploring: "${label}" (${role})`);
 
       const action = this.explorer.createAction();
       const beforeState = await action.capturePageState({});
 
       try {
-        await action.execute(`I.click({ role: '${role}', text: '${name.replace(/'/g, "\\'")}' })`);
+        const clickCommand = name ? `I.click({ role: '${role}', text: '${name.replace(/'/g, "\\'")}' })` : `I.click({ role: '${role}' })`;
+        await action.execute(clickCommand);
         const afterState = await action.capturePageState({});
 
         const resultDescription = this.detectChangeResult(beforeState, afterState, originalUrl);
-        results.push({ element: name, role, result: resultDescription });
+        results.push({ element: label, role, result: resultDescription });
 
         await this.restoreState(afterState, originalUrl);
       } catch (error) {
-        debugLog(`Failed to explore ${name}:`, error);
-        results.push({ element: name, role, result: 'click failed' });
+        debugLog(`Failed to explore ${label}:`, error);
+        results.push({ element: label, role, result: 'click failed' });
       }
     }
 

--- a/src/commands/research-command.ts
+++ b/src/commands/research-command.ts
@@ -2,15 +2,16 @@ import { BaseCommand } from './base-command.js';
 
 export class ResearchCommand extends BaseCommand {
   name = 'research';
-  description = 'Research current page or navigate to URI and research';
-  suggestions = ['/navigate <page> - to go to another page', '/plan <feature> - to plan testing'];
+  description = 'Research current page or navigate to URI and research. Use --deep to explore interactive elements by clicking them. Use --data to include page data.';
+  suggestions = ['/research --deep - explore by clicking buttons', '/navigate <page> - to go to another page', '/plan <feature> - to plan testing'];
 
   async execute(args: string): Promise<void> {
     const includeData = args.includes('--data');
-    const target = args.replace('--data', '').trim();
+    const enableDeep = args.includes('--deep');
+    const target = args.replace('--data', '').replace('--deep', '').trim();
 
     if (target) {
-      await this.explorBot.getExplorer().visit(target);
+      await this.explorBot.agentNavigator().visit(target);
     }
 
     const state = this.explorBot.getExplorer().getStateManager().getCurrentState();
@@ -22,6 +23,7 @@ export class ResearchCommand extends BaseCommand {
       screenshot: true,
       force: true,
       data: includeData,
+      deep: enableDeep,
     });
   }
 }

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -79,10 +79,8 @@ const buildInteractiveEntry = (node: AriaNode): Record<string, unknown> | null =
     shouldInclude = true;
   }
   if (isButtonOrLink && !entryName && !hasValue) {
-    shouldInclude = false;
-  }
-  if (node.role === 'link' && entryName && entryName.length > 30) {
-    shouldInclude = false;
+    entry.unnamed = true;
+    shouldInclude = true;
   }
   if (!shouldInclude) {
     return null;


### PR DESCRIPTION
## **User description**
Connect the unused performInteractiveExploration() to --deep research flow, producing a deterministic element inventory alongside AI analysis.

Changes:
- Add --deep flag to TUI /research command and CLI
- Call performInteractiveExploration after performDeepAnalysis in deep mode
- Expand CLICKABLE_ROLES with checkbox, radio, slider, textbox, treeitem
- Include unnamed buttons in ARIA collection (mark with unnamed flag)
- Remove 30-char link name length filter
- Handle unnamed elements with role-only click fallback
- Accept maxElements override param, use 50 in deep mode


___

## **CodeAnt-AI Description**
Enable deep interactive exploration during research (--deep) and include unnamed/clickable elements

### What Changed
- Add --deep option to CLI and TUI research command; when used, research performs an interactive exploration that clicks UI elements after analysis
- Exploration now considers more element types (checkbox, radio, slider, textbox, treeitem) and includes unnamed buttons/links (marks them as unnamed and falls back to role-only clicks)
- Increased allowable name length and removed the previous short-name filter; exploration accepts a maxElements override and deep mode uses up to 50 elements

### Impact
`✅ Deeper UI coverage during research`
`✅ Discover previously ignored unnamed interactive elements`
`✅ Broader interactive element sampling (up to 50 clicks in deep mode)`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
