### PR TITLE
improve explorbot-debug skill with Langfuse export

### DIFF
--- a/.claude/skills/explorbot-debug/langfuse-export.ts
+++ b/.claude/skills/explorbot-debug/langfuse-export.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env bun
+import { writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const BASE_URL = process.env.LANGFUSE_BASE_URL || 'https://cloud.langfuse.com';
+const PUBLIC_KEY = process.env.LANGFUSE_PUBLIC_KEY;
+const SECRET_KEY = process.env.LANGFUSE_SECRET_KEY;
+
+if (!PUBLIC_KEY || !SECRET_KEY) {
+  console.error('Missing LANGFUSE_PUBLIC_KEY or LANGFUSE_SECRET_KEY in .env');
+  process.exit(1);
+}
+
+const AUTH = `Basic ${btoa(`${PUBLIC_KEY}:${SECRET_KEY}`)}`;
+
+async function api(path: string) {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    headers: { Authorization: AUTH },
+  });
+  if (!res.ok) {
+    throw new Error(`Langfuse API ${res.status}: ${await res.text()}`);
+  }
+  return res.json();
+}
+
+function parseTimeRange(range: string): { from: string; to: string } {
+  const to = new Date();
+  const from = new Date();
+
+  const match = range.match(/^(\d+)([mhd])$/);
+  if (match) {
+    const [, amount, unit] = match;
+    const ms = { m: 60_000, h: 3_600_000, d: 86_400_000 }[unit]!;
+    from.setTime(to.getTime() - Number(amount) * ms);
+    return { from: from.toISOString(), to: to.toISOString() };
+  }
+
+  if (range === 'today') {
+    from.setHours(0, 0, 0, 0);
+    return { from: from.toISOString(), to: to.toISOString() };
+  }
+
+  return { from: new Date(range).toISOString(), to: to.toISOString() };
+}
+
+async function fetchTraces(from: string, to: string) {
+  const params = new URLSearchParams({
+    limit: '50',
+    fromTimestamp: from,
+    toTimestamp: to,
+  });
+  const data = await api(`/api/public/traces?${params}`);
+  return data.data;
+}
+
+async function fetchObservations(traceId: string) {
+  const params = new URLSearchParams({
+    traceId,
+    limit: '100',
+  });
+  const data = await api(`/api/public/observations?${params}`);
+  return data.data;
+}
+
+const range = process.argv[2] || '1h';
+const outPath = process.argv[3] || `output/langfuse-export-${Date.now()}.json`;
+
+console.log(`Fetching traces for range: ${range}`);
+const { from, to } = parseTimeRange(range);
+console.log(`  From: ${from}`);
+console.log(`  To:   ${to}`);
+
+const traces = await fetchTraces(from, to);
+console.log(`Found ${traces.length} traces`);
+
+if (!traces.length) {
+  console.log('No traces found in this time range.');
+  process.exit(0);
+}
+
+for (const t of traces) {
+  console.log(`  ${t.timestamp} | ${t.name || '(unnamed)'} | ${(t.tags || []).join(', ')}`);
+}
+
+console.log('\nFetching observations for each trace...');
+const result = [];
+for (const t of traces) {
+  const observations = await fetchObservations(t.id);
+  result.push({ ...t, observations });
+  console.log(`  ${t.name || t.id}: ${observations.length} observations`);
+}
+
+const resolved = resolve(outPath);
+writeFileSync(resolved, JSON.stringify(result, null, 2));
+console.log(`\nSaved to: ${resolved}`);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "check": "biome check .",
-    "check:fix": "biome check --write ."
+    "check:fix": "biome check --write .",
+    "langfuse:export": "bun run .claude/skills/explorbot-debug/langfuse-export.ts"
   },
   "keywords": ["cli", "react", "ink", "codeceptjs", "playwright"],
   "author": "",


### PR DESCRIPTION
## **User description**
Rewrote the debug skill to automatically analyze log timeline, locate/export Langfuse traces, and correlate both sources. Added langfuse-export.ts script and npm script shortcut.


___

## **CodeAnt-AI Description**
Improve Explorbot debug workflow with on-demand Langfuse trace export and clearer log correlation

### What Changed
- Adds a command-line script to fetch and save Langfuse traces and their observations for a specified time range, producing a JSON export usable for session analysis
- Updates the Explorbot debug guide to describe how to determine the session time range from logs, when to run the Langfuse export, and how to correlate Langfuse traces with browser logs; includes a log-only fallback if Langfuse data is unavailable
- Exposes a new npm script shortcut to run the Langfuse export easily from the project

### Impact
`✅ Easier Langfuse exports for specific sessions`
`✅ Shorter debug sessions by correlating AI traces with browser logs`
`✅ Clearer root-cause correlation between AI decisions and browser behavior`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
