### PR TITLE
fix(doc-collector): two SPA-robustness fixes (recoverable nav error, page-state repopulation)

### DIFF
--- a/boat/doc-collector/src/docbot.ts
+++ b/boat/doc-collector/src/docbot.ts
@@ -5,6 +5,7 @@ import type { Link, WebPageState } from '../../../src/state-manager.ts';
 import { normalizeUrl } from '../../../src/state-manager.ts';
 import { sanitizeFilename } from '../../../src/utils/strings.ts';
 import { tag } from '../../../src/utils/logger.ts';
+import { extractLinks } from '../../../src/utils/html.ts';
 import { Documentarian, type PageDocumentation } from './ai/documentarian.ts';
 import { type DocbotConfig, DocbotConfigParser } from './config.ts';
 import { type DocumentedPage, renderPageDocumentation, renderSpecIndex, type SkippedPage } from './docs-renderer.ts';
@@ -92,13 +93,21 @@ class DocBot {
           break;
         }
 
-        const state = this.explorBot.getCurrentState();
+        let state = this.explorBot.getCurrentState();
         if (!state) {
           skipped.push({
             url: target,
             reason: 'page state was not captured after navigation',
           });
           continue;
+        }
+        // If the current state is a stripped basic WebPageState (no html — happens when
+        // framenavigated fires after visit's own capture), force a fresh capture so
+        // links / html / aria are available for downstream link enqueue and research.
+        if (!state.html) {
+          const action = this.explorBot.getExplorer().createAction();
+          await action.capturePageState({ includeScreenshot: this.shouldUseScreenshots() }).catch(() => undefined);
+          state = this.explorBot.getCurrentState() ?? state;
         }
 
         const pageKey = this.getPageKey(state.url || target);
@@ -189,7 +198,15 @@ class DocBot {
     const paths: string[] = [];
     const seen = new Set<string>();
 
-    for (const link of state.links || []) {
+    // state.links may be empty when framenavigated overwrote a full ActionResult with a
+    // stripped-down basic state. Fall back to extracting from state.html so subtree crawl
+    // still discovers child paths.
+    let links = state.links ?? [];
+    if (links.length === 0 && state.html) {
+      links = extractLinks(state.html);
+    }
+
+    for (const link of links) {
       const nextPath = this.resolveLink(link, baseUrl);
       if (!nextPath) {
         continue;

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -40,7 +40,7 @@ declare namespace CodeceptJS {
 
 const debugLog = createDebug('explorbot:explorer');
 const FATAL_BROWSER_ERRORS = /Frame was detached|Target closed|Execution context was destroyed|Protocol error|Session closed/i;
-const RECOVERABLE_NAVIGATION_ERRORS = /net::ERR_ABORTED|page\.screenshot.*Timeout|waiting for fonts to load/i;
+const RECOVERABLE_NAVIGATION_ERRORS = /net::ERR_ABORTED|page\.screenshot.*Timeout|waiting for fonts to load|navigating and changing the content/i;
 
 interface TabInfo {
   url: string;


### PR DESCRIPTION
## Summary

Two independent fixes that came out of running `explorbot docs collect` against a real-world SPA (Testomat.io beta). Each is in its own commit.

> **Note:** Initial version of this PR included a third fix to `ConfigParser.loadEnv` (walk parent dirs to find .env). It regressed `action-result-diff.test.ts` on CI in ways the diff alone doesn't fully explain. Dropped from this PR — will resubmit separately with a CLI-level bootstrap so library semantics are unchanged.

### 1. `fix(explorer)`: treat "navigating and changing the content" as recoverable

Playwright throws `page.content: Unable to retrieve content because the page is navigating and changing the content` on heavy SPAs whose client router rewrites the DOM mid-action (Ember, React Router, etc.). The current regex covered `net::ERR_ABORTED`, screenshot timeout, and font-wait — this new phrase fell through to `FATAL_BROWSER_ERRORS` and killed the whole crawl on the first race. Added to `RECOVERABLE_NAVIGATION_ERRORS` so the explorer retries instead.

### 2. `fix(doc-collector)`: repopulate page state when framenavigated stripped it

After navigation, the `framenavigated` handler overwrites the rich `ActionResult` (html / links / aria) with a stripped `WebPageState` carrying only `{ url, title, statusCode }`. `doc-collector` then reads `getCurrentState()` and gets `state.html === undefined`, `state.links === []`. Two consequences:

- `Documentarian` receives empty html → page docs degrade to a near-empty stub.
- `extractNextPaths` sees an empty links array → subtree crawl stops at the entry page even when many followable links exist.

Targeted fixes:
- In the main collect loop: if `state.html` is falsy, force `capturePageState` before passing to the AI documenter.
- In `extractNextPaths`: if `state.links` is empty but `state.html` is present, fall back to `extractLinks(state.html)`.

## Repro (combined effect)

Running `explorbot docs collect /projects/{slug}/runs/{id}` on Testomat.io beta:

| Before | After |
|---|---|
| Crash on first action with the "navigating and changing the content" error | Crawl completes |
| When it didn't crash: "Pages documented: 1" | "Pages documented: 2-3" (entry + linked subpages) |