### PR TITLE
Stop testing on error pages

### DIFF
--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -52,6 +52,7 @@ export interface ToolResultMetadata {
 export class ActionResult implements ActionResultData {
   public id?: number;
   public title = '';
+  public httpStatus: number | undefined = undefined;
   public error: string | null = null;
   public timestamp: Date = new Date();
   public h1: string | undefined = undefined;
@@ -82,6 +83,7 @@ export class ActionResult implements ActionResultData {
     this.url = data.url ?? '';
     this.fullUrl = data.fullUrl;
     this.title = data.title ?? '';
+    this.httpStatus = data.httpStatus;
     this.error = data.error ?? null;
     this.browserLogs = data.browserLogs ?? [];
     this.iframeSnapshots = data.iframeSnapshots ?? [];

--- a/src/action.ts
+++ b/src/action.ts
@@ -41,6 +41,7 @@ class Action {
   public playwrightGroupId: string | null = null;
   public assertionSteps: Array<{ name: string; args: any[] }> = [];
   private recorder?: PlaywrightRecorder;
+  private mainDocumentStatus: number | undefined = undefined;
 
   constructor(actor: CodeceptJS.I, stateManager: StateManager, recorder?: PlaywrightRecorder) {
     this.actor = actor;
@@ -144,6 +145,7 @@ class Action {
       const result = new ActionResult({
         html,
         title,
+        httpStatus: await this.captureMainDocumentStatus(),
         url,
         browserLogs,
         htmlFile,
@@ -163,6 +165,45 @@ class Action {
       const url = this.playwrightHelper.page?.url?.() || '';
       return new ActionResult({ url, error: msg });
     }
+  }
+
+  private async captureMainDocumentStatus(): Promise<number | undefined> {
+    if (this.mainDocumentStatus) return this.mainDocumentStatus;
+
+    try {
+      const page = this.playwrightHelper.page;
+      const status = await page.evaluate(() => {
+        const navigation = performance.getEntriesByType('navigation').at(-1) as PerformanceNavigationTiming & { responseStatus?: number };
+        if (!navigation) return undefined;
+        if (new URL(navigation.name).href !== window.location.href) return undefined;
+        return navigation.responseStatus;
+      });
+      if (typeof status !== 'number') return undefined;
+      if (status <= 0) return undefined;
+      return status;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private captureMainDocumentResponse(): () => void {
+    const page = this.playwrightHelper.page;
+    if (!page?.on || !page?.off) return () => {};
+
+    this.mainDocumentStatus = undefined;
+
+    const handler = (response: any) => {
+      const request = response.request();
+      if (request.resourceType() !== 'document') return;
+      if (response.frame() !== page.mainFrame()) return;
+      const status = response.status();
+      if (typeof status !== 'number') return;
+      if (status <= 0) return;
+      this.mainDocumentStatus = status;
+    };
+
+    page.on('response', handler);
+    return () => page.off('response', handler);
   }
 
   /**
@@ -235,6 +276,7 @@ class Action {
     const stepListener = attachStepLogger(executedSteps, assertionSteps);
     const groupId = this.recorder ? await this.recorder.beginAction(codeString) : null;
     this.playwrightGroupId = groupId;
+    const detachMainDocumentResponse = this.captureMainDocumentResponse();
     const activeSpan = Observability.getSpan();
     const tracer = trace.getTracer('ai');
     const stepSpan = activeSpan ? tracer.startSpan('codeceptjs.step', undefined, trace.setSpan(context.active(), activeSpan)) : null;
@@ -280,6 +322,7 @@ class Action {
       this.assertionSteps = [];
       throw err;
     } finally {
+      detachMainDocumentResponse();
       if (groupId) await this.recorder!.endAction();
       detachStepLogger(stepListener);
       if (stepSpan) {

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -135,7 +135,7 @@ export class Researcher extends ResearcherBase implements Agent {
       const condition = detectPageCondition(this.actionResult!);
       if (condition === 'error') {
         tag('warning').log(`Detected error page at ${state.url}`);
-        throw new ErrorPageError(state.url, this.actionResult!.title);
+        throw new ErrorPageError(state.url, this.actionResult!.title, this.actionResult!.httpStatus);
       }
       if (condition === 'loading') {
         const settled = await this.waitUntilSettled(screenshot);
@@ -376,7 +376,7 @@ export class Researcher extends ResearcherBase implements Agent {
 
     let condition = detectPageCondition(this.actionResult!);
     if (condition === 'error') {
-      throw new ErrorPageError(this.actionResult!.url, this.actionResult!.title);
+      throw new ErrorPageError(this.actionResult!.url, this.actionResult!.title, this.actionResult!.httpStatus);
     }
     if (condition === 'ok') return true;
 
@@ -386,7 +386,7 @@ export class Researcher extends ResearcherBase implements Agent {
       this.actionResult = await this.explorer.createAction().capturePageState({ includeScreenshot });
       condition = detectPageCondition(this.actionResult!);
       if (condition === 'error') {
-        throw new ErrorPageError(this.actionResult!.url, this.actionResult!.title);
+        throw new ErrorPageError(this.actionResult!.url, this.actionResult!.title, this.actionResult!.httpStatus);
       }
       if (condition === 'ok') return true;
     }

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -4,7 +4,7 @@ import { tool } from 'ai';
 import dedent from 'dedent';
 import { z } from 'zod';
 import { ActionResult } from '../action-result.ts';
-import { setActivity } from '../activity.ts';
+import { clearActivity, setActivity } from '../activity.ts';
 import { ConfigParser } from '../config.ts';
 import type { ExperienceTracker } from '../experience-tracker.ts';
 import type Explorer from '../explorer.ts';
@@ -13,7 +13,7 @@ import type { StateTransition, WebPageState } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Note, type Test, TestResult, type TestResultType } from '../test-plan.ts';
 import { detectFocusArea, extractFocusedElement } from '../utils/aria.ts';
-import { ErrorPageError } from '../utils/error-page.ts';
+import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { HooksRunner } from '../utils/hooks-runner.ts';
 import { codeToMarkdown } from '../utils/html.ts';
 import { createDebug, tag } from '../utils/logger.ts';
@@ -148,6 +148,14 @@ export class Tester extends TaskAgent implements Agent {
     page?.on('console', onConsoleMessage);
 
     const initialState = ActionResult.fromState(state);
+    if (isErrorPage(initialState)) {
+      task.start();
+      await this.explorer.startTest(task);
+      offFailedRequest?.();
+      page?.off('pageerror', onPageError);
+      page?.off('console', onConsoleMessage);
+      return await this.abortStartedTestOnErrorPage(task, initialState);
+    }
 
     const conversation = this.provider.startConversation(this.getSystemMessage(), 'tester');
     conversation.markLastMessageCacheable();
@@ -217,6 +225,15 @@ export class Tester extends TaskAgent implements Agent {
 
     const startState = this.explorer.getStateManager().getCurrentState();
     if (startState) task.addUrlNote(startState);
+    if (startState) {
+      const startActionResult = ActionResult.fromState(startState);
+      if (isErrorPage(startActionResult)) {
+        offFailedRequest?.();
+        page?.off('pageerror', onPageError);
+        page?.off('console', onConsoleMessage);
+        return await this.abortStartedTestOnErrorPage(task, startActionResult);
+      }
+    }
     const currentUrl = startState?.url || task.startUrl || '';
     await this.hooksRunner.runBeforeHook('tester', currentUrl);
 
@@ -432,11 +449,7 @@ export class Tester extends TaskAgent implements Agent {
     page?.off('pageerror', onPageError);
     page?.off('console', onConsoleMessage);
     await this.finishTest(task);
-    await this.explorer.stopTest(task, {
-      startUrl: task.startUrl,
-      style: task.style,
-      sessionName: task.sessionName,
-    });
+    await this.explorer.stopTest(task, this.buildStopTestMeta(task));
 
     return {
       success: task.isSuccessful,
@@ -687,6 +700,26 @@ export class Tester extends TaskAgent implements Agent {
     } else {
       tag('warning').log(`Test with no result: ${task.scenario}`);
     }
+  }
+
+  private async abortStartedTestOnErrorPage(task: Test, actionResult: ActionResult): Promise<{ success: boolean }> {
+    const error = new ErrorPageError(actionResult.url || task.startUrl || '', actionResult.title, actionResult.httpStatus);
+    tag('warning').log(error.message);
+    task.addNote(error.message, TestResult.FAILED, actionResult.screenshotFile, actionResult.fullUrl || actionResult.url);
+    task.finish(TestResult.FAILED);
+    this.finishTest(task);
+    await this.explorer.stopTest(task, this.buildStopTestMeta(task));
+    clearActivity(true);
+    return { success: false };
+  }
+
+  private buildStopTestMeta(task: Test): Record<string, string> {
+    const meta: Record<string, string> = {
+      startUrl: task.startUrl,
+    };
+    if (task.style) meta.style = task.style;
+    if (task.sessionName) meta.sessionName = task.sessionName;
+    return meta;
   }
 
   getSystemMessage(): string {

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -224,8 +224,8 @@ export class Tester extends TaskAgent implements Agent {
     await this.explorer.visit(task.startUrl!);
 
     const startState = this.explorer.getStateManager().getCurrentState();
-    if (startState) task.addUrlNote(startState);
     if (startState) {
+      task.addUrlNote(startState);
       const startActionResult = ActionResult.fromState(startState);
       if (isErrorPage(startActionResult)) {
         offFailedRequest?.();

--- a/src/commands/explore-command.ts
+++ b/src/commands/explore-command.ts
@@ -1,11 +1,12 @@
 import figureSet from 'figures';
+import { ActionResult } from '../action-result.ts';
 import { getStyles } from '../ai/planner/styles.js';
 import { outputPath } from '../config.js';
 import { normalizeUrl } from '../state-manager.js';
 import { Stats } from '../stats.js';
 import { type Plan, type Test, TestResult } from '../test-plan.js';
 import { getCliName } from '../utils/cli-name.ts';
-import { ErrorPageError } from '../utils/error-page.ts';
+import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { tag } from '../utils/logger.js';
 import { type NextStepSection, printNextSteps, relativeToCwd } from '../utils/next-steps.ts';
 import { safeFilename } from '../utils/strings.ts';
@@ -56,6 +57,7 @@ export class ExploreCommand extends BaseCommand {
     Stats.mode ??= 'explore';
     Stats.focus ??= feature;
     const mainUrl = this.getCurrentPageUrl();
+    if (this.isCurrentPageErrorPage()) return;
 
     if (cfg.enabled) {
       await this.runReuseMode(mainUrl, feature, cfg);
@@ -78,6 +80,16 @@ export class ExploreCommand extends BaseCommand {
 
   private originLabel(test: Test): string {
     return this.oldTestRefs.has(test) ? 'OLD' : 'NEW';
+  }
+
+  private isCurrentPageErrorPage(): boolean {
+    const state = this.explorBot.getExplorer().getStateManager().getCurrentState();
+    if (!state) return false;
+    const actionResult = ActionResult.fromState(state);
+    if (!isErrorPage(actionResult)) return false;
+    const error = new ErrorPageError(actionResult.url, actionResult.title, actionResult.httpStatus);
+    tag('warning').log(error.message);
+    return true;
   }
 
   private printPreview(label: string, tests: Test[]): void {

--- a/src/commands/explore-command.ts
+++ b/src/commands/explore-command.ts
@@ -1,12 +1,11 @@
 import figureSet from 'figures';
-import { ActionResult } from '../action-result.ts';
 import { getStyles } from '../ai/planner/styles.js';
 import { outputPath } from '../config.js';
 import { normalizeUrl } from '../state-manager.js';
 import { Stats } from '../stats.js';
 import { type Plan, type Test, TestResult } from '../test-plan.js';
 import { getCliName } from '../utils/cli-name.ts';
-import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
+import { ErrorPageError, getStateErrorPageError } from '../utils/error-page.ts';
 import { tag } from '../utils/logger.js';
 import { type NextStepSection, printNextSteps, relativeToCwd } from '../utils/next-steps.ts';
 import { safeFilename } from '../utils/strings.ts';
@@ -57,7 +56,11 @@ export class ExploreCommand extends BaseCommand {
     Stats.mode ??= 'explore';
     Stats.focus ??= feature;
     const mainUrl = this.getCurrentPageUrl();
-    if (this.isCurrentPageErrorPage()) return;
+    const error = getStateErrorPageError(this.explorBot.getExplorer().getStateManager().getCurrentState());
+    if (error) {
+      tag('warning').log(error.message);
+      return;
+    }
 
     if (cfg.enabled) {
       await this.runReuseMode(mainUrl, feature, cfg);
@@ -80,16 +83,6 @@ export class ExploreCommand extends BaseCommand {
 
   private originLabel(test: Test): string {
     return this.oldTestRefs.has(test) ? 'OLD' : 'NEW';
-  }
-
-  private isCurrentPageErrorPage(): boolean {
-    const state = this.explorBot.getExplorer().getStateManager().getCurrentState();
-    if (!state) return false;
-    const actionResult = ActionResult.fromState(state);
-    if (!isErrorPage(actionResult)) return false;
-    const error = new ErrorPageError(actionResult.url, actionResult.title, actionResult.httpStatus);
-    tag('warning').log(error.message);
-    return true;
   }
 
   private printPreview(label: string, tests: Test[]): void {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -24,6 +24,8 @@ export interface WebPageState {
   url: string;
   /** Page title */
   title?: string;
+  /** HTTP status of the main document navigation */
+  httpStatus?: number;
   /** Full URL for reference */
   fullUrl?: string;
   /** Timestamp when state was captured */

--- a/src/utils/error-page.ts
+++ b/src/utils/error-page.ts
@@ -9,6 +9,8 @@ const LOADING_WORD = /\bloading\b/i;
 export type PageCondition = 'ok' | 'loading' | 'error';
 
 export function detectPageCondition(actionResult: ActionResult): PageCondition {
+  if (actionResult.httpStatus && actionResult.httpStatus >= 400) return 'error';
+
   const headingFields = [actionResult.title, actionResult.h1, actionResult.h2].filter(Boolean) as string[];
 
   for (const field of headingFields) {
@@ -40,9 +42,12 @@ export function isErrorPage(actionResult: ActionResult): boolean {
 export class ErrorPageError extends Error {
   constructor(
     public readonly url: string,
-    public readonly title?: string
+    public readonly title?: string,
+    public readonly httpStatus?: number
   ) {
-    super(`Error page detected at ${url}${title ? ` (${title})` : ''}`);
+    const status = httpStatus ? `HTTP ${httpStatus}` : '';
+    const details = [status, title].filter(Boolean).join(', ');
+    super(`Error page detected at ${url}${details ? ` (${details})` : ''}`);
     this.name = 'ErrorPageError';
   }
 }

--- a/src/utils/error-page.ts
+++ b/src/utils/error-page.ts
@@ -1,4 +1,5 @@
-import type { ActionResult } from '../action-result.js';
+import { ActionResult } from '../action-result.js';
+import type { WebPageState } from '../state-manager.js';
 import { isBodyEmpty } from './html.js';
 
 const HTTP_ERRORS = ['400 Bad Request', '401 Unauthorized', '403 Forbidden', '404 Not Found', '405 Method Not Allowed', '408 Request Timeout', '500 Internal Server Error', '502 Bad Gateway', '503 Service Unavailable', '504 Gateway Timeout'];
@@ -37,6 +38,13 @@ export function detectPageCondition(actionResult: ActionResult): PageCondition {
 
 export function isErrorPage(actionResult: ActionResult): boolean {
   return detectPageCondition(actionResult) === 'error';
+}
+
+export function getStateErrorPageError(state: WebPageState | null | undefined): ErrorPageError | null {
+  if (!state) return null;
+  const actionResult = ActionResult.fromState(state);
+  if (!isErrorPage(actionResult)) return null;
+  return new ErrorPageError(actionResult.url, actionResult.title, actionResult.httpStatus);
 }
 
 export class ErrorPageError extends Error {

--- a/tests/unit/error-page.test.ts
+++ b/tests/unit/error-page.test.ts
@@ -2,16 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { ActionResult } from '../../src/action-result.ts';
 import { detectPageCondition, isErrorPage } from '../../src/utils/error-page.ts';
 
-function createActionResult(data: { title?: string; h1?: string; h2?: string; html?: string; url?: string }): ActionResult {
+function createActionResult(data: { title?: string; h1?: string; h2?: string; html?: string; url?: string; httpStatus?: number }): ActionResult {
   const html = data.html ?? `<html><body><h1>${data.h1 ?? ''}</h1><h2>${data.h2 ?? ''}</h2></body></html>`;
   return new ActionResult({
     url: data.url ?? '/test',
     title: data.title ?? '',
+    httpStatus: data.httpStatus,
     html,
   });
 }
 
 describe('isErrorPage', () => {
+  describe('HTTP status detection', () => {
+    it('should detect failed document navigation by status', () => {
+      expect(isErrorPage(createActionResult({ httpStatus: 404, html: '<html><body>Not Found</body></html>' }))).toBe(true);
+      expect(isErrorPage(createActionResult({ httpStatus: 500, html: '<html><body>Server Error</body></html>' }))).toBe(true);
+    });
+
+    it('should not treat successful document navigation as an error page', () => {
+      expect(isErrorPage(createActionResult({ httpStatus: 200, html: '<html><body>Not Found</body></html>' }))).toBe(false);
+    });
+  });
+
   describe('HTTP error detection', () => {
     it('should detect 400 Bad Request', () => {
       expect(isErrorPage(createActionResult({ title: '400 Bad Request' }))).toBe(true);

--- a/tests/unit/explore-command.test.ts
+++ b/tests/unit/explore-command.test.ts
@@ -249,6 +249,49 @@ describe('ExploreCommand picking algorithm (via dry-run execute)', () => {
   });
 });
 
+describe('ExploreCommand error page guard', () => {
+  test('does not plan or run tests when current page is an error page', async () => {
+    let planCalled = 0;
+    let testerCalled = 0;
+    let saveCalled = 0;
+    const explorBot = {
+      getExplorer: () => ({
+        getStateManager: () => ({
+          getCurrentState: () => ({
+            url: '/missing',
+            fullUrl: 'https://example.com/missing',
+            title: 'Application',
+            httpStatus: 404,
+            html: '<html><body>Short response</body></html>',
+          }),
+        }),
+      }),
+      plan: async () => {
+        planCalled++;
+      },
+      agentTester: () => ({
+        test: async () => {
+          testerCalled++;
+        },
+      }),
+      getCurrentPlan: () => undefined,
+      savePlans: () => {
+        saveCalled++;
+        return null;
+      },
+      printSessionAnalysis: async () => {},
+      agentHistorian: () => ({ getSavedFiles: () => [] }),
+    } as unknown as ExplorBot;
+
+    const cmd = new ExploreCommand(explorBot);
+    await cmd.execute('--max-tests 1');
+
+    expect(planCalled).toBe(0);
+    expect(testerCalled).toBe(0);
+    expect(saveCalled).toBe(0);
+  });
+});
+
 describe('ExploreCommand priority filter applies to NEW tests too', () => {
   test('new tests with disallowed priorities get disabled and do not run', async () => {
     const fakePlan = new Plan('Live');

--- a/tests/unit/tester-error-page.test.ts
+++ b/tests/unit/tester-error-page.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { Tester } from '../../src/ai/tester.ts';
+import { clearActivity, getCurrentActivity } from '../../src/activity.ts';
+import { ConfigParser } from '../../src/config.ts';
+import { Test, TestResult } from '../../src/test-plan.ts';
+
+beforeEach(() => {
+  ConfigParser.resetForTesting();
+  ConfigParser.setupTestConfig();
+  clearActivity(true);
+});
+
+function createState(title: string, html: string, url = '/missing', httpStatus?: number) {
+  return {
+    url,
+    fullUrl: url,
+    title,
+    httpStatus,
+    html,
+    ariaSnapshot: '',
+  };
+}
+
+function createConversation() {
+  return {
+    messages: [],
+    addUserText: mock(() => {}),
+    markLastMessageCacheable: mock(() => {}),
+    protectPrefix: mock(() => {}),
+  };
+}
+
+describe('Tester error page handling', () => {
+  test('stops before creating a conversation when current page is already an error page', async () => {
+    const currentState = createState('500 Internal Server Error', '<html><body><h1>500 Internal Server Error</h1></body></html>', '/broken');
+    const startConversation = mock(() => createConversation());
+    const visit = mock(async () => {});
+    const startTest = mock(async () => {});
+    const stopTest = mock(async () => {});
+
+    const explorer: any = {
+      getConfig: () => ({}),
+      getStateManager: () => ({
+        getCurrentState: () => currentState,
+        clearHistory: () => {},
+        getExperienceTracker: () => ({}),
+      }),
+      getKnowledgeTracker: () => ({
+        getRelevantKnowledge: () => [],
+      }),
+      getRequestStore: () => null,
+      playwrightHelper: {
+        page: {
+          on: () => {},
+          off: () => {},
+        },
+      },
+      startTest,
+      stopTest,
+      visit,
+    };
+    const provider: any = {
+      getSystemPromptForAgent: () => '',
+      startConversation,
+      invokeConversation: mock(async () => null),
+    };
+    const researcher: any = {};
+    const navigator: any = {};
+    const tester = new Tester(explorer, provider, researcher, navigator);
+    const task = new Test('check broken page', 'normal', 'page works', '/broken');
+
+    const result = await tester.test(task);
+
+    expect(result.success).toBe(false);
+    expect(task.result).toBe(TestResult.FAILED);
+    expect(Object.values(task.notes).some((note) => note.message.includes('Error page detected at /broken'))).toBe(true);
+    expect(startConversation).not.toHaveBeenCalled();
+    expect(visit).not.toHaveBeenCalled();
+    expect(startTest).toHaveBeenCalledTimes(1);
+    expect(stopTest).toHaveBeenCalledTimes(1);
+    expect(getCurrentActivity()).toBeNull();
+  });
+
+  test('stops without AI execution when start URL opens an error page', async () => {
+    let currentState = createState('Dashboard', `<html><body>${'x'.repeat(600)}</body></html>`, '/dashboard');
+    const invokeConversation = mock(async () => {
+      throw new Error('should not invoke AI loop');
+    });
+    const visit = mock(async () => {
+      currentState = createState('Application', '<html><body>Short response</body></html>', '/missing', 404);
+    });
+    const startTest = mock(async () => {});
+    const stopTest = mock(async () => {});
+
+    const explorer: any = {
+      getConfig: () => ({}),
+      getStateManager: () => ({
+        getCurrentState: () => currentState,
+        clearHistory: () => {},
+        getExperienceTracker: () => ({}),
+      }),
+      getKnowledgeTracker: () => ({
+        getRelevantKnowledge: () => [],
+      }),
+      getRequestStore: () => null,
+      hasOtherTabs: () => false,
+      getOtherTabsInfo: () => [],
+      clearOtherTabsInfo: () => {},
+      getCurrentIframeInfo: () => null,
+      playwrightHelper: {
+        page: {
+          on: () => {},
+          off: () => {},
+        },
+      },
+      startTest,
+      stopTest,
+      visit,
+    };
+    const provider: any = {
+      getSystemPromptForAgent: () => '',
+      startConversation: mock(() => createConversation()),
+      invokeConversation,
+    };
+    const researcher: any = {
+      research: mock(async () => ''),
+      researchOverlay: mock(async () => null),
+    };
+    const navigator: any = {};
+    const tester = new Tester(explorer, provider, researcher, navigator);
+    const task = new Test('check missing page', 'normal', 'page works', '/missing');
+
+    const result = await tester.test(task);
+
+    expect(result.success).toBe(false);
+    expect(task.result).toBe(TestResult.FAILED);
+    expect(Object.values(task.notes).some((note) => note.message.includes('Error page detected at /missing (HTTP 404'))).toBe(true);
+    expect(visit).toHaveBeenCalledTimes(1);
+    expect(startTest).toHaveBeenCalledTimes(1);
+    expect(stopTest).toHaveBeenCalledTimes(1);
+    expect(invokeConversation).not.toHaveBeenCalled();
+    expect(getCurrentActivity()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Stops exploration/test execution when the current page is detected as an HTTP error page.  https://github.com/testomatio/explorbot/issues/54                                                                       
                                                                                                                                                                                                     
  ## Changes                                                                                                                                                                                         
 - Capture main document HTTP status from Playwright navigation responses
 - Store `httpStatus` in page state/action results.
 - Detect error pages by HTTP status before falling back to existing title/heading checks
 - Stop `explore` before planning when the current page is an error page
 - Stop `test` before AI execution when the start/current page is an error page
 - Clear stale testing activity after early abort.
 - Add unit coverage for error-page detection, explore guard, and tester abort flow         