### PR TITLE
Fall back to JSON object mode when model rejects json_schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-06-20
+
+### Changes
+- Structured output (test planning, supervisor verdicts, and other AI steps that return data) now works with models that don't support strict JSON Schema. When a model rejects the `json_schema` response format, the AI provider automatically retries the same request in JSON object mode — sending the expected shape in the prompt and validating the reply — instead of failing the whole step. The model is remembered for the rest of the session so later requests skip straight to the working mode. Previously these models failed every planning attempt with "This model does not support response format `json_schema`".
+- [Planner] Now honors its own per-agent settings from `ai.agents.planner` (such as `providerOptions`) when generating a plan. Previously those settings were silently ignored during planning, so options like a model's reasoning effort never took effect — which could leave a reasoning model spending its whole output budget thinking and never returning a plan.
+- AI requests no longer print the "System messages in the prompt or messages fields can be a security risk" warning on every call.
+
 ## 2026-06-06
 
 ### Changes

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -181,7 +181,7 @@ export class Planner extends PlannerBase implements Agent {
 
       debugLog('Sending planning prompt to AI provider with structured output');
 
-      const aiResult = await this.provider.generateObject(conversation.messages, TasksSchema, conversation.model);
+      const aiResult = await this.provider.generateObject(conversation.messages, TasksSchema, conversation.model, { agentName: 'planner' });
 
       if (!aiResult?.object?.scenarios) {
         throw new Error('No tasks were created successfully');

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -1,6 +1,7 @@
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { generateObject, generateText, stepCountIs } from 'ai';
+import dedent from 'dedent';
+import { asSchema, generateObject, generateText, stepCountIs } from 'ai';
 import type { ModelMessage } from 'ai';
 import { clearActivity, setActivity } from '../activity.ts';
 import type { AIConfig } from '../config.js';
@@ -18,6 +19,13 @@ const responseLog = createDebug('explorbot:provider:in');
 
 class AiError extends Error {}
 export class ContextLengthError extends Error {}
+
+const modelsWithoutJsonSchema = new Set<string>();
+
+function isJsonSchemaUnsupportedError(error: any): boolean {
+  const msg = (error?.message || error?.toString() || '').toLowerCase();
+  return msg.includes('json_schema') && (msg.includes('does not support') || msg.includes('not supported'));
+}
 
 function extractCachedTokens(usage: any): number {
   if (!usage) return 0;
@@ -242,6 +250,7 @@ export class Provider {
     const telemetry = this.getTelemetry(options);
     const config = this.mergeProviderOptions(
       {
+        allowSystemInMessages: true,
         maxTokens: 16384,
         ...(this.config.config || {}),
         ...options,
@@ -317,6 +326,7 @@ export class Provider {
     const { stopWhen: _ignoredStopWhen, ...optionsWithoutStop } = options;
     const config = this.mergeProviderOptions(
       {
+        allowSystemInMessages: true,
         tools,
         maxTokens: 16384,
         toolChoice: 'auto',
@@ -400,53 +410,10 @@ export class Provider {
   async generateObject(messages: ModelMessage[], schema: any, model?: any, options: any = {}): Promise<any> {
     const modelToUse = model || this.config.model;
     const modelName = this.getModelName(modelToUse);
-    setActivity(`🤖 Asking ${modelName} for structured output`, 'ai');
-    promptLog(`Using model: ${modelName}`);
-
-    const telemetry = this.getTelemetry(options);
-    const config = this.mergeProviderOptions(
-      {
-        schema,
-        ...(this.config.config || {}),
-        ...options,
-        ...(telemetry ? { experimental_telemetry: telemetry } : {}),
-        model: modelToUse,
-        abortSignal: executionController.getAbortSignal(),
-      },
-      options.agentName
-    );
+    const jsonMode = modelsWithoutJsonSchema.has(modelName);
 
     try {
-      promptLog(messages[messages.length - 1].content);
-      const response = await withRetry(async () => {
-        const timeout = config.timeout || 30000;
-        const cancel = { cancelled: false };
-        try {
-          return (await Promise.race([
-            generateObject({
-              messages,
-              ...config,
-            }),
-            rejectAfterIdle(timeout, cancel),
-          ])) as any;
-        } finally {
-          cancel.cancelled = true;
-        }
-      }, this.getRetryOptions(options));
-
-      clearActivity();
-      responseLog(response.object);
-
-      if (response.usage) {
-        Stats.recordTokens(options.agentName || 'unknown', modelName, {
-          input: response.usage.inputTokens ?? response.usage.promptTokens ?? 0,
-          output: response.usage.outputTokens ?? response.usage.completionTokens ?? 0,
-          total: response.usage.totalTokens ?? 0,
-          cached: extractCachedTokens(response.usage),
-        });
-      }
-
-      return response;
+      return await this.runGenerateObject(messages, schema, modelToUse, modelName, options, jsonMode);
     } catch (error: any) {
       clearActivity();
       if (error?.name === 'AbortError') throw error;
@@ -459,8 +426,89 @@ export class Provider {
         }
         throw new ContextLengthError(error.message || error.toString());
       }
+      if (!jsonMode && isJsonSchemaUnsupportedError(error)) {
+        modelsWithoutJsonSchema.add(modelName);
+        tag('warning').log(`${modelName} does not support json_schema, falling back to JSON object mode`);
+        return this.runGenerateObject(messages, schema, modelToUse, modelName, options, true);
+      }
       throw new AiError(error.message || error.toString());
     }
+  }
+
+  private async runGenerateObject(messages: ModelMessage[], schema: any, modelToUse: any, modelName: string, options: any, jsonMode: boolean): Promise<any> {
+    setActivity(`🤖 Asking ${modelName} for structured output`, 'ai');
+    promptLog(`Using model: ${modelName}`);
+
+    const telemetry = this.getTelemetry(options);
+    const baseConfig: Record<string, any> = {
+      allowSystemInMessages: true,
+      ...(this.config.config || {}),
+      ...options,
+      model: modelToUse,
+      abortSignal: executionController.getAbortSignal(),
+    };
+    if (telemetry) baseConfig.experimental_telemetry = telemetry;
+
+    let requestMessages = messages;
+    if (jsonMode) {
+      baseConfig.output = 'no-schema';
+      const instruction = dedent`
+        Respond with a single valid JSON object that conforms to this JSON Schema.
+        Output only the JSON, with no markdown fences or surrounding text.
+
+        ${JSON.stringify(await asSchema(schema).jsonSchema, null, 2)}
+      `;
+      requestMessages = [...messages, { role: 'user', content: instruction }];
+    }
+    if (!jsonMode) {
+      baseConfig.schema = schema;
+    }
+
+    const config = this.mergeProviderOptions(baseConfig, options.agentName);
+
+    const retryOptions = this.getRetryOptions(options);
+    if (!jsonMode) {
+      const baseCondition = retryOptions.retryCondition;
+      retryOptions.retryCondition = (error: Error) => !isJsonSchemaUnsupportedError(error) && (!baseCondition || baseCondition(error));
+    }
+
+    promptLog(messages[messages.length - 1].content);
+    const response = await withRetry(async () => {
+      const timeout = config.timeout || 30000;
+      const cancel = { cancelled: false };
+      try {
+        return (await Promise.race([
+          generateObject({
+            messages: requestMessages,
+            ...config,
+          }),
+          rejectAfterIdle(timeout, cancel),
+        ])) as any;
+      } finally {
+        cancel.cancelled = true;
+      }
+    }, retryOptions);
+
+    clearActivity();
+
+    if (jsonMode) {
+      const validation = await asSchema(schema).validate?.(response.object);
+      if (validation && !validation.success) throw new AiError(`JSON object did not match schema: ${validation.error.message}`);
+      if (validation?.success) response.object = validation.value;
+    }
+
+    responseLog(response.object);
+
+    if (response.usage) {
+      Stats.recordTokens(options.agentName || 'unknown', modelName, {
+        input: response.usage.inputTokens ?? response.usage.promptTokens ?? 0,
+        output: response.usage.outputTokens ?? response.usage.completionTokens ?? 0,
+        total: response.usage.totalTokens ?? 0,
+        cached: extractCachedTokens(response.usage),
+      });
+    }
+
+    return response;
   }
 
   static isContextLengthError(error: any): boolean {


### PR DESCRIPTION
## Problem

Models that don't support strict **JSON Schema** structured outputs failed every structured-output call (test planning, supervisor verdicts, etc.) with:

```
This model does not support response format `json_schema`.
```

The AI SDK's default `generateObject` strategy always asks the provider for `response_format: json_schema`; providers like Groq (and many OpenRouter models, especially reasoning models) reject it for unsupported models, so the whole step failed and retried identically.

## Fix

`Provider.generateObject` now degrades gracefully:

1. **Detect** the capability error (`isJsonSchemaUnsupportedError`) and **remember** the model for the session (so later calls skip the failed first attempt).
2. **Retry in JSON object mode** — AI SDK `output: 'no-schema'` (which makes the provider send `response_format: { type: "json_object" }`), the JSON Schema injected into the prompt, and the reply validated against the original Zod schema. This matches the provider's documented "JSON Object Mode".
3. The object-mode attempt treats the deterministic `json_schema` error as **non-retryable**, so it falls back immediately instead of burning retries.

### Also in this PR

- **`[Planner]` forwards `agentName: 'planner'`** to `generateObject`. Previously the planner passed no options, so `mergeProviderOptions` dropped its per-agent config — meaning `ai.agents.planner.providerOptions` (e.g. `reasoningEffort`) was silently ignored. This matters because a reasoning model with full reasoning can spend its entire output budget thinking and never emit the plan JSON; the fix lets users disable/tune reasoning for the planner.
- **Suppress the AI SDK `allowSystemInMessages` warning** on provider calls (the codebase intentionally carries the system prompt as the first message).

## Which models this helps

The fallback is **provider-agnostic** — it triggers on the error string and works for any provider whose unsupported models still accept `json_object`. From the live OpenRouter model list (340 models): **264 already support `json_schema`** (never needed this), and **23 support `json_object` but not `json_schema`** — those now work. Examples: `qwen/qwen3-235b-a22b`, `nousresearch/hermes-4-405b`/`70b`, `z-ai/glm-4.5`, `google/gemma-4-31b-it`, `ai21/jamba-large-1.7`, `microsoft/wizardlm-2-8x22b`, `nvidia/llama-3.3-nemotron-super-49b-v1.5`. (53 models support neither and remain unsupported.)

> Reasoning models in this set also need their reasoning budgeted (via provider options like Groq `reasoningEffort` / OpenRouter `reasoning`) so they leave output room for the JSON — that's config, enabled here by the planner `agentName` fix.

## Verification

- Reproduced against Groq `qwen/qwen3.6-27b` through the real `Provider`: without the fix → `Failed to validate JSON`; with it → 4 scenarios returned.
- `bun test tests/integration/` → 62/62 pass
- `bun run format` / `bun run lint:fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)