### PR TITLE
Improve form state verification and split-pane UI awareness

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -20,7 +20,7 @@ import type { PlaywrightRecorder } from './playwright-recorder.ts';
 import type { StateManager } from './state-manager.js';
 import { isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
 import { extractCodeBlocks } from './utils/code-extractor.js';
-import { captureDomHtmlSnapshot, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
+import { captureHtmlForSnapshot, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
 import { createDebug, setStepSpanParent, tag } from './utils/logger.js';
 import { waitForPageReadiness } from './utils/page-readiness.ts';
 import { safeFilename } from './utils/strings.ts';
@@ -470,7 +470,7 @@ function errorToString(error: any): string {
 async function captureHtml(page: any, frame: any, actor: any): Promise<string> {
   for (const scope of [frame, page]) {
     if (!scope?.evaluate) continue;
-    const html = await scope.evaluate(captureDomHtmlSnapshot).catch(() => null);
+    const html = await scope.evaluate(captureHtmlForSnapshot).catch(() => null);
     if (typeof html === 'string') return html;
   }
   if (frame?.content) return frame.content();

--- a/src/action.ts
+++ b/src/action.ts
@@ -20,7 +20,7 @@ import type { PlaywrightRecorder } from './playwright-recorder.ts';
 import type { StateManager } from './state-manager.js';
 import { isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
 import { extractCodeBlocks } from './utils/code-extractor.js';
-import { htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
+import { captureDomHtmlSnapshot, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
 import { createDebug, setStepSpanParent, tag } from './utils/logger.js';
 import { waitForPageReadiness } from './utils/page-readiness.ts';
 import { safeFilename } from './utils/strings.ts';
@@ -468,6 +468,8 @@ function errorToString(error: any): string {
 }
 
 async function captureHtml(page: any, frame: any, actor: any): Promise<string> {
+  if (frame?.evaluate) return frame.evaluate(captureDomHtmlSnapshot);
+  if (page?.evaluate) return page.evaluate(captureDomHtmlSnapshot);
   if (frame?.content) return frame.content();
   if (page?.content) return page.content();
   if (actor?.grabSource) return actor.grabSource();

--- a/src/action.ts
+++ b/src/action.ts
@@ -468,8 +468,11 @@ function errorToString(error: any): string {
 }
 
 async function captureHtml(page: any, frame: any, actor: any): Promise<string> {
-  if (frame?.evaluate) return frame.evaluate(captureDomHtmlSnapshot);
-  if (page?.evaluate) return page.evaluate(captureDomHtmlSnapshot);
+  for (const scope of [frame, page]) {
+    if (!scope?.evaluate) continue;
+    const html = await scope.evaluate(captureDomHtmlSnapshot).catch(() => null);
+    if (typeof html === 'string') return html;
+  }
   if (frame?.content) return frame.content();
   if (page?.content) return page.content();
   if (actor?.grabSource) return actor.grabSource();

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -428,7 +428,10 @@ export class Researcher extends ResearcherBase implements Agent {
       - Research all menus and navigational areas.
       - Ignore decorative sidebars, footer-only links, and external links.
       - Detect layout patterns: list/detail split, 2-pane, or 3-pane layouts.
-      - Every element with an eidx attribute MUST appear in the UI map — describe icon-only buttons by their visual role.
+      - In split-pane layouts, keep global toolbar, list pane, and detail pane as separate sections. Do not copy toolbar/list elements into the detail section unless they are physically inside that detail container.
+      - If the URL or page state opens an entity detail panel, describe that panel as the active detail context and include its close/back/pin controls when present.
+      - If an element has data-explorbot-hit="covered" or "offscreen", do not present it as directly actionable. Prefer the overlay, drawer, dialog, or focused section covering it, and mention what must be dismissed or revealed first.
+      - Every element with an eidx attribute MUST appear in exactly one matching UI map section — describe icon-only buttons by their visual role.
       - Every UI map row needs a CSS selector; ARIA may be "-" for icon-only buttons, CSS must never be "-".
       - ARIA locator JSON uses keys "role" and "text" (NOT "name").
       - Mark elements with likely hover interactions (title, aria-describedby, menu items with submenus) as "(hover)".
@@ -445,6 +448,7 @@ export class Researcher extends ResearcherBase implements Agent {
         .join('\n')}
 
       - Sections can overlap; prefer more detailed sections over broader ones.
+      - Section tables must list only elements physically inside the declared container. If a control belongs to a global toolbar, list it only in the toolbar section.
       - Never name a section "Focus" or "Focused" — use what it contains (Detail, Modal, Form, Content, List).
       - Omit sections that are not present or not relevant.
       - Each section needs a container CSS locator; UI map CSS locators are relative to it.

--- a/src/ai/researcher/sections.ts
+++ b/src/ai/researcher/sections.ts
@@ -105,9 +105,13 @@ export function WithSections<T extends Constructor>(Base: T) {
         </section_format>
 
         <rules>
-        - Every element with eidx MUST appear in the table.
+        - List only elements physically inside this section's declared container.
+        - Do not copy global toolbar, navigation, list, or detail elements into this section unless they are descendants of this section container.
+        - Every element with eidx inside this section's container MUST appear in the table.
         - Every row needs CSS; ARIA may be "-" for icon-only buttons.
         - ARIA locator JSON uses keys "role" and "text" (NOT "name").
+        - Elements marked data-explorbot-hit="covered" or "offscreen" are not directly actionable; describe the covering or focused UI first.
+        - In split-pane pages, entity detail panels are active detail context; include close/back/pin controls in the detail panel section when present.
         </rules>
 
         ${generalLocatorRuleText}

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -50,6 +50,7 @@ export const locatorRule = dedent`
   - If no accessible name exists, mark ARIA as "-" and use CSS/XPath:
     * CSS: use partial href a[href*="settings"] or SVG icon class a:has(svg.md-icon-cog)
     * XPath: use contains(@href,"settings") or SVG class //a[.//svg[contains(@class,"md-icon-cog")]]
+  - In inline create/edit rows, confirmation can be an icon-only control near the edited field instead of a text Save button. Anchor the locator to the same row/form as the field and target the adjacent confirm icon/control.
   - NEVER use empty text: { "role": "button", "text": "" } is INVALID and useless
 
   <good_aria_locator_example>
@@ -307,6 +308,7 @@ export const actionRule = dedent`
   Use context parameter (second argument) to narrow click area when:
   - The same text/button appears multiple times on page
   - You need to click inside a specific form, modal, or section
+  - You need an icon-only confirm/save control next to a field in an inline create/edit row
   Context should be a CSS selector pointing to a unique container.
 
   <example>
@@ -319,6 +321,7 @@ export const actionRule = dedent`
   </example>
 
   Prefer text/ARIA locators with context over complex CSS/XPath selectors.
+  For inline create/edit flows, after filling a field verify it contains the value, then confirm using the nearest explicit button/link, an adjacent icon-only confirm control in the same row/form, or Enter if the field remains focused.
   If locator doesn't work, try CSS or XPath locators.
   If nothing works, use I.clickXY(x, y) as last resort.
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1021,8 +1021,8 @@ export function createAgentTools({
 
         const visibilityNote = visible ? 'Element IS visible in browser — Tester can use this XPath as locator.' : 'Element exists in DOM but is NOT visible. May need scrolling, a click to reveal, or is hidden.';
 
-        const hit = liveElement?.attrs['data-explorbot-hit'] || null;
-        const coveredBy = liveElement?.attrs['data-explorbot-covered-by'] || null;
+        const hit = liveElement?.ourAttr('hit') || null;
+        const coveredBy = liveElement?.ourAttr('coveredBy') || null;
         let resolvedVisibilityNote = visibilityNote;
         if (hit === 'covered') {
           resolvedVisibilityNote = `Element exists in DOM and is visible, but is covered by ${coveredBy || 'another UI layer'}. Dismiss or move the covering UI before interacting with it.`;

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -41,6 +41,7 @@ export function createCodeceptJSTools(explorer: Explorer, task: Task) {
         CRITICAL: All commands MUST target the SAME element using different locators.
         This is a FALLBACK list, NOT a sequence of different clicks.
         If you need to click multiple different elements, make SEPARATE click() calls.
+        Inline create/edit UIs may use icon-only confirm controls near the edited field instead of text buttons. Target the nearest actionable icon/control in the same row or form.
       `,
       inputSchema: z.object({
         commands: z.array(z.string()).describe(dedent`
@@ -471,6 +472,14 @@ export function createCodeceptJSTools(explorer: Explorer, task: Task) {
 
           if (toolResult?.pageDiff?.ariaChanges || toolResult?.pageDiff?.urlChanged) {
             activeNote.screenshot = await action.saveScreenshot();
+          }
+          if (!hasObservablePageChange(toolResult)) {
+            activeNote.commit(TestResult.FAILED);
+            return failedToolResult('form', 'Form command executed, but no observable page or form-state change was captured.', {
+              ...toolResult,
+              code: codeBlock,
+              suggestion: 'Treat the field/form action as not completed. Re-locate the editable control, check whether another UI layer is active, then retry and verify the field value before submitting.',
+            });
           }
           activeNote.commit(TestResult.PASSED);
           return successToolResult(
@@ -1006,15 +1015,28 @@ export function createAgentTools({
 
         const action = explorer.createAction();
         const visible = await action.attempt(`I.seeElement(${JSON.stringify(xpath)})`, 'xpathCheck visibility', false);
+        const liveElement = await WebElement.fromPlaywrightLocator(explorer.playwrightHelper.page.locator(`xpath=${xpath}`));
 
         const matchesSummary = result.elements.map((el, i) => `${i + 1}. <${el.tag} ${el.keyAttrs}> text="${el.text}" html: ${el.outerHTML}`).join('\n');
 
         const visibilityNote = visible ? 'Element IS visible in browser — Tester can use this XPath as locator.' : 'Element exists in DOM but is NOT visible. May need scrolling, a click to reveal, or is hidden.';
 
+        const hit = liveElement?.attrs['data-explorbot-hit'] || null;
+        const coveredBy = liveElement?.attrs['data-explorbot-covered-by'] || null;
+        let resolvedVisibilityNote = visibilityNote;
+        if (hit === 'covered') {
+          resolvedVisibilityNote = `Element exists in DOM and is visible, but is covered by ${coveredBy || 'another UI layer'}. Dismiss or move the covering UI before interacting with it.`;
+        }
+        if (hit === 'offscreen') {
+          resolvedVisibilityNote = 'Element exists in DOM but its interaction point is outside the viewport. Scroll or reveal it before interacting.';
+        }
+
         return successToolResult('xpathCheck', {
           totalFound: result.totalFound,
           matches: matchesSummary,
-          visibilityNote,
+          visibilityNote: resolvedVisibilityNote,
+          hit,
+          coveredBy,
           xpath,
         });
       },
@@ -1162,6 +1184,13 @@ function successToolResult(action: string, data?: Record<string, any>, source?: 
     result.suggestion = data.suggestion ? `${data.suggestion} ${suggestion}` : suggestion;
   }
   return result;
+}
+
+function hasObservablePageChange(data?: Record<string, any>): boolean {
+  if (!data?.pageDiff) return false;
+  if (data.pageDiff.urlChanged === true) return true;
+  if (data.pageDiff.ariaChanges) return true;
+  return Array.isArray(data.pageDiff.htmlParts) && data.pageDiff.htmlParts.length > 0;
 }
 
 async function failedToolResult(action: string, message: string, data?: Record<string, any>, error?: Error | null) {

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -85,8 +85,10 @@ const HIDDEN_CLASSES = new Set(['hidden', 'invisible', 'd-none', 'hide', 'dn', '
 
 export const EXPLORBOT_ATTRS = {
   area: 'data-explorbot-area',
+  coveredBy: 'data-explorbot-covered-by',
   context: 'data-explorbot-context',
   eidx: 'data-explorbot-eidx',
+  hit: 'data-explorbot-hit',
   variant: 'data-explorbot-variant',
 } as const;
 
@@ -169,14 +171,49 @@ export type ComponentScopeExtractionConfig = {
   limits: typeof HTML_EXTRACTION_LIMITS;
 };
 
+export function captureDomHtmlSnapshot(): string {
+  const clone = document.documentElement.cloneNode(true) as HTMLElement;
+  const liveControls = Array.from(document.querySelectorAll('input, textarea, select')) as Array<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
+  const clonedControls = Array.from(clone.querySelectorAll('input, textarea, select')) as HTMLElement[];
+
+  for (let i = 0; i < liveControls.length; i++) {
+    const source = liveControls[i];
+    const target = clonedControls[i];
+    if (!target) continue;
+
+    if (source instanceof HTMLInputElement || source instanceof HTMLTextAreaElement) {
+      target.setAttribute('data-explorbot-value', source.value);
+    }
+
+    if (source instanceof HTMLInputElement && (source.type === 'checkbox' || source.type === 'radio')) {
+      let checked = 'false';
+      if (source.checked) checked = 'true';
+      target.setAttribute('data-explorbot-checked', checked);
+    }
+
+    if (source instanceof HTMLSelectElement) {
+      target.setAttribute(
+        'data-explorbot-value',
+        Array.from(source.selectedOptions)
+          .map((option) => option.value)
+          .join(',')
+      );
+    }
+  }
+
+  return clone.outerHTML;
+}
+
 export function extractElementData(el: Element, config?: ElementExtractionConfig) {
   const cfg =
     config ||
     ({
       attrs: {
         area: 'data-explorbot-area',
+        coveredBy: 'data-explorbot-covered-by',
         context: 'data-explorbot-context',
         eidx: 'data-explorbot-eidx',
+        hit: 'data-explorbot-hit',
         variant: 'data-explorbot-variant',
       },
       codeEditorMarkers: ['monaco', 'codemirror', 'ace', 'ace_editor', 'code'],
@@ -244,6 +281,45 @@ export function extractElementData(el: Element, config?: ElementExtractionConfig
     if (tagName === 'a' && target.getAttribute('href')) tokens.add('navigates');
 
     return Array.from(tokens).slice(0, 8);
+  }
+
+  function describeTopElement(target: Element): string {
+    const parts = [target.tagName.toLowerCase()];
+    const role = target.getAttribute('role');
+    const ariaLabel = target.getAttribute('aria-label');
+    const id = target.getAttribute('id');
+    const className = (target.getAttribute('class') || '').split(/\s+/).filter(Boolean).slice(0, 3).join('.');
+
+    if (id) parts.push(`#${id.slice(0, 40)}`);
+    if (className) parts.push(`.${className.slice(0, 80)}`);
+    if (role) parts.push(`[role="${role.slice(0, 40)}"]`);
+    if (ariaLabel) parts.push(`[aria-label="${ariaLabel.slice(0, 80)}"]`);
+
+    return parts.join('');
+  }
+
+  function inspectHitTarget(target: Element, rect: DOMRect): { hit: string; coveredBy?: string } {
+    const viewportPoints = [
+      { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 },
+      { x: rect.left + Math.min(rect.width - 1, Math.max(1, rect.width * 0.25)), y: rect.top + Math.min(rect.height - 1, Math.max(1, rect.height * 0.25)) },
+      { x: rect.left + Math.min(rect.width - 1, Math.max(1, rect.width * 0.75)), y: rect.top + Math.min(rect.height - 1, Math.max(1, rect.height * 0.75)) },
+    ].filter((point) => point.x >= 0 && point.y >= 0 && point.x <= window.innerWidth && point.y <= window.innerHeight);
+
+    if (viewportPoints.length === 0) {
+      return { hit: 'offscreen' };
+    }
+
+    for (const point of viewportPoints) {
+      const top = document.elementFromPoint(point.x, point.y);
+      if (!top) continue;
+      if (top === target || target.contains(top)) {
+        return { hit: 'target' };
+      }
+    }
+
+    const centerPoint = viewportPoints[0];
+    const top = document.elementFromPoint(centerPoint.x, centerPoint.y);
+    return { hit: 'covered', coveredBy: top ? describeTopElement(top) : undefined };
   }
 
   function isEmbeddedCodeEditorFrame(target: Element): boolean {
@@ -354,6 +430,9 @@ export function extractElementData(el: Element, config?: ElementExtractionConfig
   allAttrs[cfg.attrs.area] = areaHints.join('|');
   allAttrs[cfg.attrs.context] = findContextLabel(el);
   allAttrs[cfg.attrs.variant] = collectVariantHints(el).join('|');
+  const hitTarget = inspectHitTarget(el, rect);
+  allAttrs[cfg.attrs.hit] = hitTarget.hit;
+  if (hitTarget.coveredBy) allAttrs[cfg.attrs.coveredBy] = hitTarget.coveredBy;
 
   return {
     tag: el.tagName.toLowerCase(),

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -171,7 +171,7 @@ export type ComponentScopeExtractionConfig = {
   limits: typeof HTML_EXTRACTION_LIMITS;
 };
 
-export function captureDomHtmlSnapshot(): string {
+export function captureHtmlForSnapshot(): string {
   const clone = document.documentElement.cloneNode(true) as HTMLElement;
   const liveControls = Array.from(document.querySelectorAll('input, textarea, select')) as Array<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>;
   const clonedControls = Array.from(clone.querySelectorAll('input, textarea, select')) as HTMLElement[];
@@ -283,7 +283,7 @@ export function extractElementData(el: Element, config?: ElementExtractionConfig
     return Array.from(tokens).slice(0, 8);
   }
 
-  function describeTopElement(target: Element): string {
+  function describeOverlappingElement(target: Element): string {
     const parts = [target.tagName.toLowerCase()];
     const role = target.getAttribute('role');
     const ariaLabel = target.getAttribute('aria-label');
@@ -319,7 +319,7 @@ export function extractElementData(el: Element, config?: ElementExtractionConfig
 
     const centerPoint = viewportPoints[0];
     const top = document.elementFromPoint(centerPoint.x, centerPoint.y);
-    return { hit: 'covered', coveredBy: top ? describeTopElement(top) : undefined };
+    return { hit: 'covered', coveredBy: top ? describeOverlappingElement(top) : undefined };
   }
 
   function isEmbeddedCodeEditorFrame(target: Element): boolean {

--- a/src/utils/web-element.ts
+++ b/src/utils/web-element.ts
@@ -47,6 +47,10 @@ export class WebElement {
     return this.attrs[EXPLORBOT_ATTRS.eidx] || this.attrs.eidx || null;
   }
 
+  ourAttr(name: keyof typeof EXPLORBOT_ATTRS): string | undefined {
+    return this.attrs[EXPLORBOT_ATTRS[name]];
+  }
+
   get isNavigationLink(): boolean {
     if (this.tag !== 'a') return false;
     const href = this.attrs.href || '';

--- a/tests/unit/html.test.ts
+++ b/tests/unit/html.test.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
-import { extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, isBodyEmpty } from '../../src/utils/html.ts';
+import { captureDomHtmlSnapshot, extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, isBodyEmpty } from '../../src/utils/html.ts';
 
 // Load test HTML files
 const githubHtml = readFileSync(join(process.cwd(), 'test-data/github.html'), 'utf8');
@@ -13,6 +14,49 @@ const testomatHtml = readFileSync(join(process.cwd(), 'test-data/testomat.html')
 const checkoutHtml = readFileSync(join(process.cwd(), 'test-data/checkout.html'), 'utf8');
 
 describe('HTML Parsing Library', () => {
+  describe('captureDomHtmlSnapshot', () => {
+    it('serializes live form control state', () => {
+      const dom = new JSDOM(`
+        <html>
+          <body>
+            <input aria-label="Suite name" />
+            <textarea aria-label="Description"></textarea>
+            <input type="checkbox" aria-label="Enabled" />
+          </body>
+        </html>
+      `);
+      const previousWindow = globalThis.window;
+      const previousDocument = globalThis.document;
+      const previousInput = globalThis.HTMLInputElement;
+      const previousTextArea = globalThis.HTMLTextAreaElement;
+      const previousSelect = globalThis.HTMLSelectElement;
+      (globalThis as any).window = dom.window;
+      (globalThis as any).document = dom.window.document;
+      (globalThis as any).HTMLInputElement = dom.window.HTMLInputElement;
+      (globalThis as any).HTMLTextAreaElement = dom.window.HTMLTextAreaElement;
+      (globalThis as any).HTMLSelectElement = dom.window.HTMLSelectElement;
+
+      const input = dom.window.document.querySelector('input[aria-label="Suite name"]') as HTMLInputElement;
+      const textarea = dom.window.document.querySelector('textarea') as HTMLTextAreaElement;
+      const checkbox = dom.window.document.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      input.value = 'Managerial Objective';
+      textarea.value = 'Runtime-only text';
+      checkbox.checked = true;
+
+      const snapshot = captureDomHtmlSnapshot();
+
+      expect(snapshot).toContain('data-explorbot-value="Managerial Objective"');
+      expect(snapshot).toContain('data-explorbot-value="Runtime-only text"');
+      expect(snapshot).toContain('data-explorbot-checked="true"');
+
+      (globalThis as any).window = previousWindow;
+      (globalThis as any).document = previousDocument;
+      (globalThis as any).HTMLInputElement = previousInput;
+      (globalThis as any).HTMLTextAreaElement = previousTextArea;
+      (globalThis as any).HTMLSelectElement = previousSelect;
+    });
+  });
+
   describe('htmlMinimalUISnapshot', () => {
     // Ported from CodeceptJS tests
     it('should cut out all non-interactive elements from GitHub HTML', async () => {

--- a/tests/unit/html.test.ts
+++ b/tests/unit/html.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
-import { captureDomHtmlSnapshot, extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, isBodyEmpty } from '../../src/utils/html.ts';
+import { captureHtmlForSnapshot, extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, isBodyEmpty } from '../../src/utils/html.ts';
 
 // Load test HTML files
 const githubHtml = readFileSync(join(process.cwd(), 'test-data/github.html'), 'utf8');
@@ -14,8 +14,8 @@ const testomatHtml = readFileSync(join(process.cwd(), 'test-data/testomat.html')
 const checkoutHtml = readFileSync(join(process.cwd(), 'test-data/checkout.html'), 'utf8');
 
 describe('HTML Parsing Library', () => {
-  describe('captureDomHtmlSnapshot', () => {
-    it('serializes live form control state', () => {
+  describe('captureHtmlForSnapshot', () => {
+    it('feeds live form control state into the combined snapshot pipeline', () => {
       const dom = new JSDOM(`
         <html>
           <body>
@@ -43,11 +43,16 @@ describe('HTML Parsing Library', () => {
       textarea.value = 'Runtime-only text';
       checkbox.checked = true;
 
-      const snapshot = captureDomHtmlSnapshot();
+      const snapshot = captureHtmlForSnapshot();
 
       expect(snapshot).toContain('data-explorbot-value="Managerial Objective"');
       expect(snapshot).toContain('data-explorbot-value="Runtime-only text"');
       expect(snapshot).toContain('data-explorbot-checked="true"');
+
+      const combined = htmlCombinedSnapshot(snapshot);
+      expect(combined).toContain('value="Managerial Objective"');
+      expect(combined).toContain('value="Runtime-only text"');
+      expect(combined).toContain('checked="true"');
 
       (globalThis as any).window = previousWindow;
       (globalThis as any).document = previousDocument;

--- a/tests/unit/web-element.test.ts
+++ b/tests/unit/web-element.test.ts
@@ -21,6 +21,7 @@ describe('extractElementData', () => {
     expect(data?.allAttrs['data-explorbot-context']).toBe('Toggle - off');
     expect(data?.allAttrs['data-explorbot-area']).toContain('main');
     expect(data?.allAttrs['data-explorbot-area']).toContain('role:switch');
+    expect(data?.allAttrs['data-explorbot-hit']).toBe('target');
     expect(data?.allAttrs['data-explorbot-variant']).toContain('primary-btn');
     expect(data?.allAttrs['data-explorbot-variant']).toContain('btn-md');
     expect(data?.outerHTML).toContain('aria-checked="false"');
@@ -48,11 +49,35 @@ describe('extractElementData', () => {
     expect(data?.allAttrs['data-explorbot-variant']).toContain('code-editor');
     expect(data?.allAttrs['data-explorbot-frame-source-index']).toBe('1');
   });
+
+  it('marks visible elements covered by another UI layer', () => {
+    const dom = new JSDOM(`
+      <main>
+        <input aria-label="Suite name" />
+        <aside role="dialog" aria-label="Navigation drawer"></aside>
+      </main>
+    `);
+    useDom(dom);
+    const input = dom.window.document.querySelector('input')!;
+    const aside = dom.window.document.querySelector('aside')!;
+    mockVisibleBox(input);
+    mockVisibleBox(aside);
+    dom.window.document.elementFromPoint = () => aside;
+
+    const data = extractElementData(input);
+
+    expect(data?.allAttrs['data-explorbot-hit']).toBe('covered');
+    expect(data?.allAttrs['data-explorbot-covered-by']).toContain('aside');
+    expect(data?.allAttrs['data-explorbot-covered-by']).toContain('role="dialog"');
+  });
 });
 
 function useDom(dom: JSDOM) {
   (globalThis as any).window = dom.window;
   (globalThis as any).document = dom.window.document;
+  Object.defineProperty(dom.window, 'innerWidth', { configurable: true, value: 1280 });
+  Object.defineProperty(dom.window, 'innerHeight', { configurable: true, value: 720 });
+  dom.window.document.elementFromPoint = () => null;
 }
 
 function mockVisibleBox(element: Element) {
@@ -68,4 +93,10 @@ function mockVisibleBox(element: Element) {
     toJSON: () => ({}),
   });
   (element as HTMLElement).style.position = 'fixed';
+  const originalElementFromPoint = element.ownerDocument.elementFromPoint;
+  element.ownerDocument.elementFromPoint = (x: number, y: number) => {
+    const rect = element.getBoundingClientRect();
+    if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) return element;
+    return originalElementFromPoint.call(element.ownerDocument, x, y);
+  };
 }

--- a/tests/unit/web-element.test.ts
+++ b/tests/unit/web-element.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { JSDOM } from 'jsdom';
-import { extractElementData } from '../../src/utils/web-element.ts';
+import { WebElement, extractElementData } from '../../src/utils/web-element.ts';
 
 describe('extractElementData', () => {
   it('adds context, area, and variant hints for component drilling', () => {
@@ -69,6 +69,26 @@ describe('extractElementData', () => {
     expect(data?.allAttrs['data-explorbot-hit']).toBe('covered');
     expect(data?.allAttrs['data-explorbot-covered-by']).toContain('aside');
     expect(data?.allAttrs['data-explorbot-covered-by']).toContain('role="dialog"');
+  });
+});
+
+describe('WebElement', () => {
+  it('reads internal explorbot attributes by logical name', () => {
+    const element = new WebElement({
+      tag: 'input',
+      xpath: '',
+      clickXPath: '',
+      attrs: {
+        'data-explorbot-hit': 'covered',
+        'data-explorbot-covered-by': 'aside[role="dialog"]',
+      },
+      text: '',
+      x: 10,
+      y: 20,
+    });
+
+    expect(element.ourAttr('hit')).toBe('covered');
+    expect(element.ourAttr('coveredBy')).toBe('aside[role="dialog"]');
   });
 });
 


### PR DESCRIPTION
## Summary 

  - Serialize live form control state into HTML snapshots so filled inputs can be verified from page diffs.
  - Mark elements as covered/offscreen/target using browser hit-testing metadata.
  - Teach researcher output to treat split-pane detail panels as active UI context instead of mixing them with list/toolbar sections.                                        
  - Improve inline create/edit guidance for icon-only confirm controls near edited fields.