### PR TITLE
Reuse successful test experience during execution

### DIFF
--- a/src/ai/historian.ts
+++ b/src/ai/historian.ts
@@ -13,7 +13,7 @@ import { type PlaywrightMethods, WithPlaywright } from './historian/playwright.t
 import { type ScreencastMethods, WithScreencast } from './historian/screencast.ts';
 import type { Provider } from './provider.ts';
 
-export { isNonReusableCode } from './historian/utils.ts';
+export { isNonReusableCode } from '../utils/step-analyzer.ts';
 
 const HistorianBase = WithScreencast(WithPlaywright(WithCodeceptJS(WithExperience(Object as unknown as new (...args: any[]) => object))));
 

--- a/src/ai/historian/codeceptjs.ts
+++ b/src/ai/historian/codeceptjs.ts
@@ -7,10 +7,11 @@ import type { Plan } from '../../test-plan.ts';
 import { tag } from '../../utils/logger.ts';
 import { relativeToCwd } from '../../utils/next-steps.ts';
 import { safeFilename } from '../../utils/strings.ts';
+import { CODECEPT_TOOLS, isNonReusableCode, stripComments } from '../../utils/step-analyzer.ts';
 import type { Conversation } from '../conversation.ts';
-import { ASSERTION_TOOLS, CODECEPT_TOOLS } from '../tools.ts';
+import { ASSERTION_TOOLS } from '../tools.ts';
 import type { Constructor } from './mixin.ts';
-import { escapeString, getExecutionLabel, isNonReusableCode, stripComments } from './utils.ts';
+import { escapeString, getExecutionLabel } from './utils.ts';
 
 export interface CodeceptJSMethods {
   toCode(conversation: Conversation, scenario: string): string;

--- a/src/ai/historian/experience.ts
+++ b/src/ai/historian/experience.ts
@@ -4,14 +4,14 @@ import { ActionResult } from '../../action-result.ts';
 import { ExperienceTracker, type SessionStep } from '../../experience-tracker.ts';
 import type { Reporter, ReporterStep } from '../../reporter.ts';
 import type { StateManager } from '../../state-manager.ts';
-import { type StepData, type Task, Test } from '../../test-plan.ts';
+import { type Task, Test } from '../../test-plan.ts';
 import { tag } from '../../utils/logger.ts';
+import { isCodeceptToolName, isNonReusableCode, mergeUniqueStepsByCode, stripComments, toReusableSessionStep } from '../../utils/step-analyzer.ts';
 import { extractStatePath } from '../../utils/url-matcher.ts';
 import type { Conversation, ToolExecution } from '../conversation.ts';
 import type { Provider } from '../provider.ts';
-import { CODECEPT_TOOLS, getCodeceptToolNameFromCode } from '../tools.ts';
 import { type Constructor, debugLog } from './mixin.ts';
-import { getExecutionLabel, isNonReusableCode, stripComments } from './utils.ts';
+import { getExecutionLabel } from './utils.ts';
 
 export interface ExperienceMethods {
   saveSession(task: Task, initialState: ActionResult, conversation: Conversation): Promise<void>;
@@ -40,7 +40,7 @@ export function WithExperience<T extends Constructor>(Base: T) {
 
       const conversationSteps = await this.extractSteps(toolExecutions);
       const taskSteps = this.extractPassedCodeceptSteps(task);
-      const steps = this.mergeUniqueStepsByCode(conversationSteps, taskSteps);
+      const steps = mergeUniqueStepsByCode(conversationSteps, taskSteps);
 
       const skipExperience = result === 'failed' || (task instanceof Test && (task.hasFailed || task.isSkipped));
       if (!skipExperience) {
@@ -82,7 +82,7 @@ export function WithExperience<T extends Constructor>(Base: T) {
       const stepsWithDiffs: Array<{ step: SessionStep; ariaDiff: string | null }> = [];
 
       for (const exec of toolExecutions) {
-        if (!CODECEPT_TOOLS.includes(exec.toolName as any)) continue;
+        if (!isCodeceptToolName(exec.toolName)) continue;
         if (!exec.output?.code) continue;
         if (!exec.wasSuccessful) continue;
         if (isNonReusableCode(exec.output.code)) continue;
@@ -109,38 +109,10 @@ export function WithExperience<T extends Constructor>(Base: T) {
     private extractPassedCodeceptSteps(task: Task): SessionStep[] {
       const steps: SessionStep[] = [];
       for (const step of Object.values(task.steps)) {
-        const sessionStep = this.toReusableSessionStep(step);
+        const sessionStep = toReusableSessionStep(step);
         if (sessionStep) steps.push(sessionStep);
       }
       return steps;
-    }
-
-    private toReusableSessionStep(step: StepData): SessionStep | null {
-      if (step.status !== 'passed') return null;
-      const code = stripComments(step.text);
-      if (!code || isNonReusableCode(code)) return null;
-      const toolName = getCodeceptToolNameFromCode(code);
-      if (!toolName) return null;
-
-      return {
-        message: step.text,
-        status: 'passed',
-        tool: toolName,
-        code,
-      };
-    }
-
-    private mergeUniqueStepsByCode(primary: SessionStep[], secondary: SessionStep[]): SessionStep[] {
-      const merged: SessionStep[] = [];
-      const seen = new Set<string>();
-      for (const step of [...primary, ...secondary]) {
-        const identity = stripComments(step.code || '').trim();
-        if (!identity) continue;
-        if (seen.has(identity)) continue;
-        seen.add(identity);
-        merged.push(step);
-      }
-      return merged;
     }
 
     private async curateFlow(steps: SessionStep[], task: Task, initialState: ActionResult): Promise<string> {
@@ -287,7 +259,7 @@ export function WithExperience<T extends Constructor>(Base: T) {
       const candidates: Array<{ failed: ToolExecution[]; success: ToolExecution }> = [];
 
       for (const exec of toolExecutions) {
-        if (!CODECEPT_TOOLS.includes(exec.toolName as any)) continue;
+        if (!isCodeceptToolName(exec.toolName)) continue;
         if (!exec.output?.code) continue;
 
         if (!exec.wasSuccessful) {

--- a/src/ai/historian/experience.ts
+++ b/src/ai/historian/experience.ts
@@ -4,12 +4,12 @@ import { ActionResult } from '../../action-result.ts';
 import { ExperienceTracker, type SessionStep } from '../../experience-tracker.ts';
 import type { Reporter, ReporterStep } from '../../reporter.ts';
 import type { StateManager } from '../../state-manager.ts';
-import { type Task, Test } from '../../test-plan.ts';
+import { type StepData, type Task, Test } from '../../test-plan.ts';
 import { tag } from '../../utils/logger.ts';
 import { extractStatePath } from '../../utils/url-matcher.ts';
 import type { Conversation, ToolExecution } from '../conversation.ts';
 import type { Provider } from '../provider.ts';
-import { CODECEPT_TOOLS } from '../tools.ts';
+import { CODECEPT_TOOLS, getCodeceptToolNameFromCode } from '../tools.ts';
 import { type Constructor, debugLog } from './mixin.ts';
 import { getExecutionLabel, isNonReusableCode, stripComments } from './utils.ts';
 
@@ -38,12 +38,18 @@ export function WithExperience<T extends Constructor>(Base: T) {
         task.generatedCode = this.isPlaywrightFramework() ? await this.toPlaywrightCode(conversation, task.description) : this.toCode(conversation, task.description);
       }
 
-      const steps = await this.extractSteps(toolExecutions);
+      const conversationSteps = await this.extractSteps(toolExecutions);
+      const taskSteps = this.extractPassedCodeceptSteps(task);
+      const steps = this.mergeUniqueStepsByCode(conversationSteps, taskSteps);
 
       const skipExperience = result === 'failed' || (task instanceof Test && (task.hasFailed || task.isSkipped));
       if (!skipExperience) {
+        const hasExistingFlow = this.hasRelevantFlowExperience(initialState);
         await this.detectRetryPatterns(toolExecutions, initialState);
-        const body = await this.curateFlow(steps, task, initialState);
+        let body = await this.curateFlow(steps, task, initialState);
+        if (!body.trim() && !hasExistingFlow) {
+          body = this.renderFlowFromSuccessfulSteps(steps, task);
+        }
         if (body.trim()) {
           const relatedUrls = this.extractVisitedUrls(toolExecutions, initialState.url || '');
           this.experienceTracker.writeFlow(initialState, body, relatedUrls);
@@ -94,6 +100,47 @@ export function WithExperience<T extends Constructor>(Base: T) {
       await this.analyzeDiscoveries(stepsWithDiffs);
 
       return stepsWithDiffs.map((s) => s.step);
+    }
+
+    private hasRelevantFlowExperience(state: ActionResult): boolean {
+      return this.experienceTracker.getRelevantExperience(state).some((experience) => experience.content.includes('## FLOW:'));
+    }
+
+    private extractPassedCodeceptSteps(task: Task): SessionStep[] {
+      const steps: SessionStep[] = [];
+      for (const step of Object.values(task.steps)) {
+        const sessionStep = this.toReusableSessionStep(step);
+        if (sessionStep) steps.push(sessionStep);
+      }
+      return steps;
+    }
+
+    private toReusableSessionStep(step: StepData): SessionStep | null {
+      if (step.status !== 'passed') return null;
+      const code = stripComments(step.text);
+      if (!code || isNonReusableCode(code)) return null;
+      const toolName = getCodeceptToolNameFromCode(code);
+      if (!toolName) return null;
+
+      return {
+        message: step.text,
+        status: 'passed',
+        tool: toolName,
+        code,
+      };
+    }
+
+    private mergeUniqueStepsByCode(primary: SessionStep[], secondary: SessionStep[]): SessionStep[] {
+      const merged: SessionStep[] = [];
+      const seen = new Set<string>();
+      for (const step of [...primary, ...secondary]) {
+        const identity = stripComments(step.code || '').trim();
+        if (!identity) continue;
+        if (seen.has(identity)) continue;
+        seen.add(identity);
+        merged.push(step);
+      }
+      return merged;
     }
 
     private async curateFlow(steps: SessionStep[], task: Task, initialState: ActionResult): Promise<string> {
@@ -205,6 +252,32 @@ export function WithExperience<T extends Constructor>(Base: T) {
         debugLog('curateFlow failed, skipping flow write: %s', error.message);
         return '';
       }
+    }
+
+    private renderFlowFromSuccessfulSteps(steps: SessionStep[], task: Task): string {
+      if (steps.length === 0) return '';
+
+      const title = task.description.charAt(0).toLowerCase() + task.description.slice(1);
+      const blocks = steps
+        .filter((step) => step.code)
+        .map((step) => {
+          const lines = [`* ${step.message}`];
+          lines.push('');
+          lines.push('```js');
+          lines.push(stripComments(step.code || ''));
+          lines.push('```');
+          if (step.discovery) {
+            lines.push('');
+            for (const discovery of step.discovery.split('\n').filter((line) => line.trim())) {
+              lines.push(`> ${discovery.trim()}`);
+            }
+          }
+          return lines.join('\n');
+        });
+
+      if (blocks.length === 0) return '';
+
+      return `## FLOW: ${title}\n\n${blocks.join('\n\n')}\n\n---\n`;
     }
 
     private async detectRetryPatterns(toolExecutions: ToolExecution[], initialState: ActionResult): Promise<void> {

--- a/src/ai/historian/playwright.ts
+++ b/src/ai/historian/playwright.ts
@@ -8,8 +8,9 @@ import type { Plan } from '../../test-plan.ts';
 import { tag } from '../../utils/logger.ts';
 import { relativeToCwd } from '../../utils/next-steps.ts';
 import { safeFilename } from '../../utils/strings.ts';
+import { CODECEPT_TOOLS } from '../../utils/step-analyzer.ts';
 import type { Conversation } from '../conversation.ts';
-import { ASSERTION_TOOLS, CODECEPT_TOOLS } from '../tools.ts';
+import { ASSERTION_TOOLS } from '../tools.ts';
 import type { Constructor } from './mixin.ts';
 import { escapeString, getExecutionLabel } from './utils.ts';
 

--- a/src/ai/historian/utils.ts
+++ b/src/ai/historian/utils.ts
@@ -1,28 +1,8 @@
-import { isDynamicId } from '../../utils/xpath.ts';
 import type { ToolExecution } from '../conversation.ts';
-
-export function isNonReusableCode(code: string): boolean {
-  if (/\bI\.clickXY\s*\(/.test(code)) return true;
-
-  for (const m of code.matchAll(/#([A-Za-z_][\w-]*)/g)) {
-    if (isDynamicId(m[1])) return true;
-  }
-
-  return false;
-}
+export { isNonReusableCode, stripComments } from '../../utils/step-analyzer.ts';
 
 export function escapeString(str: string): string {
   return str.replace(/'/g, "\\'").replace(/\n/g, ' ');
-}
-
-export function stripComments(code: string): string {
-  return code
-    .split('\n')
-    .filter((line) => {
-      const trimmed = line.trim();
-      return trimmed && !trimmed.startsWith('//') && !trimmed.startsWith('/*') && !trimmed.startsWith('*');
-    })
-    .join('\n');
 }
 
 export function getExecutionLabel(exec: ToolExecution, fallback?: string): string {

--- a/src/ai/quartermaster.ts
+++ b/src/ai/quartermaster.ts
@@ -6,9 +6,9 @@ import { ConfigParser } from '../config.ts';
 import type { StateManager, StateTransition, WebPageState } from '../state-manager.ts';
 import type { Task } from '../test-plan.ts';
 import { createDebug, tag } from '../utils/logger.ts';
+import { isCodeceptToolName } from '../utils/step-analyzer.ts';
 import type { Conversation, ToolExecution } from './conversation.ts';
 import type { Provider } from './provider.ts';
-import { CODECEPT_TOOLS } from './tools.ts';
 
 const debugLog = createDebug('explorbot:quartermaster');
 
@@ -140,7 +140,7 @@ export class Quartermaster {
       const pageAnalysis = this.pageAnalyses.get(stateHash);
 
       const toolExecutions = conversation.getToolExecutions();
-      const codeceptExecutions = toolExecutions.filter((e) => CODECEPT_TOOLS.includes(e.toolName as any));
+      const codeceptExecutions = toolExecutions.filter((e) => isCodeceptToolName(e.toolName));
 
       if (codeceptExecutions.length === 0 && !pageAnalysis?.axeViolations.length) {
         debugLog('No interactions or violations to analyze');

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -853,6 +853,7 @@ export class Tester extends TaskAgent implements Agent {
 
   private buildScenarioBlock(task: Test, actionResult: ActionResult): string {
     const knowledge = this.getKnowledge(actionResult);
+    const experience = this.getExperience(actionResult);
 
     return dedent`
       <task>
@@ -883,6 +884,8 @@ export class Tester extends TaskAgent implements Agent {
       ${this.buildAvailableFiles()}
 
       ${knowledge}
+
+      ${experience}
     `;
   }
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -20,6 +20,22 @@ const debugLog = createDebug('explorbot:tools');
 
 export const CODECEPT_TOOLS = ['click', 'hover', 'pressKey', 'form'] as const;
 export const ASSERTION_TOOLS = ['verify'] as const;
+export type CodeceptToolName = (typeof CODECEPT_TOOLS)[number];
+
+const CODECEPT_FORM_COMMANDS: readonly string[] = ['I.fillField', 'I.type', 'I.selectOption', 'I.attachFile', 'I.checkOption', 'I.uncheckOption'];
+
+function getCodeceptToolName(commandName: string): CodeceptToolName | null {
+  const toolName = CODECEPT_TOOLS.find((name) => commandName === `I.${name}`);
+  if (toolName) return toolName;
+  if (CODECEPT_FORM_COMMANDS.includes(commandName)) return 'form';
+  return null;
+}
+
+export function getCodeceptToolNameFromCode(code: string): CodeceptToolName | null {
+  const parenIndex = code.trim().indexOf('(');
+  if (parenIndex < 1) return null;
+  return getCodeceptToolName(code.trim().slice(0, parenIndex));
+}
 
 export function createCodeceptJSTools(explorer: Explorer, task: Task) {
   const stateManager = explorer.getStateManager();

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -18,24 +18,7 @@ import { isInteractive } from './task-agent.ts';
 
 const debugLog = createDebug('explorbot:tools');
 
-export const CODECEPT_TOOLS = ['click', 'hover', 'pressKey', 'form'] as const;
 export const ASSERTION_TOOLS = ['verify'] as const;
-export type CodeceptToolName = (typeof CODECEPT_TOOLS)[number];
-
-const CODECEPT_FORM_COMMANDS: readonly string[] = ['I.fillField', 'I.type', 'I.selectOption', 'I.attachFile', 'I.checkOption', 'I.uncheckOption'];
-
-function getCodeceptToolName(commandName: string): CodeceptToolName | null {
-  const toolName = CODECEPT_TOOLS.find((name) => commandName === `I.${name}`);
-  if (toolName) return toolName;
-  if (CODECEPT_FORM_COMMANDS.includes(commandName)) return 'form';
-  return null;
-}
-
-export function getCodeceptToolNameFromCode(code: string): CodeceptToolName | null {
-  const parenIndex = code.trim().indexOf('(');
-  if (parenIndex < 1) return null;
-  return getCodeceptToolName(code.trim().slice(0, parenIndex));
-}
 
 export function createCodeceptJSTools(explorer: Explorer, task: Task) {
   const stateManager = explorer.getStateManager();

--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -3,12 +3,12 @@ import { basename, dirname, join } from 'node:path';
 import matter from 'gray-matter';
 import { type Tokens, marked } from 'marked';
 import type { ActionResult } from './action-result.js';
-import { isNonReusableCode } from './ai/historian/utils.ts';
 import { ConfigParser } from './config.js';
 import { KnowledgeTracker } from './knowledge-tracker.js';
 import type { WebPageState } from './state-manager.js';
 import { createDebug, tag } from './utils/logger.js';
 import { mdq } from './utils/markdown-query.js';
+import { isNonReusableCode } from './utils/step-analyzer.ts';
 import { extractStatePath } from './utils/url-matcher.js';
 
 const debugLog = createDebug('explorbot:experience');

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -221,7 +221,13 @@ export class ExplorBot {
       this.agents.tester = this.createAgent(({ ai, explorer }) => {
         const researcher = this.agentResearcher();
         const navigator = this.agentNavigator();
-        const tools = createAgentTools({ explorer, researcher, navigator });
+        const stateManager = explorer.getStateManager();
+        const experienceTracker = stateManager.getExperienceTracker();
+        const getState = () => {
+          const state = stateManager.getCurrentState();
+          return state ? ActionResult.fromState(state) : null;
+        };
+        const tools = createAgentTools({ explorer, researcher, navigator, experienceTracker, getState });
         return new Tester(explorer, ai, researcher, navigator, tools);
       });
 

--- a/src/utils/step-analyzer.ts
+++ b/src/utils/step-analyzer.ts
@@ -1,0 +1,73 @@
+import type { SessionStep } from '../experience-tracker.ts';
+import type { StepData } from '../test-plan.ts';
+import { isDynamicId } from './xpath.ts';
+
+export const CODECEPT_TOOLS = ['click', 'hover', 'pressKey', 'form'] as const;
+export type CodeceptToolName = (typeof CODECEPT_TOOLS)[number];
+
+const CODECEPT_FORM_COMMANDS: readonly string[] = ['I.fillField', 'I.type', 'I.selectOption', 'I.attachFile', 'I.checkOption', 'I.uncheckOption'];
+
+export function isCodeceptToolName(toolName: string): toolName is CodeceptToolName {
+  return CODECEPT_TOOLS.includes(toolName as CodeceptToolName);
+}
+
+export function getCodeceptToolName(commandName: string): CodeceptToolName | null {
+  const toolName = CODECEPT_TOOLS.find((name) => commandName === `I.${name}`);
+  if (toolName) return toolName;
+  if (CODECEPT_FORM_COMMANDS.includes(commandName)) return 'form';
+  return null;
+}
+
+export function getCodeceptToolNameFromCode(code: string): CodeceptToolName | null {
+  const parenIndex = code.trim().indexOf('(');
+  if (parenIndex < 1) return null;
+  return getCodeceptToolName(code.trim().slice(0, parenIndex));
+}
+
+export function stripComments(code: string): string {
+  return code
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed && !trimmed.startsWith('//') && !trimmed.startsWith('/*') && !trimmed.startsWith('*');
+    })
+    .join('\n');
+}
+
+export function isNonReusableCode(code: string): boolean {
+  if (/\bI\.clickXY\s*\(/.test(code)) return true;
+
+  for (const m of code.matchAll(/#([A-Za-z_][\w-]*)/g)) {
+    if (isDynamicId(m[1])) return true;
+  }
+
+  return false;
+}
+
+export function toReusableSessionStep(step: StepData): SessionStep | null {
+  if (step.status !== 'passed') return null;
+  const code = stripComments(step.text);
+  if (!code || isNonReusableCode(code)) return null;
+  const toolName = getCodeceptToolNameFromCode(code);
+  if (!toolName) return null;
+
+  return {
+    message: step.text,
+    status: 'passed',
+    tool: toolName,
+    code,
+  };
+}
+
+export function mergeUniqueStepsByCode(primary: SessionStep[], secondary: SessionStep[]): SessionStep[] {
+  const merged: SessionStep[] = [];
+  const seen = new Set<string>();
+  for (const step of [...primary, ...secondary]) {
+    const identity = stripComments(step.code || '').trim();
+    if (!identity) continue;
+    if (seen.has(identity)) continue;
+    seen.add(identity);
+    merged.push(step);
+  }
+  return merged;
+}

--- a/tests/unit/agent-tools.test.ts
+++ b/tests/unit/agent-tools.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { ActionResult } from '../../src/action-result.ts';
+import { createAgentTools } from '../../src/ai/tools.ts';
+
+describe('createAgentTools experience', () => {
+  it('adds learnExperience when experience tracker and state reader are provided', async () => {
+    const state = new ActionResult({
+      url: '/page',
+      title: 'Page',
+      html: '<html></html>',
+      ariaSnapshot: '',
+    });
+    const tools = createAgentTools({
+      explorer: {} as any,
+      researcher: {} as any,
+      navigator: {} as any,
+      getState: () => state,
+      experienceTracker: {
+        getExperienceSection: (fileTag: string, sectionIndex: number, currentState: ActionResult) => ({
+          title: `section ${fileTag}.${sectionIndex}`,
+          url: currentState.url,
+          content: '## FLOW: use prior success',
+        }),
+      } as any,
+    });
+
+    expect(tools.learnExperience).toBeDefined();
+
+    const result = await tools.learnExperience.execute({ fileTag: 'A', sectionIndex: 1 });
+
+    expect(result).toEqual({
+      title: 'section A.1',
+      url: '/page',
+      content: '## FLOW: use prior success',
+    });
+  });
+});

--- a/tests/unit/historian-experience.test.ts
+++ b/tests/unit/historian-experience.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'bun:test';
+import { ActionResult } from '../../src/action-result.ts';
+import type { Conversation, ToolExecution } from '../../src/ai/conversation.ts';
+import { Historian } from '../../src/ai/historian.ts';
+import { Test, TestResult } from '../../src/test-plan.ts';
+
+function fakeConversation(execs: ToolExecution[]): Conversation {
+  return { getToolExecutions: () => execs } as unknown as Conversation;
+}
+
+describe('Historian experience', () => {
+  it('writes a fallback flow from successful steps when curator returns empty', async () => {
+    let written = '';
+    const provider = {
+      chat: async () => ({ text: '' }),
+      getModelForAgent: () => undefined,
+    };
+    const experienceTracker = {
+      getRelevantExperience: () => [],
+      writeAction: () => {},
+      writeFlow: (_state: ActionResult, body: string) => {
+        written = body;
+      },
+    };
+    const historian = new Historian(provider as any, experienceTracker as any);
+    const task = new Test('Create item', 'normal', ['item exists'], '/items');
+    task.finish(TestResult.PASSED);
+
+    await historian.saveSession(
+      task,
+      new ActionResult({ url: '/items', title: 'Items' }),
+      fakeConversation([
+        {
+          toolName: 'form',
+          input: { explanation: 'Fill item title' },
+          wasSuccessful: true,
+          output: {
+            success: true,
+            action: 'form',
+            code: 'I.fillField("Title", "Item One")',
+          },
+        },
+        {
+          toolName: 'pressKey',
+          input: { explanation: 'Confirm item' },
+          wasSuccessful: true,
+          output: {
+            success: true,
+            action: 'pressKey',
+            code: 'I.pressKey("Enter")',
+          },
+        },
+      ])
+    );
+
+    expect(written).toContain('## FLOW: create item');
+    expect(written).toContain('I.fillField("Title", "Item One")');
+    expect(written).toContain('I.pressKey("Enter")');
+  });
+
+  it('keeps curated flow when curator selects a subset of successful steps', async () => {
+    let written = '';
+    const provider = {
+      chat: async () => ({
+        text: '## FLOW: start item creation\n\n* Start item creation\n\n```js\nI.click("New item")\n```\n',
+      }),
+      getModelForAgent: () => undefined,
+    };
+    const experienceTracker = {
+      getRelevantExperience: () => [],
+      writeAction: () => {},
+      writeFlow: (_state: ActionResult, body: string) => {
+        written = body;
+      },
+    };
+    const historian = new Historian(provider as any, experienceTracker as any);
+    const task = new Test('Create item', 'normal', ['item exists'], '/items');
+    task.finish(TestResult.PASSED);
+
+    await historian.saveSession(
+      task,
+      new ActionResult({ url: '/items', title: 'Items' }),
+      fakeConversation([
+        {
+          toolName: 'click',
+          input: { explanation: 'Open item form' },
+          wasSuccessful: true,
+          output: {
+            success: true,
+            action: 'click',
+            code: 'I.click("New item")',
+          },
+        },
+        {
+          toolName: 'form',
+          input: { explanation: 'Fill item title' },
+          wasSuccessful: true,
+          output: {
+            success: true,
+            action: 'form',
+            code: 'I.fillField("Title", "Item One")',
+          },
+        },
+      ])
+    );
+
+    expect(written).toContain('## FLOW: start item creation');
+    expect(written).toContain('I.click("New item")');
+    expect(written).not.toContain('I.fillField("Title", "Item One")');
+  });
+
+  it('uses passed task steps when conversation missed reusable actions', async () => {
+    let written = '';
+    const provider = {
+      chat: async () => ({ text: '' }),
+      getModelForAgent: () => undefined,
+    };
+    const experienceTracker = {
+      getRelevantExperience: () => [],
+      writeAction: () => {},
+      writeFlow: (_state: ActionResult, body: string) => {
+        written = body;
+      },
+    };
+    const historian = new Historian(provider as any, experienceTracker as any);
+    const task = new Test('Create item', 'normal', ['item exists'], '/items');
+    task.addStep('I.fillField("Title", "Item One")', 10, 'passed');
+    task.addStep('I.pressKey("Enter")', 10, 'passed');
+    task.finish(TestResult.PASSED);
+
+    await historian.saveSession(
+      task,
+      new ActionResult({ url: '/items', title: 'Items' }),
+      fakeConversation([
+        {
+          toolName: 'click',
+          input: { explanation: 'Open item form' },
+          wasSuccessful: true,
+          output: {
+            success: true,
+            action: 'click',
+            code: 'I.click("New item")',
+          },
+        },
+      ])
+    );
+
+    expect(written).toContain('I.click("New item")');
+    expect(written).toContain('I.fillField("Title", "Item One")');
+    expect(written).toContain('I.pressKey("Enter")');
+  });
+
+  it('does not fallback-write when a relevant flow already exists', async () => {
+    let writeCount = 0;
+    const provider = {
+      chat: async () => ({ text: '' }),
+      getModelForAgent: () => undefined,
+    };
+    const experienceTracker = {
+      getRelevantExperience: () => [{ content: '## FLOW: create item\n\n```js\nI.click("New item")\n```' }],
+      writeAction: () => {},
+      writeFlow: () => {
+        writeCount += 1;
+      },
+    };
+    const historian = new Historian(provider as any, experienceTracker as any);
+    const task = new Test('Create item', 'normal', ['item exists'], '/items');
+    task.finish(TestResult.PASSED);
+
+    await historian.saveSession(
+      task,
+      new ActionResult({ url: '/items', title: 'Items' }),
+      fakeConversation([
+        {
+          toolName: 'click',
+          input: { explanation: 'Open item form' },
+          wasSuccessful: true,
+          output: {
+            success: true,
+            action: 'click',
+            code: 'I.click("New item")',
+          },
+        },
+      ])
+    );
+
+    expect(writeCount).toBe(0);
+  });
+});

--- a/tests/unit/historian-filters.test.ts
+++ b/tests/unit/historian-filters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { isNonReusableCode } from '../../src/ai/historian';
+import { isNonReusableCode } from '../../src/utils/step-analyzer.ts';
 
 describe('isNonReusableCode', () => {
   it('flags I.clickXY calls', () => {

--- a/tests/unit/step-analyzer.test.ts
+++ b/tests/unit/step-analyzer.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import type { SessionStep } from '../../src/experience-tracker.ts';
+import { getCodeceptToolNameFromCode, isCodeceptToolName, isNonReusableCode, mergeUniqueStepsByCode, stripComments, toReusableSessionStep } from '../../src/utils/step-analyzer.ts';
+
+describe('step-analyzer', () => {
+  it('maps CodeceptJS commands to agent tool names', () => {
+    expect(getCodeceptToolNameFromCode('I.click("Save")')).toBe('click');
+    expect(getCodeceptToolNameFromCode('I.hover(".menu")')).toBe('hover');
+    expect(getCodeceptToolNameFromCode('I.pressKey("Enter")')).toBe('pressKey');
+    expect(getCodeceptToolNameFromCode('I.fillField("Title", "Item")')).toBe('form');
+    expect(getCodeceptToolNameFromCode('I.selectOption("Role", "Admin")')).toBe('form');
+    expect(getCodeceptToolNameFromCode('I.see("Done")')).toBe(null);
+  });
+
+  it('recognizes CodeceptJS agent tools by name', () => {
+    expect(isCodeceptToolName('click')).toBe(true);
+    expect(isCodeceptToolName('form')).toBe(true);
+    expect(isCodeceptToolName('verify')).toBe(false);
+  });
+
+  it('strips standalone comments from code blocks', () => {
+    expect(stripComments('// setup\nI.click("Save")\n/* note */\n* skipped')).toBe('I.click("Save")');
+  });
+
+  it('flags non-reusable CodeceptJS code', () => {
+    expect(isNonReusableCode('I.clickXY(100, 200)')).toBe(true);
+    expect(isNonReusableCode("I.click('#ember42')")).toBe(true);
+    expect(isNonReusableCode('I.click("Save", ".modal")')).toBe(false);
+  });
+
+  it('converts passed task steps into reusable session steps', () => {
+    expect(toReusableSessionStep({ text: 'I.fillField("Title", "Item")', status: 'passed' })).toEqual({
+      message: 'I.fillField("Title", "Item")',
+      status: 'passed',
+      tool: 'form',
+      code: 'I.fillField("Title", "Item")',
+    });
+    expect(toReusableSessionStep({ text: 'I.fillField("Title", "Item")', status: 'failed' })).toBe(null);
+    expect(toReusableSessionStep({ text: 'I.clickXY(1, 2)', status: 'passed' })).toBe(null);
+  });
+
+  it('merges steps by reusable code identity', () => {
+    const primary: SessionStep[] = [{ message: 'first', status: 'passed', tool: 'click', code: 'I.click("Save")' }];
+    const secondary: SessionStep[] = [
+      { message: 'same', status: 'passed', tool: 'click', code: '// comment\nI.click("Save")' },
+      { message: 'next', status: 'passed', tool: 'pressKey', code: 'I.pressKey("Enter")' },
+    ];
+
+    expect(mergeUniqueStepsByCode(primary, secondary)).toEqual([primary[0], secondary[1]]);
+  });
+});

--- a/tests/unit/tester-error-page.test.ts
+++ b/tests/unit/tester-error-page.test.ts
@@ -43,7 +43,9 @@ describe('Tester error page handling', () => {
       getStateManager: () => ({
         getCurrentState: () => currentState,
         clearHistory: () => {},
-        getExperienceTracker: () => ({}),
+        getExperienceTracker: () => ({
+          getExperienceTableOfContents: () => [],
+        }),
       }),
       getKnowledgeTracker: () => ({
         getRelevantKnowledge: () => [],
@@ -97,7 +99,9 @@ describe('Tester error page handling', () => {
       getStateManager: () => ({
         getCurrentState: () => currentState,
         clearHistory: () => {},
-        getExperienceTracker: () => ({}),
+        getExperienceTracker: () => ({
+          getExperienceTableOfContents: () => [],
+        }),
       }),
       getKnowledgeTracker: () => ({
         getRelevantKnowledge: () => [],

--- a/tests/unit/tester-focus-scope.test.ts
+++ b/tests/unit/tester-focus-scope.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it } from 'bun:test';
 import { ActionResult } from '../../src/action-result.ts';
 import { Tester } from '../../src/ai/tester.ts';
+import { Test } from '../../src/test-plan.ts';
 
 function buildTester(): Tester {
   const explorer: any = {
     getConfig: () => ({}),
+    getStateManager: () => ({
+      getExperienceTracker: () => ({
+        getExperienceTableOfContents: () => [],
+      }),
+    }),
+    getKnowledgeTracker: () => ({
+      getRelevantKnowledge: () => [],
+    }),
     getCurrentIframeInfo: () => null,
     hasOtherTabs: () => false,
     getOtherTabsInfo: () => [],
@@ -15,6 +24,31 @@ function buildTester(): Tester {
     research: async () => '',
     researchOverlay: async () => null,
   };
+  const navigator: any = {};
+  return new Tester(explorer, provider, researcher, navigator);
+}
+
+function buildTesterWithExperience(): Tester {
+  const explorer: any = {
+    getConfig: () => ({ files: {} }),
+    getStateManager: () => ({
+      getExperienceTracker: () => ({
+        getExperienceTableOfContents: () => [
+          {
+            fileTag: 'A',
+            fileHash: 'abc123',
+            url: '/page',
+            sections: [{ index: 1, level: 2, title: 'FLOW: create item' }],
+          },
+        ],
+      }),
+    }),
+    getKnowledgeTracker: () => ({
+      getRelevantKnowledge: () => [],
+    }),
+  };
+  const provider: any = {};
+  const researcher: any = {};
   const navigator: any = {};
   return new Tester(explorer, provider, researcher, navigator);
 }
@@ -67,5 +101,21 @@ describe('Tester reinjectContextIfNeeded — focus scope hint', () => {
 
     expect(context).toContain('<focus_scope>');
     expect(context).toContain('A dialog "New Form"');
+  });
+});
+
+describe('Tester experience context', () => {
+  it('adds only the experience table of contents to the scenario prompt', () => {
+    const tester = buildTesterWithExperience();
+    const task = new Test('create item', 'normal', 'item exists', '/page');
+    const state = buildState('- main:', '/page');
+
+    const scenarioBlock = (tester as any).buildScenarioBlock(task, state);
+
+    expect(scenarioBlock).toContain('<experience>');
+    expect(scenarioBlock).toContain('A.1 ## FLOW: create item');
+    expect(scenarioBlock).toContain('Call learnExperience({ fileTag, sectionIndex })');
+    expect(scenarioBlock).not.toContain('I.click');
+    expect(scenarioBlock).not.toContain('```');
   });
 });


### PR DESCRIPTION
 ## Summary
                      
  - Add experience TOC to tester context instead of full experience content. 
  - Enable tester tools to fetch relevant sections via `learnExperience`. 
  - Save fallback `FLOW` from successful steps when curator returns empty.
  - Include passed task steps when building saved experience.
  - Avoid duplicate fallback writes when relevant flow already exists. 
  - Add unit test.