### PR TITLE
Adds screenshot artifacts to generated doc collector

### DIFF
--- a/boat/doc-collector/src/config.ts
+++ b/boat/doc-collector/src/config.ts
@@ -160,6 +160,7 @@ interface DocbotConfig {
     deniedActionLabels?: string[];
     maxPrimaryCandidates?: number;
     maxInteractions?: number;
+    maxSectionScreenshots?: number;
     minCanActions?: number;
     minInteractiveElements?: number;
     interactive?: boolean;

--- a/boat/doc-collector/src/docbot.ts
+++ b/boat/doc-collector/src/docbot.ts
@@ -3,13 +3,14 @@ import path from 'node:path';
 import { ExplorBot, type ExplorBotOptions } from '../../../src/explorbot.ts';
 import type { Link, WebPageState } from '../../../src/state-manager.ts';
 import { normalizeUrl } from '../../../src/state-manager.ts';
-import { sanitizeFilename } from '../../../src/utils/strings.ts';
 import { tag } from '../../../src/utils/logger.ts';
+import { sanitizeFilename } from '../../../src/utils/strings.ts';
 import { Documentarian, type PageDocumentation } from './ai/documentarian.ts';
 import { type DocbotConfig, DocbotConfigParser } from './config.ts';
-import { type DocumentedPage, renderPageDocumentation, renderSpecIndex, type SkippedPage } from './docs-renderer.ts';
+import { type DocumentedPage, type SkippedPage, renderPageDocumentation, renderSpecIndex } from './docs-renderer.ts';
 import { getDocPageKey, shouldCrawlDocPath } from './path-filter.ts';
 import { extractResearchNavigationTargets } from './research-navigation.ts';
+import { type DocumentationScreenshot, captureDocumentationScreenshots } from './screenshots.ts';
 
 class DocBot {
   private explorBot: ExplorBot;
@@ -120,7 +121,7 @@ class DocBot {
           documented.add(pageKey);
           continue;
         }
-        const filePath = this.savePageDocumentation(state, documentation);
+        const filePath = await this.savePageDocumentation(state, documentation, research);
 
         pages.push({
           url: state.url,
@@ -397,10 +398,23 @@ class DocBot {
     return matches.reduce((sum, match) => sum + Number.parseInt(match[1], 10), 0);
   }
 
-  private savePageDocumentation(state: WebPageState, documentation: PageDocumentation): string {
+  private async savePageDocumentation(state: WebPageState, documentation: PageDocumentation, research: string): Promise<string> {
     const pagePath = this.getPageFilePath(state.url);
-    writeFileSync(pagePath, renderPageDocumentation(state, documentation), 'utf8');
+    const screenshots = await this.captureScreenshots(state, research, pagePath);
+    writeFileSync(pagePath, renderPageDocumentation(state, documentation, screenshots), 'utf8');
     return pagePath;
+  }
+
+  private async captureScreenshots(state: WebPageState, research: string, pagePath: string): Promise<DocumentationScreenshot[]> {
+    if (!this.shouldUseScreenshots()) {
+      return [];
+    }
+
+    return captureDocumentationScreenshots(this.explorBot.getExplorer(), state, research, {
+      pageFilePath: pagePath,
+      screenshotsDir: this.getScreenshotsDir(),
+      config: this.config,
+    });
   }
 
   private saveIndex(startPath: string, pages: DocumentedPage[], skipped: SkippedPage[], maxPages: number): string {
@@ -411,6 +425,10 @@ class DocBot {
 
   private getPagesDir(): string {
     return path.join(this.configParser.getOutputDir(), 'pages');
+  }
+
+  private getScreenshotsDir(): string {
+    return path.join(this.configParser.getOutputDir(), 'screenshots');
   }
 
   private getPageFilePath(pageUrl: string): string {

--- a/boat/doc-collector/src/docs-renderer.ts
+++ b/boat/doc-collector/src/docs-renderer.ts
@@ -1,8 +1,9 @@
 import path from 'node:path';
 import type { WebPageState } from '../../../src/state-manager.ts';
 import type { PageDocumentation, StateTransition } from './ai/documentarian.ts';
+import type { DocumentationScreenshot } from './screenshots.ts';
 
-function renderPageDocumentation(state: WebPageState, documentation: PageDocumentation): string {
+function renderPageDocumentation(state: WebPageState, documentation: PageDocumentation, screenshots: DocumentationScreenshot[] = []): string {
   const lines: string[] = [];
   lines.push(`# ${state.url}`);
   lines.push('');
@@ -16,6 +17,18 @@ function renderPageDocumentation(state: WebPageState, documentation: PageDocumen
   lines.push('');
   lines.push(ensureSentence(documentation.summary));
   lines.push('');
+
+  if (screenshots.length > 0) {
+    lines.push('## Screenshots');
+    lines.push('');
+    for (const screenshot of screenshots) {
+      lines.push(`![${normalizeInlineText(screenshot.title)}](${screenshot.relativePath})`);
+      if (screenshot.selector) {
+        lines.push(`Section: \`${screenshot.selector}\``);
+      }
+      lines.push('');
+    }
+  }
 
   const interactions = documentation.interactions;
   if (interactions && interactions.length > 0) {

--- a/boat/doc-collector/src/screenshots.ts
+++ b/boat/doc-collector/src/screenshots.ts
@@ -1,0 +1,126 @@
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { parseResearchSections } from '../../../src/ai/researcher/parser.ts';
+import type Explorer from '../../../src/explorer.ts';
+import type { WebPageState } from '../../../src/state-manager.ts';
+import { safeFilename, sanitizeFilename } from '../../../src/utils/strings.ts';
+import type { DocbotConfig } from './config.ts';
+
+const DEFAULT_MAX_SECTION_SCREENSHOTS = 8;
+
+export async function captureDocumentationScreenshots(explorer: Explorer, state: WebPageState, research: string, options: DocumentationScreenshotOptions): Promise<DocumentationScreenshot[]> {
+  const page = explorer.playwrightHelper?.page;
+  if (!page) {
+    return [];
+  }
+
+  mkdirSync(options.screenshotsDir, { recursive: true });
+
+  const screenshots: DocumentationScreenshot[] = [];
+  const pageName = sanitizeFilename(state.url || 'page') || 'page';
+  const fullPage = await captureFullPageScreenshot(page, pageName, options);
+  if (fullPage) {
+    screenshots.push(fullPage);
+  }
+
+  const maxSections = getMaxSectionScreenshots(options.config);
+  for (const section of getScreenshotSections(research).slice(0, maxSections)) {
+    const screenshot = await captureSectionScreenshot(page, pageName, section, options);
+    if (!screenshot) {
+      continue;
+    }
+    screenshots.push(screenshot);
+  }
+
+  return screenshots;
+}
+
+export function getScreenshotSections(research: string): ScreenshotSection[] {
+  const sections: ScreenshotSection[] = [];
+  const seen = new Set<string>();
+
+  for (const section of parseResearchSections(research)) {
+    if (!section.containerCss) {
+      continue;
+    }
+    if (section.elements.length === 0) {
+      continue;
+    }
+    if (seen.has(section.containerCss)) {
+      continue;
+    }
+    seen.add(section.containerCss);
+    sections.push({
+      title: section.name,
+      selector: section.containerCss,
+    });
+  }
+
+  return sections;
+}
+
+async function captureFullPageScreenshot(page: any, pageName: string, options: DocumentationScreenshotOptions): Promise<DocumentationScreenshot | null> {
+  const filePath = path.join(options.screenshotsDir, safeFilename(`${pageName}_page`, '.png'));
+  try {
+    await page.screenshot({ path: filePath, fullPage: true });
+  } catch {
+    return null;
+  }
+
+  return {
+    title: 'Page screenshot',
+    path: filePath,
+    relativePath: toMarkdownPath(options.pageFilePath, filePath),
+    kind: 'page',
+  };
+}
+
+async function captureSectionScreenshot(page: any, pageName: string, section: ScreenshotSection, options: DocumentationScreenshotOptions): Promise<DocumentationScreenshot | null> {
+  const sectionName = sanitizeFilename(section.title) || 'section';
+  const filePath = path.join(options.screenshotsDir, safeFilename(`${pageName}_${sectionName}`, '.png'));
+
+  try {
+    await page.locator(section.selector).first().screenshot({ path: filePath });
+  } catch {
+    return null;
+  }
+
+  return {
+    title: section.title,
+    path: filePath,
+    relativePath: toMarkdownPath(options.pageFilePath, filePath),
+    kind: 'section',
+    selector: section.selector,
+  };
+}
+
+function getMaxSectionScreenshots(config: DocbotConfig): number {
+  const configured = config.docs?.maxSectionScreenshots;
+  if (configured && configured > 0) {
+    return configured;
+  }
+  return DEFAULT_MAX_SECTION_SCREENSHOTS;
+}
+
+function toMarkdownPath(pageFilePath: string, assetPath: string): string {
+  return path.relative(path.dirname(pageFilePath), assetPath).replaceAll('\\', '/');
+}
+
+export interface DocumentationScreenshot {
+  title: string;
+  path: string;
+  relativePath: string;
+  kind: 'page' | 'section';
+  selector?: string;
+}
+
+interface DocumentationScreenshotOptions {
+  pageFilePath: string;
+  screenshotsDir: string;
+  config: DocbotConfig;
+}
+
+interface ScreenshotSection {
+  title: string;
+  selector: string;
+}

--- a/tests/unit/doc-collector.test.ts
+++ b/tests/unit/doc-collector.test.ts
@@ -6,6 +6,7 @@ import { DocBot } from '../../boat/doc-collector/src/docbot.ts';
 import { normalizeAction, renderPageDocumentation, renderSpecIndex } from '../../boat/doc-collector/src/docs-renderer.ts';
 import { getDocPageKey, shouldCrawlDocPath } from '../../boat/doc-collector/src/path-filter.ts';
 import { extractResearchNavigationTargets } from '../../boat/doc-collector/src/research-navigation.ts';
+import { captureDocumentationScreenshots, getScreenshotSections } from '../../boat/doc-collector/src/screenshots.ts';
 
 describe('doc-collector path filter', () => {
   it('allows regular documentation pages', () => {
@@ -117,6 +118,40 @@ describe('doc-collector renderer', () => {
     expect(markdown).toContain('Signal: OAuth buttons are shown in the form.');
   });
 
+  it('renders page and section screenshots as markdown images', () => {
+    const markdown = renderPageDocumentation(
+      {
+        url: '/users/sign_in',
+        title: 'Testomat.io',
+      },
+      {
+        summary: 'Sign in page for existing users',
+        can: [],
+        might: [],
+      },
+      [
+        {
+          title: 'Page screenshot',
+          path: 'D:/project/output/docs/screenshots/users_sign_in_page.png',
+          relativePath: '../screenshots/users_sign_in_page.png',
+          kind: 'page',
+        },
+        {
+          title: 'Login form',
+          path: 'D:/project/output/docs/screenshots/users_sign_in_login_form.png',
+          relativePath: '../screenshots/users_sign_in_login_form.png',
+          kind: 'section',
+          selector: '.login-form',
+        },
+      ]
+    );
+
+    expect(markdown).toContain('## Screenshots');
+    expect(markdown).toContain('![Page screenshot](../screenshots/users_sign_in_page.png)');
+    expect(markdown).toContain('![Login form](../screenshots/users_sign_in_login_form.png)');
+    expect(markdown).toContain('Section: `.login-form`');
+  });
+
   it('renders aggregate spec index with skipped pages', () => {
     const markdown = renderSpecIndex(
       'D:/project/output/docs',
@@ -164,6 +199,89 @@ describe('doc-collector renderer', () => {
   it('normalizes might-actions without duplicating prefixes', () => {
     expect(normalizeAction('user might be able to submit the login form by pressing Enter', 'might')).toBe('user might be able to submit the login form by pressing Enter');
     expect(normalizeAction('user can submit the login form by pressing Enter', 'might')).toBe('user might submit the login form by pressing Enter');
+  });
+});
+
+describe('doc-collector screenshots', () => {
+  it('selects section containers from research for cropped screenshots', () => {
+    const research = `
+## Navigation
+
+> Container: '.mainnav-menu'
+
+| Element | Type | ARIA | CSS |
+|------|------|------|------|
+| 'Projects' | link | { role: 'link', text: 'Projects' } | 'a[href="/"]' |
+
+## Empty Section
+
+> Container: '.empty'
+
+## Content
+
+> Container: '.main-content'
+
+| Element | Type | ARIA | CSS |
+|------|------|------|------|
+| 'Create' | button | { role: 'button', text: 'Create' } | 'button.primary' |
+`;
+
+    expect(getScreenshotSections(research)).toEqual([
+      { title: 'Navigation', selector: '.mainnav-menu' },
+      { title: 'Content', selector: '.main-content' },
+    ]);
+  });
+
+  it('captures full page and section screenshots from research containers', async () => {
+    const captured: Array<{ selector?: string; path: string; fullPage?: boolean }> = [];
+    const page = {
+      async screenshot(options: { path: string; fullPage?: boolean }) {
+        captured.push(options);
+      },
+      locator(selector: string) {
+        return {
+          first() {
+            return {
+              async screenshot(options: { path: string }) {
+                captured.push({ selector, path: options.path });
+              },
+            };
+          },
+        };
+      },
+    };
+
+    const screenshots = await captureDocumentationScreenshots(
+      { playwrightHelper: { page } } as any,
+      { url: '/users/sign_in' },
+      `
+## Navigation
+
+> Container: '.mainnav-menu'
+
+| Element | Type | ARIA | CSS |
+|------|------|------|------|
+| 'Projects' | link | { role: 'link', text: 'Projects' } | 'a[href="/"]' |
+
+## Content
+
+> Container: '.main-content'
+
+| Element | Type | ARIA | CSS |
+|------|------|------|------|
+| 'Create' | button | { role: 'button', text: 'Create' } | 'button.primary' |
+`,
+      {
+        pageFilePath: 'output/docs/pages/users_sign_in.md',
+        screenshotsDir: 'output/docs/screenshots',
+        config: { docs: { maxSectionScreenshots: 1 } },
+      }
+    );
+
+    expect(screenshots.map((screenshot) => screenshot.kind)).toEqual(['page', 'section']);
+    expect(screenshots[0].relativePath).toBe('../screenshots/users_sign_in_page.png');
+    expect(screenshots[1].relativePath).toBe('../screenshots/users_sign_in_navigation.png');
+    expect(captured.map((item) => item.selector)).toEqual([undefined, '.mainnav-menu']);
   });
 });
 


### PR DESCRIPTION
 ## Changes                                                                                                                                                                                    
 
  - Captures a full-page screenshot for each documented page
  - Captures cropped screenshots for documented research sections with known containers               
  - Renders screenshots in page markdown using standard image links     
  - Stores screenshot assets under `output/docs/screenshots`.            