### PR TITLE
fix: remove leaked step listeners in Explorer.startTest (plan 002)

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -727,17 +727,22 @@ class Explorer {
 
     this.watchActiveTestPage();
 
+    const onStepPassed = (step: any) => stepHandler(step, 'passed');
+    const onStepFailed = (step: any, error: any) => {
+      stepHandler(step, 'failed', error?.message || String(error), error?.stack);
+    };
+    const onTestAfter = () => {
+      codeceptjs.event.dispatcher.off('step.passed', onStepPassed);
+      codeceptjs.event.dispatcher.off('step.failed', onStepFailed);
+      codeceptjs.event.dispatcher.off('test.after', onTestAfter);
+      this.unwatchActiveTestPages();
+    };
+
     codeceptjs.event.dispatcher.emit('test.before', codeceptjsTest);
     codeceptjs.event.dispatcher.emit('test.start', codeceptjsTest);
-    codeceptjs.event.dispatcher.on('step.passed', (step: any) => stepHandler(step, 'passed'));
-    codeceptjs.event.dispatcher.on('step.failed', (step: any, error: any) => {
-      stepHandler(step, 'failed', error?.message || String(error), error?.stack);
-    });
-    codeceptjs.event.dispatcher.on('test.after', () => {
-      codeceptjs.event.dispatcher.off('step.passed', stepHandler);
-      codeceptjs.event.dispatcher.off('step.failed', stepHandler);
-      this.unwatchActiveTestPages();
-    });
+    codeceptjs.event.dispatcher.on('step.passed', onStepPassed);
+    codeceptjs.event.dispatcher.on('step.failed', onStepFailed);
+    codeceptjs.event.dispatcher.on('test.after', onTestAfter);
 
     return true;
   }

--- a/tests/unit/explorer-step-listeners.test.ts
+++ b/tests/unit/explorer-step-listeners.test.ts
@@ -44,6 +44,8 @@ describe('Explorer step listener cleanup', () => {
     };
 
     await buildExplorer().startTest(buildTest());
+    expect(countListeners('step.passed')).toBe(before.passed + 1);
+
     dispatcher.emit('test.after');
 
     expect(countListeners('step.passed')).toBe(before.passed);

--- a/tests/unit/explorer-step-listeners.test.ts
+++ b/tests/unit/explorer-step-listeners.test.ts
@@ -1,8 +1,15 @@
+import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'bun:test';
 import * as codeceptjs from 'codeceptjs';
 import Explorer from '../../src/explorer.ts';
 
 const dispatcher = (codeceptjs as any).event.dispatcher;
+
+function countListeners(event: string): number {
+  if (typeof dispatcher.listeners === 'function') return dispatcher.listeners(event).length;
+  if (typeof dispatcher.listenerCount === 'function') return dispatcher.listenerCount(event);
+  return EventEmitter.listenerCount(dispatcher, event);
+}
 
 function buildExplorer() {
   const explorer = Object.assign(Object.create(Explorer.prototype), {
@@ -31,24 +38,24 @@ function buildTest() {
 describe('Explorer step listener cleanup', () => {
   it('removes step listeners after a test lifecycle', async () => {
     const before = {
-      passed: dispatcher.listenerCount('step.passed'),
-      failed: dispatcher.listenerCount('step.failed'),
-      after: dispatcher.listenerCount('test.after'),
+      passed: countListeners('step.passed'),
+      failed: countListeners('step.failed'),
+      after: countListeners('test.after'),
     };
 
     await buildExplorer().startTest(buildTest());
     dispatcher.emit('test.after');
 
-    expect(dispatcher.listenerCount('step.passed')).toBe(before.passed);
-    expect(dispatcher.listenerCount('step.failed')).toBe(before.failed);
-    expect(dispatcher.listenerCount('test.after')).toBe(before.after);
+    expect(countListeners('step.passed')).toBe(before.passed);
+    expect(countListeners('step.failed')).toBe(before.failed);
+    expect(countListeners('test.after')).toBe(before.after);
   });
 
   it('does not accumulate listeners across repeated startTest cycles', async () => {
     const before = {
-      passed: dispatcher.listenerCount('step.passed'),
-      failed: dispatcher.listenerCount('step.failed'),
-      after: dispatcher.listenerCount('test.after'),
+      passed: countListeners('step.passed'),
+      failed: countListeners('step.failed'),
+      after: countListeners('test.after'),
     };
 
     for (let i = 0; i < 5; i++) {
@@ -56,8 +63,8 @@ describe('Explorer step listener cleanup', () => {
       dispatcher.emit('test.after');
     }
 
-    expect(dispatcher.listenerCount('step.passed')).toBe(before.passed);
-    expect(dispatcher.listenerCount('step.failed')).toBe(before.failed);
-    expect(dispatcher.listenerCount('test.after')).toBe(before.after);
+    expect(countListeners('step.passed')).toBe(before.passed);
+    expect(countListeners('step.failed')).toBe(before.failed);
+    expect(countListeners('test.after')).toBe(before.after);
   });
 });

--- a/tests/unit/explorer-step-listeners.test.ts
+++ b/tests/unit/explorer-step-listeners.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+import * as codeceptjs from 'codeceptjs';
+import Explorer from '../../src/explorer.ts';
+
+const dispatcher = (codeceptjs as any).event.dispatcher;
+
+function buildExplorer() {
+  const explorer = Object.assign(Object.create(Explorer.prototype), {
+    reporter: { reportTestStart: async () => {} },
+    stateManager: { getCurrentState: () => null },
+    otherTabs: [],
+    playwrightHelper: { page: { isClosed: () => false } },
+  }) as any;
+  explorer.closeOtherTabs = async () => {};
+  explorer.ensurePageAvailable = async () => true;
+  explorer.watchActiveTestPage = () => {};
+  explorer.unwatchActiveTestPages = () => {};
+  return explorer as Explorer;
+}
+
+function buildTest() {
+  return {
+    scenario: 'listener leak regression',
+    start: () => {},
+    addStep: () => {},
+    setActiveNoteScreenshot: () => {},
+    getPrintableNotes: () => '',
+  } as any;
+}
+
+describe('Explorer step listener cleanup', () => {
+  it('removes step listeners after a test lifecycle', async () => {
+    const before = {
+      passed: dispatcher.listenerCount('step.passed'),
+      failed: dispatcher.listenerCount('step.failed'),
+      after: dispatcher.listenerCount('test.after'),
+    };
+
+    await buildExplorer().startTest(buildTest());
+    dispatcher.emit('test.after');
+
+    expect(dispatcher.listenerCount('step.passed')).toBe(before.passed);
+    expect(dispatcher.listenerCount('step.failed')).toBe(before.failed);
+    expect(dispatcher.listenerCount('test.after')).toBe(before.after);
+  });
+
+  it('does not accumulate listeners across repeated startTest cycles', async () => {
+    const before = {
+      passed: dispatcher.listenerCount('step.passed'),
+      failed: dispatcher.listenerCount('step.failed'),
+      after: dispatcher.listenerCount('test.after'),
+    };
+
+    for (let i = 0; i < 5; i++) {
+      await buildExplorer().startTest(buildTest());
+      dispatcher.emit('test.after');
+    }
+
+    expect(dispatcher.listenerCount('step.passed')).toBe(before.passed);
+    expect(dispatcher.listenerCount('step.failed')).toBe(before.failed);
+    expect(dispatcher.listenerCount('test.after')).toBe(before.after);
+  });
+});

--- a/tests/unit/explorer-step-listeners.test.ts
+++ b/tests/unit/explorer-step-listeners.test.ts
@@ -1,14 +1,33 @@
-import { EventEmitter } from 'node:events';
 import { describe, expect, it } from 'bun:test';
 import * as codeceptjs from 'codeceptjs';
 import Explorer from '../../src/explorer.ts';
 
 const dispatcher = (codeceptjs as any).event.dispatcher;
+const TRACKED_EVENTS = ['step.passed', 'step.failed', 'test.after'];
 
-function countListeners(event: string): number {
-  if (typeof dispatcher.listeners === 'function') return dispatcher.listeners(event).length;
-  if (typeof dispatcher.listenerCount === 'function') return dispatcher.listenerCount(event);
-  return EventEmitter.listenerCount(dispatcher, event);
+// The CodeceptJS dispatcher's listener introspection (listenerCount/listeners) is
+// unreliable under the bun version CI runs, so track live registrations by wrapping
+// on()/off() (which work everywhere). registered[event] holds the handlers currently
+// attached — the leak bug leaves a handler behind because off() used the wrong ref.
+function trackRegistrations(): { registered: Map<string, Set<any>>; restore: () => void } {
+  const registered = new Map<string, Set<any>>(TRACKED_EVENTS.map((event) => [event, new Set()]));
+  const realOn = dispatcher.on.bind(dispatcher);
+  const realOff = dispatcher.off.bind(dispatcher);
+  dispatcher.on = (event: string, fn: any) => {
+    registered.get(event)?.add(fn);
+    return realOn(event, fn);
+  };
+  dispatcher.off = (event: string, fn: any) => {
+    registered.get(event)?.delete(fn);
+    return realOff(event, fn);
+  };
+  return {
+    registered,
+    restore: () => {
+      dispatcher.on = realOn;
+      dispatcher.off = realOff;
+    },
+  };
 }
 
 function buildExplorer() {
@@ -36,37 +55,35 @@ function buildTest() {
 }
 
 describe('Explorer step listener cleanup', () => {
-  it('removes step listeners after a test lifecycle', async () => {
-    const before = {
-      passed: countListeners('step.passed'),
-      failed: countListeners('step.failed'),
-      after: countListeners('test.after'),
-    };
+  it('removes every listener it registers after a test lifecycle', async () => {
+    const { registered, restore } = trackRegistrations();
+    try {
+      await buildExplorer().startTest(buildTest());
+      expect(registered.get('step.passed')!.size).toBe(1);
+      expect(registered.get('test.after')!.size).toBe(1);
 
-    await buildExplorer().startTest(buildTest());
-    expect(countListeners('step.passed')).toBe(before.passed + 1);
+      dispatcher.emit('test.after');
 
-    dispatcher.emit('test.after');
-
-    expect(countListeners('step.passed')).toBe(before.passed);
-    expect(countListeners('step.failed')).toBe(before.failed);
-    expect(countListeners('test.after')).toBe(before.after);
+      expect(registered.get('step.passed')!.size).toBe(0);
+      expect(registered.get('step.failed')!.size).toBe(0);
+      expect(registered.get('test.after')!.size).toBe(0);
+    } finally {
+      restore();
+    }
   });
 
   it('does not accumulate listeners across repeated startTest cycles', async () => {
-    const before = {
-      passed: countListeners('step.passed'),
-      failed: countListeners('step.failed'),
-      after: countListeners('test.after'),
-    };
-
-    for (let i = 0; i < 5; i++) {
-      await buildExplorer().startTest(buildTest());
-      dispatcher.emit('test.after');
+    const { registered, restore } = trackRegistrations();
+    try {
+      for (let i = 0; i < 5; i++) {
+        await buildExplorer().startTest(buildTest());
+        dispatcher.emit('test.after');
+      }
+      expect(registered.get('step.passed')!.size).toBe(0);
+      expect(registered.get('step.failed')!.size).toBe(0);
+      expect(registered.get('test.after')!.size).toBe(0);
+    } finally {
+      restore();
     }
-
-    expect(countListeners('step.passed')).toBe(before.passed);
-    expect(countListeners('step.failed')).toBe(before.failed);
-    expect(countListeners('test.after')).toBe(before.after);
   });
 });


### PR DESCRIPTION
Implements **plan 002** (`plans/002-fix-step-listener-leak.md`) — a P1 bug fix.

## Problem
`Explorer.startTest` registered `step.passed` / `step.failed` listeners as **inline arrows**, but its `test.after` cleanup called `.off('step.passed', stepHandler)` with a reference that was never registered. So the `.off()` calls were no-ops:
- Listeners leaked on the shared CodeceptJS event dispatcher — every test permanently added three listeners.
- Old tests' closures kept firing on later tests' steps, calling `addStep(...)` / `setActiveNoteScreenshot(...)` on already-finished `Test` objects and corrupting their step logs.
- Listener count grew unbounded across a run (max-listeners warnings, memory growth, work scaling with test-count²) — a real problem for hours-long sessions.

## Fix
Assign the two step listeners and the `test.after` handler to named `const`s and register those exact references. `onTestAfter` removes all three listeners (including itself) so nothing accumulates across `startTest` cycles. This mirrors the correct store-the-reference discipline already used by `attachStepLogger`/`detachStepLogger` in `src/action.ts`.

## Verification
- `tests/unit/explorer-step-listeners.test.ts` (regression) → 2 pass: net-zero listener count after a lifecycle, and no growth across 5 repeated cycles. These were the two failing baseline tests.
- `bun test tests/unit` → 736 pass, 0 fail
- `bun run lint` → clean

Non-blocking / out of scope per the plan: if a run aborts without ever emitting `test.after`, listeners still persist (pre-existing behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)