### PR TITLE
fix: redact interpolated secrets from telemetry and experience files (plan 003)

### DIFF
--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -8,6 +8,7 @@ import { KnowledgeTracker } from './knowledge-tracker.js';
 import type { WebPageState } from './state-manager.js';
 import { createDebug, tag } from './utils/logger.js';
 import { mdq } from './utils/markdown-query.js';
+import { redactSecrets } from './utils/secrets.js';
 import { isNonReusableCode } from './utils/step-analyzer.ts';
 import { extractStatePath } from './utils/url-matcher.js';
 
@@ -109,7 +110,7 @@ export class ExperienceTracker {
       return;
     }
     const filePath = this.getExperienceFilePath(stateHash);
-    const fileContent = matter.stringify(content, frontmatter || {});
+    const fileContent = matter.stringify(redactSecrets(content), frontmatter || {});
     writeFileSync(filePath, fileContent, 'utf8');
   }
 

--- a/src/knowledge-tracker.ts
+++ b/src/knowledge-tracker.ts
@@ -5,6 +5,7 @@ import { ActionResult } from './action-result.js';
 import { ConfigParser } from './config.js';
 import { getCliName } from './utils/cli-name.ts';
 import { createDebug } from './utils/logger.js';
+import { isSecretName, registerSecret } from './utils/secrets.js';
 
 const debugLog = createDebug('explorbot:knowledge-tracker');
 
@@ -138,9 +139,14 @@ export class KnowledgeTracker {
       const namespace = expr.slice(0, dotIndex);
       const key = expr.slice(dotIndex + 1);
 
-      if (namespace === 'env') return process.env[key] ?? '';
+      if (namespace === 'env') {
+        const value = process.env[key] ?? '';
+        if (isSecretName(key)) registerSecret(value);
+        return value;
+      }
 
       if (namespace === 'config') {
+        if (isSecretName(key)) return '';
         const config = ConfigParser.getInstance().getConfig();
         const value = key.split('.').reduce((obj: any, k) => obj?.[k], config);
         if (value !== undefined && typeof value !== 'object') return String(value);

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,4 +1,5 @@
 import { type Span, trace } from '@opentelemetry/api';
+import { redactSecrets } from './utils/secrets.js';
 
 type TelemetryMetadata = Record<string, unknown>;
 
@@ -84,7 +85,7 @@ function buildRootSpanAttributes(name: string, metadata: TelemetryMetadata): Rec
     attributes['langfuse.trace.tags'] = metadata.tags as string[];
   }
   if (metadata.input !== undefined) {
-    attributes['langfuse.trace.input'] = JSON.stringify(metadata.input);
+    attributes['langfuse.trace.input'] = redactSecrets(JSON.stringify(metadata.input));
   }
 
   return attributes;

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,4 +1,5 @@
 const MIN_SECRET_LENGTH = 4;
+const SECRET_NAME_TOKENS = ['password', 'passwd', 'secret', 'token', 'apikey', 'api_key', 'credential', 'private_key', 'privatekey', 'access_key'];
 const secretValues = new Set<string>();
 
 export function registerSecret(value: string): void {
@@ -10,7 +11,7 @@ export function registerSecret(value: string): void {
 export function redactSecrets(text: string): string {
   if (!text) return text;
   let result = text;
-  for (const value of secretValues) {
+  for (const value of [...secretValues].sort((a, b) => b.length - a.length)) {
     if (!result.includes(value)) continue;
     result = result.split(value).join('***REDACTED***');
   }
@@ -20,8 +21,6 @@ export function redactSecrets(text: string): string {
 export function clearRegisteredSecrets(): void {
   secretValues.clear();
 }
-
-const SECRET_NAME_TOKENS = ['password', 'passwd', 'secret', 'token', 'apikey', 'api_key', 'credential', 'private_key', 'privatekey', 'access_key'];
 
 export function isSecretName(name: string): boolean {
   const lower = name.toLowerCase();

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,0 +1,29 @@
+const MIN_SECRET_LENGTH = 4;
+const secretValues = new Set<string>();
+
+export function registerSecret(value: string): void {
+  if (!value) return;
+  if (value.length < MIN_SECRET_LENGTH) return;
+  secretValues.add(value);
+}
+
+export function redactSecrets(text: string): string {
+  if (!text) return text;
+  let result = text;
+  for (const value of secretValues) {
+    if (!result.includes(value)) continue;
+    result = result.split(value).join('***REDACTED***');
+  }
+  return result;
+}
+
+export function clearRegisteredSecrets(): void {
+  secretValues.clear();
+}
+
+const SECRET_NAME_TOKENS = ['password', 'passwd', 'secret', 'token', 'apikey', 'api_key', 'credential', 'private_key', 'privatekey', 'access_key'];
+
+export function isSecretName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SECRET_NAME_TOKENS.some((token) => lower.includes(token));
+}

--- a/src/utils/secrets.ts
+++ b/src/utils/secrets.ts
@@ -1,5 +1,5 @@
 const MIN_SECRET_LENGTH = 4;
-const SECRET_NAME_TOKENS = ['password', 'passwd', 'secret', 'token', 'apikey', 'api_key', 'credential', 'private_key', 'privatekey', 'access_key'];
+const SECRET_NAME_TOKENS = ['password', 'passwd', 'secret', 'token', 'apikey', 'api_key', 'credential', 'private_key', 'privatekey', 'access_key', 'jwt', 'auth', 'bearer', 'authorization', 'cert', 'certificate'];
 const secretValues = new Set<string>();
 
 export function registerSecret(value: string): void {

--- a/tests/unit/knowledge-tracker.test.ts
+++ b/tests/unit/knowledge-tracker.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import matter from 'gray-matter';
 import { ConfigParser } from '../../src/config';
 import { KnowledgeTracker } from '../../src/knowledge-tracker';
+import { clearRegisteredSecrets, redactSecrets } from '../../src/utils/secrets';
 
 const knowledgeDir = '/tmp/explorbot-test-knowledge';
 
@@ -123,6 +124,33 @@ describe('KnowledgeTracker', () => {
 
       expect(content[0]).toContain('value:');
       expect(content[0]).not.toContain('${config.');
+    });
+
+    it('should block credential-named config keys from interpolating', () => {
+      (ConfigParser.getInstance() as any).config.ai.apiKey = 'sk-should-not-leak';
+      writeKnowledgeFile('page.md', '/page', 'key: ${config.ai.apiKey}');
+
+      const tracker = new KnowledgeTracker();
+      const content = tracker.getKnowledgeForUrl('/page');
+
+      expect(content[0]).not.toContain('sk-should-not-leak');
+      expect(content[0]).not.toContain('${config.');
+    });
+
+    it('should register env secrets so they are redacted at sinks', () => {
+      clearRegisteredSecrets();
+      process.env.APP_PASSWORD = 'hunter2secret';
+
+      writeKnowledgeFile('login.md', '/login', 'password: ${env.APP_PASSWORD}');
+
+      const tracker = new KnowledgeTracker();
+      const content = tracker.getKnowledgeForUrl('/login');
+
+      expect(content[0]).toContain('password: hunter2secret');
+      expect(redactSecrets('typed hunter2secret into the field')).toBe('typed ***REDACTED*** into the field');
+
+      process.env.APP_PASSWORD = undefined;
+      clearRegisteredSecrets();
     });
   });
 });

--- a/tests/unit/secrets.test.ts
+++ b/tests/unit/secrets.test.ts
@@ -26,6 +26,12 @@ describe('secrets', () => {
     expect(redactSecrets('topsecret and topsecret again')).toBe('***REDACTED*** and ***REDACTED*** again');
   });
 
+  it('redacts a longer secret fully even when a registered secret is its substring', () => {
+    registerSecret('hunter2');
+    registerSecret('hunter2extended');
+    expect(redactSecrets('login with hunter2extended now')).toBe('login with ***REDACTED*** now');
+  });
+
   it('detects credential-named keys', () => {
     expect(isSecretName('APP_PASSWORD')).toBe(true);
     expect(isSecretName('ai.apiKey')).toBe(true);

--- a/tests/unit/secrets.test.ts
+++ b/tests/unit/secrets.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { clearRegisteredSecrets, isSecretName, redactSecrets, registerSecret } from '../../src/utils/secrets';
+
+describe('secrets', () => {
+  beforeEach(() => {
+    clearRegisteredSecrets();
+  });
+
+  it('redacts a registered value', () => {
+    registerSecret('hunter2secret');
+    expect(redactSecrets('login with hunter2secret now')).toBe('login with ***REDACTED*** now');
+  });
+
+  it('passes unregistered values through unchanged', () => {
+    registerSecret('hunter2secret');
+    expect(redactSecrets('nothing to hide here')).toBe('nothing to hide here');
+  });
+
+  it('does not redact short values', () => {
+    registerSecret('12');
+    expect(redactSecrets('code 12 is fine')).toBe('code 12 is fine');
+  });
+
+  it('replaces every occurrence', () => {
+    registerSecret('topsecret');
+    expect(redactSecrets('topsecret and topsecret again')).toBe('***REDACTED*** and ***REDACTED*** again');
+  });
+
+  it('detects credential-named keys', () => {
+    expect(isSecretName('APP_PASSWORD')).toBe(true);
+    expect(isSecretName('ai.apiKey')).toBe(true);
+    expect(isSecretName('SESSION_TOKEN')).toBe(true);
+    expect(isSecretName('BASE_URL')).toBe(false);
+    expect(isSecretName('playwright.browser')).toBe(false);
+  });
+});

--- a/tests/unit/secrets.test.ts
+++ b/tests/unit/secrets.test.ts
@@ -36,6 +36,12 @@ describe('secrets', () => {
     expect(isSecretName('APP_PASSWORD')).toBe(true);
     expect(isSecretName('ai.apiKey')).toBe(true);
     expect(isSecretName('SESSION_TOKEN')).toBe(true);
+    expect(isSecretName('JWT_SIGNING_KEY')).toBe(true);
+    expect(isSecretName('AUTH_HEADER')).toBe(true);
+    expect(isSecretName('BEARER_VALUE')).toBe(true);
+    expect(isSecretName('AUTHORIZATION')).toBe(true);
+    expect(isSecretName('TLS_CERT')).toBe(true);
+    expect(isSecretName('CLIENT_CERTIFICATE')).toBe(true);
     expect(isSecretName('BASE_URL')).toBe(false);
     expect(isSecretName('playwright.browser')).toBe(false);
   });


### PR DESCRIPTION
Implements **plan 003** (`plans/003-redact-secrets-from-persistence-and-telemetry.md`) — a P1 security fix.

## Problem
Knowledge files interpolate `${env.APP_PASSWORD}` (and other `${env.*}` / `${config.*}`) into cleartext at load time. Those resolved secrets then flow into two persisted/exported sinks:
- **Langfuse trace input** (`JSON.stringify(metadata.input)` shipped to telemetry).
- **On-disk experience files** — which are routinely git-committed (the repo ships `example/experience/*`).

Separately, `${config.*}` walked the entire config object and stringified any leaf, so `${config.ai.apiKey}` silently expanded the provider API key into every prompt and both sinks.

## Fix
- New `src/utils/secrets.ts`: a process-global secret registry (`registerSecret`), `redactSecrets(text)`, `isSecretName(name)` (credential-name denylist), and `clearRegisteredSecrets()` for test isolation.
- `knowledge-tracker.ts`: the `env` branch registers credential-named values (**still returns cleartext** — the model must type the real password), and the `config` branch **blocks** credential-named keys from interpolating at all (SEC-03).
- `observability.ts` + `experience-tracker.ts`: run `redactSecrets` on the serialized telemetry string and on experience content before write. Both are single chokepoints.

## Verification
- `bun test tests/unit/secrets.test.ts tests/unit/knowledge-tracker.test.ts` → 15 pass (incl. `${config.ai.apiKey}` blocked, and `${env.APP_PASSWORD}` register→redact end-to-end)
- `bun test tests/unit` → 736 pass, 0 fail; `bun run lint` clean

## Deferred (intentional — see plan Maintenance notes)
Masking the credential in (a) the LLM request itself (needs CodeceptJS `secret()` + a prompt change), (b) the AI SDK's `experimental_telemetry` inputs, and (c) the Testomat.io reporter. **This PR is not a complete secret-masking solution** — it closes the two persisted/exported sinks we control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)