### PR TITLE
fix: abort in-flight AI request when idle timeout fires (plan 005)

### DIFF
--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -31,10 +31,10 @@ function extractCachedTokens(usage: any): number {
   return typeof fromRaw === 'number' ? fromRaw : 0;
 }
 
-function rejectAfterIdle(ms: number, signal: { cancelled: boolean }, controller: AbortController): Promise<never> {
+function abortAfterIdle(ms: number, cancel: { cancelled: boolean }, controller: AbortController): Promise<never> {
   return new Promise((_, reject) => {
     const tick = () => {
-      if (signal.cancelled) return;
+      if (cancel.cancelled) return;
       if (executionController.isAwaitingInput()) {
         setTimeout(tick, ms);
         return;
@@ -44,6 +44,12 @@ function rejectAfterIdle(ms: number, signal: { cancelled: boolean }, controller:
     };
     setTimeout(tick, ms);
   });
+}
+
+function combinedAbortSignal(controller: AbortController): AbortSignal {
+  const global = executionController.getAbortSignal();
+  if (!global) return controller.signal;
+  return AbortSignal.any([controller.signal, global]);
 }
 
 export class Provider {
@@ -359,7 +365,6 @@ export class Provider {
         ...optionsWithoutStop,
         stopWhen: stopConditions,
         model,
-        abortSignal: executionController.getAbortSignal(),
       },
       options.agentName
     );
@@ -369,7 +374,7 @@ export class Provider {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
         const controller = new AbortController();
-        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
+        const combinedSignal = combinedAbortSignal(controller);
         try {
           const result = (await Promise.race([
             generateText({
@@ -377,7 +382,7 @@ export class Provider {
               ...config,
               abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel, controller),
+            abortAfterIdle(timeout, cancel, controller),
           ])) as any;
           const hasToolCall = (result.toolCalls?.length || 0) > 0;
           if (!result.text && !hasToolCall && result.finishReason === 'length') {
@@ -448,7 +453,6 @@ export class Provider {
         ...(this.config.config || {}),
         ...options,
         model: modelToUse,
-        abortSignal: executionController.getAbortSignal(),
       },
       options.agentName
     );
@@ -460,7 +464,7 @@ export class Provider {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
         const controller = new AbortController();
-        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
+        const combinedSignal = combinedAbortSignal(controller);
         try {
           return (await Promise.race([
             generateObject({
@@ -468,7 +472,7 @@ export class Provider {
               ...config,
               abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel, controller),
+            abortAfterIdle(timeout, cancel, controller),
           ])) as any;
         } finally {
           cancel.cancelled = true;

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -47,9 +47,9 @@ function abortAfterIdle(ms: number, cancel: { cancelled: boolean }, controller: 
 }
 
 function combinedAbortSignal(controller: AbortController): AbortSignal {
-  const global = executionController.getAbortSignal();
-  if (!global) return controller.signal;
-  return AbortSignal.any([controller.signal, global]);
+  const executionSignal = executionController.getAbortSignal();
+  if (!executionSignal) return controller.signal;
+  return AbortSignal.any([controller.signal, executionSignal]);
 }
 
 export class Provider {

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -31,7 +31,7 @@ function extractCachedTokens(usage: any): number {
   return typeof fromRaw === 'number' ? fromRaw : 0;
 }
 
-function rejectAfterIdle(ms: number, signal: { cancelled: boolean }): Promise<never> {
+function rejectAfterIdle(ms: number, signal: { cancelled: boolean }, controller: AbortController): Promise<never> {
   return new Promise((_, reject) => {
     const tick = () => {
       if (signal.cancelled) return;
@@ -39,6 +39,7 @@ function rejectAfterIdle(ms: number, signal: { cancelled: boolean }): Promise<ne
         setTimeout(tick, ms);
         return;
       }
+      controller.abort();
       reject(new Error('AI request timeout'));
     };
     setTimeout(tick, ms);
@@ -367,13 +368,16 @@ export class Provider {
       const response = await withRetry(async () => {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
+        const controller = new AbortController();
+        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
         try {
           const result = (await Promise.race([
             generateText({
               messages,
               ...config,
+              abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel),
+            rejectAfterIdle(timeout, cancel, controller),
           ])) as any;
           const hasToolCall = (result.toolCalls?.length || 0) > 0;
           if (!result.text && !hasToolCall && result.finishReason === 'length') {
@@ -455,13 +459,16 @@ export class Provider {
       const response = await withRetry(async () => {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
+        const controller = new AbortController();
+        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
         try {
           return (await Promise.race([
             generateObject({
               messages,
               ...config,
+              abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel),
+            rejectAfterIdle(timeout, cancel, controller),
           ])) as any;
         } finally {
           cancel.cancelled = true;

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,9 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { ModelMessage } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
 import { AiError, Provider } from '../../src/ai/provider.js';
 import { ConfigParser } from '../../src/config.js';
 import type { AIConfig } from '../../src/config.js';
+import { executionController } from '../../src/execution-controller.js';
 import { MockAIProvider } from '../mocks/ai-provider.mock.js';
+
+function buildHangingModel(capture: { signal?: AbortSignal }): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: 'test',
+    modelId: 'hanging-model',
+    doGenerate: async (params: any) => {
+      capture.signal = params.abortSignal;
+      return await new Promise((_resolve, reject) => {
+        params.abortSignal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    },
+  });
+}
 
 function makeToolCallMessage(calls: Array<{ id: string; name: string; input: any }>): ModelMessage {
   return {
@@ -350,6 +365,42 @@ describe('Provider', () => {
       ];
       const result = (provider as any).tryReduceMessages(messages, 2);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('abort on idle timeout', () => {
+    it('aborts the in-flight request when the idle timeout fires', async () => {
+      const capture: { signal?: AbortSignal } = {};
+      const model = buildHangingModel(capture);
+      const messages: ModelMessage[] = [{ role: 'user', content: 'hi' }];
+
+      const rejected = await provider
+        .generateWithTools(messages, model, {}, { timeout: 20, maxRetries: 1 })
+        .then(() => false)
+        .catch(() => true);
+
+      expect(rejected).toBe(true);
+      expect(capture.signal?.aborted).toBe(true);
+    });
+
+    it('propagates the global execution abort through the combined signal', async () => {
+      executionController.startExecution();
+      const capture: { signal?: AbortSignal } = {};
+      const model = buildHangingModel(capture);
+      const messages: ModelMessage[] = [{ role: 'user', content: 'hi' }];
+
+      const pending = provider.generateWithTools(messages, model, {}, { timeout: 60000, maxRetries: 1 });
+      while (!capture.signal) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      executionController.interrupt();
+
+      const rejected = await pending.then(() => false).catch(() => true);
+      const aborted = capture.signal?.aborted === true;
+      executionController.reset();
+
+      expect(rejected).toBe(true);
+      expect(aborted).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Implements **plan 005** (`plans/005-abort-ai-request-on-idle-timeout.md`) — a P2 correctness/cost fix.

## Problem
The provider races every LLM call against `rejectAfterIdle(timeout)` (default 30s). When the timer wins, it rejects with `'AI request timeout'` and the retry condition retries — **but nothing aborts the original request**. The losing `generateText`/`generateObject` keeps running to completion while a retry starts, so a legitimately slow call (reasoning models, large HTML contexts) produces **duplicate concurrent LLM calls** — extra tokens/cost, and sometimes a spurious failure even though the first call would have succeeded. The only abort wired in was the process-global `executionController` signal; the per-call idle timeout cancelled nothing.

## Fix
At both race sites (`generateWithTools`, `generateObject`):
- Create a **per-attempt** `AbortController` inside the `withRetry` callback.
- Combine it with the global signal: `AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean))` (the global signal can be `undefined`, hence the filter).
- Pass `abortSignal: combinedSignal` **after** the `...config` spread so it wins.
- `rejectAfterIdle` now calls `controller.abort()` before rejecting.

## Verification
- New tests in `tests/unit/provider.test.ts`: (1) idle timeout → the in-flight SDK `abortSignal` becomes `aborted` (the regression for the duplicate-call bug); (2) the global execution abort still propagates through the combined signal.
- `bun test tests/unit` → 728 pass, 0 fail; `bun run lint` clean.
- `bun test tests/integration/planner.test.ts` (aimock, exercises the provider path) → 10 pass, 0 fail.

## Notes
- The stale `config.abortSignal` set upstream is now overridden by `combinedSignal` — harmless but dead.
- **Base branch note**: plans 007 and 017 also touch `provider.ts`; I'm stacking those PRs on top of this one to avoid conflicts.
- Deferred (per plan): making the 30s idle timeout configurable per agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)