### PR TITLE
fix: diff back navigation against pre-navigation state (plan 006)

### DIFF
--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -921,12 +921,15 @@ export function createAgentTools({
           });
         }
 
+        let previousState: ActionResult | null = null;
+        if (currentState) previousState = ActionResult.fromState(currentState);
+
         const action = explorer.createAction();
         const success = await action.attempt(`I.amOnPage(${JSON.stringify(targetUrl)})`, `${reason} (BACK to ${targetUrl})`);
 
         if (success) {
-          const previousState = ActionResult.fromState(stateManager.getCurrentState()!);
-          const toolResult = await previousState.toToolResult(previousState, `I.amOnPage("${targetUrl}")`);
+          const newState = ActionResult.fromState(stateManager.getCurrentState()!);
+          const toolResult = await newState.toToolResult(previousState, `I.amOnPage("${targetUrl}")`);
           return successToolResult('back', {
             ...toolResult,
             message: `Navigated back to ${targetUrl}`,
@@ -1273,7 +1276,7 @@ async function disambiguateElements(error: Error | null | undefined, explanation
 }
 
 function getNotFoundSuggestion(errorMessage: string): string | null {
-  if (!errorMessage.includes('was not found') && !errorMessage.includes('not found by text|CSS|XPath')) {
+  if (!errorMessage.includes('not found')) {
     return null;
   }
 

--- a/tests/unit/tools-back.test.ts
+++ b/tests/unit/tools-back.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { createAgentTools } from '../../src/ai/tools.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+function stateFixture(id: number, url: string, heading: string) {
+  return {
+    id,
+    url,
+    fullUrl: url,
+    title: heading,
+    html: `<html><body><h1>${heading}</h1><a href="/other">link</a></body></html>`,
+    ariaSnapshot: `- heading "${heading}" [level=1]`,
+  };
+}
+
+describe('back tool', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  it('diffs the post-navigation state against the pre-navigation state', async () => {
+    const before = stateFixture(1, '/page-b', 'Page B');
+    const after = stateFixture(2, '/page-a', 'Page A');
+
+    let navigated = false;
+    const stateManager = {
+      getCurrentState: () => (navigated ? after : before),
+      getStateHistory: () => [{ toState: after }],
+    };
+    const explorer = {
+      getStateManager: () => stateManager,
+      createAction: () => ({
+        attempt: async () => {
+          navigated = true;
+          return true;
+        },
+        lastError: null,
+      }),
+    };
+
+    const tools = createAgentTools({
+      explorer: explorer as any,
+      researcher: {} as any,
+      navigator: {} as any,
+      getState: () => before as any,
+    });
+
+    const result: any = await tools.back.execute({ reason: 'went to the wrong page' });
+
+    expect(result.success).toBe(true);
+    expect(result.pageDiff).not.toBeNull();
+    expect(result.pageDiff.urlChanged).toBe(true);
+    expect(result.pageDiff.currentUrl).toContain('/page-a');
+  });
+});


### PR DESCRIPTION
Implements **plan 006** (`plans/006-fix-tools-small-bugs.md`) — a P1 bug fix.

## Problem 1 — `back` tool self-diff
The `back` tool built its "previous" state *after* `action.attempt` had already navigated and called `stateManager.updateState(...)`. So `toToolResult` compared the new page against itself — equal state ids short-circuit to `pageDiff: null` — and the model got **no feedback about what going back changed**, exactly when it's trying to recover from a wrong navigation. Every other interaction tool (`click`, `hover`, `form`) reports a real `pageDiff`.

**Fix**: capture `previousState` from the pre-navigation `currentState` *before* `action.attempt`, then diff a fresh post-navigation state against it — the pattern `click` already uses. Handles `currentState === null` (`toToolResult` accepts `ActionResult | null`).

## Problem 2 — redundant not-found gate
`getNotFoundSuggestion` gated on two overlapping substrings; the second (`'not found by text|CSS|XPath'`) was fully covered by the first. Simplified to a single `'not found'` check (a literal superset; case-sensitive so `404 Not Found` won't false-positive).

## Verification
- `tests/unit/tools-back.test.ts` (new): drives `back` with a duck-typed explorer/stateManager, asserts a non-null `pageDiff` with `urlChanged: true`. **Fails against the old self-diff code**, passes now.
- `bun test tests/unit` → 727 pass, 0 fail; `bun run lint` clean.

## Notes
- The conditional-spread at the `back` failure path is left untouched (plan 016's style batch).
- **Base branch note**: plan 018 also touches `tools.ts`; I'm stacking that PR on top of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)