### PR TITLE
fix: unify tool-success mapping and honor telemetryFunctionId (plan 007)

### DIFF
--- a/src/ai/conversation.ts
+++ b/src/ai/conversation.ts
@@ -7,6 +7,12 @@ export interface ToolExecution {
   wasSuccessful: boolean;
 }
 
+export function toToolExecution(toolName: string, input: any, rawOutput: any): ToolExecution {
+  let output = rawOutput;
+  if (rawOutput?.type === 'json' && rawOutput?.value) output = rawOutput.value;
+  return { toolName, input, output, wasSuccessful: output?.success !== false };
+}
+
 export function toolExecutionLabel(input: Record<string, any> | undefined): string {
   return input?.explanation || input?.assertion || input?.reason || input?.request || '';
 }
@@ -18,15 +24,13 @@ export class Conversation {
   id: string;
   messages: ModelMessage[];
   model: any;
-  telemetryFunctionId?: string;
   protectedPrefixCount = 0;
   private autoTrimRules: Map<string, number>;
 
-  constructor(messages: ModelMessage[] = [], model?: any, telemetryFunctionId?: string) {
+  constructor(messages: ModelMessage[] = [], model?: any) {
     this.id = this.generateId();
     this.messages = messages;
     this.model = model || '';
-    this.telemetryFunctionId = telemetryFunctionId;
     this.autoTrimRules = new Map();
   }
 
@@ -83,7 +87,7 @@ export class Conversation {
   }
 
   clone(): Conversation {
-    return new Conversation([...this.messages], this.model, this.telemetryFunctionId);
+    return new Conversation([...this.messages], this.model);
   }
 
   cleanupTag(tagName: string, replacement: string, keepLast = 0): void {
@@ -243,14 +247,7 @@ export class Conversation {
       if (!Array.isArray(message.content)) continue;
       for (const part of message.content) {
         if (part.type !== 'tool-result') continue;
-        const rawOutput = part.output as Record<string, any>;
-        const output = rawOutput?.type === 'json' && rawOutput?.value ? rawOutput.value : rawOutput;
-        executions.push({
-          toolName: part.toolName,
-          input: toolCalls.get(part.toolCallId) || {},
-          output,
-          wasSuccessful: output?.success !== false,
-        });
+        executions.push(toToolExecution(part.toolName, toolCalls.get(part.toolCallId) || {}, part.output));
       }
     }
 

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -11,7 +11,7 @@ import { Stats } from '../stats.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { type RetryOptions, withRetry } from '../utils/retry.js';
 import { RulesLoader } from '../utils/rules-loader.ts';
-import { Conversation } from './conversation.js';
+import { Conversation, toToolExecution } from './conversation.js';
 
 const debugLog = createDebug('explorbot:provider');
 const promptLog = createDebug('explorbot:provider:out');
@@ -207,20 +207,25 @@ export class Provider {
 
     const runTelemetry = Observability.getTelemetry();
 
-    if (!options.telemetry) {
+    let optionTelemetry = options.telemetry;
+    if (options.telemetryFunctionId && !optionTelemetry?.functionId) {
+      optionTelemetry = { ...optionTelemetry, functionId: options.telemetryFunctionId };
+    }
+
+    if (!optionTelemetry) {
       return runTelemetry;
     }
 
     if (!runTelemetry) {
-      return options.telemetry;
+      return optionTelemetry;
     }
 
     return {
       ...runTelemetry,
-      ...options.telemetry,
+      ...optionTelemetry,
       metadata: {
         ...runTelemetry.metadata,
-        ...options.telemetry.metadata,
+        ...optionTelemetry.metadata,
       },
     };
   }
@@ -254,12 +259,8 @@ export class Provider {
     const toolCalls = response.toolCalls || [];
     const toolResults = response.toolResults || [];
 
-    const toolExecutions = toolCalls.map((call: any, index: number) => ({
-      toolName: call.toolName || '',
-      input: call.input,
-      output: toolResults[index]?.output,
-      wasSuccessful: toolResults[index]?.output?.success || false,
-    }));
+    const resultsById = new Map(toolResults.map((r: any) => [r.toolCallId, r]));
+    const toolExecutions = toolCalls.map((call: any) => toToolExecution(call.toolName || '', call.input, resultsById.get(call.toolCallId)?.output));
 
     return { conversation, response, toolExecutions };
   }

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -31,10 +31,10 @@ function extractCachedTokens(usage: any): number {
   return typeof fromRaw === 'number' ? fromRaw : 0;
 }
 
-function rejectAfterIdle(ms: number, signal: { cancelled: boolean }, controller: AbortController): Promise<never> {
+function abortAfterIdle(ms: number, cancel: { cancelled: boolean }, controller: AbortController): Promise<never> {
   return new Promise((_, reject) => {
     const tick = () => {
-      if (signal.cancelled) return;
+      if (cancel.cancelled) return;
       if (executionController.isAwaitingInput()) {
         setTimeout(tick, ms);
         return;
@@ -44,6 +44,12 @@ function rejectAfterIdle(ms: number, signal: { cancelled: boolean }, controller:
     };
     setTimeout(tick, ms);
   });
+}
+
+function combinedAbortSignal(controller: AbortController): AbortSignal {
+  const global = executionController.getAbortSignal();
+  if (!global) return controller.signal;
+  return AbortSignal.any([controller.signal, global]);
 }
 
 export class Provider {
@@ -359,7 +365,6 @@ export class Provider {
         ...optionsWithoutStop,
         stopWhen: stopConditions,
         model,
-        abortSignal: executionController.getAbortSignal(),
       },
       options.agentName
     );
@@ -369,7 +374,7 @@ export class Provider {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
         const controller = new AbortController();
-        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
+        const combinedSignal = combinedAbortSignal(controller);
         try {
           const result = (await Promise.race([
             generateText({
@@ -377,7 +382,7 @@ export class Provider {
               ...config,
               abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel, controller),
+            abortAfterIdle(timeout, cancel, controller),
           ])) as any;
           const hasToolCall = (result.toolCalls?.length || 0) > 0;
           if (!result.text && !hasToolCall && result.finishReason === 'length') {
@@ -448,7 +453,6 @@ export class Provider {
         ...(this.config.config || {}),
         ...options,
         model: modelToUse,
-        abortSignal: executionController.getAbortSignal(),
       },
       options.agentName
     );
@@ -460,7 +464,7 @@ export class Provider {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
         const controller = new AbortController();
-        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
+        const combinedSignal = combinedAbortSignal(controller);
         try {
           return (await Promise.race([
             generateObject({
@@ -468,7 +472,7 @@ export class Provider {
               ...config,
               abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel, controller),
+            abortAfterIdle(timeout, cancel, controller),
           ])) as any;
         } finally {
           cancel.cancelled = true;

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -31,7 +31,7 @@ function extractCachedTokens(usage: any): number {
   return typeof fromRaw === 'number' ? fromRaw : 0;
 }
 
-function rejectAfterIdle(ms: number, signal: { cancelled: boolean }): Promise<never> {
+function rejectAfterIdle(ms: number, signal: { cancelled: boolean }, controller: AbortController): Promise<never> {
   return new Promise((_, reject) => {
     const tick = () => {
       if (signal.cancelled) return;
@@ -39,6 +39,7 @@ function rejectAfterIdle(ms: number, signal: { cancelled: boolean }): Promise<ne
         setTimeout(tick, ms);
         return;
       }
+      controller.abort();
       reject(new Error('AI request timeout'));
     };
     setTimeout(tick, ms);
@@ -367,13 +368,16 @@ export class Provider {
       const response = await withRetry(async () => {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
+        const controller = new AbortController();
+        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
         try {
           const result = (await Promise.race([
             generateText({
               messages,
               ...config,
+              abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel),
+            rejectAfterIdle(timeout, cancel, controller),
           ])) as any;
           const hasToolCall = (result.toolCalls?.length || 0) > 0;
           if (!result.text && !hasToolCall && result.finishReason === 'length') {
@@ -455,13 +459,16 @@ export class Provider {
       const response = await withRetry(async () => {
         const timeout = config.timeout || 30000;
         const cancel = { cancelled: false };
+        const controller = new AbortController();
+        const combinedSignal = AbortSignal.any([controller.signal, executionController.getAbortSignal()].filter(Boolean) as AbortSignal[]);
         try {
           return (await Promise.race([
             generateObject({
               messages,
               ...config,
+              abortSignal: combinedSignal,
             }),
-            rejectAfterIdle(timeout, cancel),
+            rejectAfterIdle(timeout, cancel, controller),
           ])) as any;
         } finally {
           cancel.cancelled = true;

--- a/tests/unit/conversation.test.ts
+++ b/tests/unit/conversation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { Conversation } from '../../src/ai/conversation';
+import { Conversation, toToolExecution } from '../../src/ai/conversation';
 
 describe('Conversation', () => {
   describe('cleanupTag', () => {
@@ -403,6 +403,30 @@ describe('Conversation', () => {
 
       const output: any = (conversation.messages[0].content as any)[0].output.value;
       expect(output.pageDiff.htmlParts).toBeDefined();
+    });
+  });
+
+  describe('toToolExecution', () => {
+    it('unwraps the {type:json, value} envelope', () => {
+      const exec = toToolExecution('click', { locator: 'Save' }, { type: 'json', value: { success: true, url: '/x' } });
+      expect(exec.output).toEqual({ success: true, url: '/x' });
+      expect(exec.wasSuccessful).toBe(true);
+    });
+
+    it('defaults missing success to true', () => {
+      const exec = toToolExecution('getVisitedStates', {}, { states: ['/a', '/b'] });
+      expect(exec.wasSuccessful).toBe(true);
+    });
+
+    it('respects explicit success: false', () => {
+      const exec = toToolExecution('click', { locator: 'Save' }, { success: false, message: 'not found' });
+      expect(exec.wasSuccessful).toBe(false);
+    });
+
+    it('handles a missing output', () => {
+      const exec = toToolExecution('click', { locator: 'Save' }, undefined);
+      expect(exec.wasSuccessful).toBe(true);
+      expect(exec.output).toBeUndefined();
     });
   });
 });

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -368,6 +368,20 @@ describe('Provider', () => {
     });
   });
 
+  describe('getTelemetry', () => {
+    it('honors the telemetryFunctionId option shorthand', () => {
+      (provider as any).telemetryEnabled = true;
+      const telemetry = (provider as any).getTelemetry({ telemetryFunctionId: 'researcher.textContent' });
+      expect(telemetry?.functionId).toBe('researcher.textContent');
+    });
+
+    it('lets an explicit telemetry.functionId win over the shorthand', () => {
+      (provider as any).telemetryEnabled = true;
+      const telemetry = (provider as any).getTelemetry({ telemetry: { functionId: 'explicit' }, telemetryFunctionId: 'shorthand' });
+      expect(telemetry?.functionId).toBe('explicit');
+    });
+  });
+
   describe('abort on idle timeout', () => {
     it('aborts the in-flight request when the idle timeout fires', async () => {
       const capture: { signal?: AbortSignal } = {};

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,9 +1,24 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { ModelMessage } from 'ai';
+import { MockLanguageModelV3 } from 'ai/test';
 import { AiError, Provider } from '../../src/ai/provider.js';
 import { ConfigParser } from '../../src/config.js';
 import type { AIConfig } from '../../src/config.js';
+import { executionController } from '../../src/execution-controller.js';
 import { MockAIProvider } from '../mocks/ai-provider.mock.js';
+
+function buildHangingModel(capture: { signal?: AbortSignal }): MockLanguageModelV3 {
+  return new MockLanguageModelV3({
+    provider: 'test',
+    modelId: 'hanging-model',
+    doGenerate: async (params: any) => {
+      capture.signal = params.abortSignal;
+      return await new Promise((_resolve, reject) => {
+        params.abortSignal?.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+    },
+  });
+}
 
 function makeToolCallMessage(calls: Array<{ id: string; name: string; input: any }>): ModelMessage {
   return {
@@ -350,6 +365,42 @@ describe('Provider', () => {
       ];
       const result = (provider as any).tryReduceMessages(messages, 2);
       expect(result).toBeNull();
+    });
+  });
+
+  describe('abort on idle timeout', () => {
+    it('aborts the in-flight request when the idle timeout fires', async () => {
+      const capture: { signal?: AbortSignal } = {};
+      const model = buildHangingModel(capture);
+      const messages: ModelMessage[] = [{ role: 'user', content: 'hi' }];
+
+      const rejected = await provider
+        .generateWithTools(messages, model, {}, { timeout: 20, maxRetries: 1 })
+        .then(() => false)
+        .catch(() => true);
+
+      expect(rejected).toBe(true);
+      expect(capture.signal?.aborted).toBe(true);
+    });
+
+    it('propagates the global execution abort through the combined signal', async () => {
+      executionController.startExecution();
+      const capture: { signal?: AbortSignal } = {};
+      const model = buildHangingModel(capture);
+      const messages: ModelMessage[] = [{ role: 'user', content: 'hi' }];
+
+      const pending = provider.generateWithTools(messages, model, {}, { timeout: 60000, maxRetries: 1 });
+      while (!capture.signal) {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+      executionController.interrupt();
+
+      const rejected = await pending.then(() => false).catch(() => true);
+      const aborted = capture.signal?.aborted === true;
+      executionController.reset();
+
+      expect(rejected).toBe(true);
+      expect(aborted).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Implements **plan 007** (`plans/007-unify-tool-success-and-telemetry.md`) — a P1 bug fix.

> **Stacked PR** — base branch is `fix/abort-ai-request-on-timeout` (plan 005), because both touch `provider.ts`. Review/merge #73 first; this diff shows only plan 007's changes.

## Problem 1 — two classifiers disagree
`Provider.invokeConversation` paired tool calls with results **by array position** and defaulted a missing `success` field to **failed**. `Conversation.getToolExecutions` paired **by `toolCallId`**, unwrapped the AI-SDK `{type:json,value}` envelope, and defaulted to **passed**. Tester consumes the former, Pilot's session log the latter — so Pilot could review a step as "succeeded" that Tester counted as failed. Positional pairing also mis-attributes outputs if the SDK returns results out of order.

**Fix**: one exported `toToolExecution(toolName, input, rawOutput)` owns the unwrap + `success !== false` default; both sites route through it. `invokeConversation` now pairs by `toolCallId` via a `Map`. Data-shaped tools with no `success` field now count as successful in both views (matching what Pilot already trusted — action/assertion tools always return explicit `success` via `successToolResult`/`failedToolResult`, so stuck-detection is unaffected).

## Problem 2 — dead `telemetryFunctionId` option
Ten call sites passed `telemetryFunctionId` expecting a named Langfuse trace, but `getTelemetry` only read `options.telemetry`. Normalized the shorthand into `{ functionId }` (explicit `telemetry.functionId` still wins). Deleted the never-read `Conversation.telemetryFunctionId` field/param/clone-arg.

## Verification
- `toToolExecution` unit tests (unwrap, default-true, explicit-false, missing output) + `getTelemetry` tests (shorthand honored, explicit wins).
- `bun test tests/unit` → 734 pass, 0 fail; `bun run lint` clean.
- `bun test tests/integration/planner.test.ts` (exercises the tester tool loop through `invokeConversation`) → 10 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)