### PR TITLE
fix: read experience sections from the directory they were found in (plan 011)

### DIFF
--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -98,7 +98,10 @@ export class ExperienceTracker {
   }
 
   readExperienceFile(stateHash: string): { content: string; data: any } {
-    const filePath = this.getExperienceFilePath(stateHash);
+    return this.readExperienceFileAt(this.getExperienceFilePath(stateHash));
+  }
+
+  private readExperienceFileAt(filePath: string): { content: string; data: any } {
     const fileContent = readFileSync(filePath, 'utf8');
     const { content, data } = matter(fileContent);
     return { content, data };
@@ -325,21 +328,7 @@ export class ExperienceTracker {
       return aHash.localeCompare(bHash);
     });
 
-    const toc: ExperienceTocEntry[] = [];
-    for (let i = 0; i < sorted.length; i++) {
-      const record = sorted[i];
-      const fileHash = basename(record.filePath, '.md');
-      const url = (record.data as WebPageState)?.url || '';
-      const sections = listTocHeadings(record.content);
-      if (sections.length === 0) continue;
-      toc.push({
-        fileTag: indexToLetters(i),
-        fileHash,
-        url,
-        sections,
-      });
-    }
-    return toc;
+    return this.buildToc(sorted);
   }
 
   getExperienceSection(fileTag: string, sectionIndex: number, state: ActionResult, options?: { includeDescendantExperience?: boolean }): { title: string; url: string; content: string } | null {
@@ -347,14 +336,32 @@ export class ExperienceTracker {
     const entry = toc.find((e) => e.fileTag === fileTag);
     if (!entry) return null;
 
-    const filePath = this.findExperienceFileByHash(entry.fileHash);
-    if (!filePath) return null;
-
-    const { content } = this.readExperienceFile(entry.fileHash);
-    const extracted = extractHeadingSection(content, sectionIndex);
+    const extracted = this.readSectionByHash(entry.fileHash, sectionIndex);
     if (!extracted) return null;
 
     return { title: extracted.title, url: entry.url, content: extracted.body };
+  }
+
+  private buildToc(records: ExperienceFile[]): ExperienceTocEntry[] {
+    const toc: ExperienceTocEntry[] = [];
+    for (const record of records) {
+      const sections = listTocHeadings(record.content);
+      if (sections.length === 0) continue;
+      toc.push({
+        fileTag: indexToLetters(toc.length),
+        fileHash: basename(record.filePath, '.md'),
+        url: (record.data as WebPageState)?.url || '',
+        sections,
+      });
+    }
+    return toc;
+  }
+
+  private readSectionByHash(fileHash: string, sectionIndex: number): { title: string; body: string } | null {
+    const filePath = this.findExperienceFileByHash(fileHash);
+    if (!filePath) return null;
+    const { content } = this.readExperienceFileAt(filePath);
+    return extractHeadingSection(content, sectionIndex);
   }
 
   private findExperienceFileByHash(fileHash: string): string | null {
@@ -401,19 +408,7 @@ export class ExperienceTracker {
       return aUrl.localeCompare(bUrl);
     });
 
-    const toc: ExperienceTocEntry[] = [];
-    for (let i = 0; i < sorted.length; i++) {
-      const record = sorted[i];
-      const sections = listTocHeadings(record.content);
-      if (sections.length === 0) continue;
-      toc.push({
-        fileTag: indexToLetters(toc.length),
-        fileHash: basename(record.filePath, '.md'),
-        url: (record.data as WebPageState)?.url || '',
-        sections,
-      });
-    }
-    return toc;
+    return this.buildToc(sorted);
   }
 
   getExperienceSectionByTag(fileTag: string, sectionIndex: number, filter?: string): { title: string; url: string; content: string; fileHash: string } | null {
@@ -421,11 +416,7 @@ export class ExperienceTracker {
     const entry = toc.find((e) => e.fileTag === fileTag);
     if (!entry) return null;
 
-    const filePath = this.findExperienceFileByHash(entry.fileHash);
-    if (!filePath) return null;
-
-    const { content } = this.readExperienceFile(entry.fileHash);
-    const extracted = extractHeadingSection(content, sectionIndex);
+    const extracted = this.readSectionByHash(entry.fileHash, sectionIndex);
     if (!extracted) return null;
 
     return { title: extracted.title, url: entry.url, content: extracted.body, fileHash: entry.fileHash };

--- a/tests/unit/experience-tracker.test.ts
+++ b/tests/unit/experience-tracker.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import matter from 'gray-matter';
 import { ActionResult } from '../../src/action-result';
 import { ConfigParser } from '../../src/config';
 import { ExperienceTracker } from '../../src/experience-tracker';
@@ -302,6 +304,61 @@ describe('ExperienceTracker', () => {
 
         expect(data.url).toBe(testCase.expectedPath);
       }
+    });
+  });
+
+  describe('section lookup across directories', () => {
+    const secondaryRoot = '/tmp/explorbot-secondary-exp';
+    const secondaryExpDir = join(secondaryRoot, 'experience');
+    const savedInitialCwd = process.env.INITIAL_CWD;
+    const secondaryHash = 'secondarystate';
+    const sectionBody = ['## ACTION: do a thing', '', '```js', "I.click('Save')", '```', ''].join('\n');
+
+    beforeEach(() => {
+      rmSync(secondaryRoot, { recursive: true, force: true });
+      mkdirSync(secondaryExpDir, { recursive: true });
+      writeFileSync(join(secondaryExpDir, `${secondaryHash}.md`), matter.stringify(sectionBody, { url: '/secondary-page' }), 'utf8');
+      process.env.INITIAL_CWD = secondaryRoot;
+    });
+
+    afterEach(() => {
+      process.env.INITIAL_CWD = savedInitialCwd;
+      rmSync(secondaryRoot, { recursive: true, force: true });
+    });
+
+    it('reads a section from a secondary experience directory via getExperienceSectionByTag', () => {
+      const toc = experienceTracker.listAllExperienceToc();
+      const entry = toc.find((e) => e.fileHash === secondaryHash);
+      expect(entry).toBeDefined();
+
+      const section = experienceTracker.getExperienceSectionByTag(entry!.fileTag, 1);
+      expect(section).not.toBeNull();
+      expect(section!.content).toContain("I.click('Save')");
+    });
+
+    it('reads a section from a secondary directory via getExperienceSection when the state matches', () => {
+      const state = new ActionResult({ url: '/secondary-page' });
+      const toc = experienceTracker.getExperienceTableOfContents(state);
+      const entry = toc.find((e) => e.fileHash === secondaryHash);
+      expect(entry).toBeDefined();
+
+      const section = experienceTracker.getExperienceSection(entry!.fileTag, 1, state);
+      expect(section).not.toBeNull();
+      expect(section!.content).toContain("I.click('Save')");
+    });
+  });
+
+  describe('table-of-contents lettering', () => {
+    it('assigns contiguous fileTags when a zero-section file sorts first', () => {
+      const url = '/lettering-page';
+      writeFileSync(join(testDir, 'aaa.md'), matter.stringify('Just a note, no headings here.', { url }), 'utf8');
+      writeFileSync(join(testDir, 'bbb.md'), matter.stringify(['## ACTION: do it', '', '```js', "I.click('x')", '```', ''].join('\n'), { url }), 'utf8');
+
+      const toc = experienceTracker.getExperienceTableOfContents(new ActionResult({ url }));
+
+      expect(toc).toHaveLength(1);
+      expect(toc[0].fileHash).toBe('bbb');
+      expect(toc[0].fileTag).toBe('A');
     });
   });
 });


### PR DESCRIPTION
Implements **plan 011** (`plans/011-fix-experience-section-lookup.md`) — a P1 bug + dedup fix.

## Problem
`ExperienceTracker` reads experience from up to **three** directories (configured dir, `$CWD/experience`, `$INITIAL_CWD/experience`) via `findExperienceFileByHash()`. But the section getters threw away the found path and re-read by hash via `readExperienceFile()`, which resolves **only** against the primary dir. For any experience file living in a **secondary** dir, the existence check passed and the read then threw uncaught `ENOENT` — from inside the `learnExperience` AI tool and the `/experience` command. The AI was shown a TOC entry it could never open.

## Fix
- Route both `getExperienceSection` and `getExperienceSectionByTag` through a shared `readSectionByHash()` that reads from the path `findExperienceFileByHash()` returned (via a new `readExperienceFileAt(path)`; `readExperienceFile(hash)` now delegates to it — one read implementation).
- Collapse the two near-verbatim TOC builders (`getExperienceTableOfContents` / `listAllExperienceToc`) onto one `buildToc(records)` helper. Each caller keeps its own sort (by fileHash vs URL). Lettering is now **contiguous** for both (`indexToLetters(toc.length)`) — previously `getExperienceTableOfContents` left letter gaps (`A, C`) when a file had zero sections; now `A, B`. Both the prompt render and the `learnExperience` resolution derive from the same builder, so they stay consistent.

## Verification
- New `section lookup across directories` tests: read a section from a secondary dir via **both** getter variants. Confirmed these **fail with ENOENT on the old code** (via `git stash` of the fix) and pass now.
- New `table-of-contents lettering` test: zero-section file sorting first → surviving file gets `A`, not `B`.
- `bun test tests/unit` → 729 pass, 0 fail; `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)