### PR TITLE
fix: record executed code on state transitions, update state once per action (plan 008)

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -73,7 +73,7 @@ class Action {
     }
   }
 
-  async capturePageState({ includeScreenshot = false }: { includeScreenshot?: boolean } = {}): Promise<ActionResult> {
+  async capturePageState({ includeScreenshot = false, codeBlock }: { includeScreenshot?: boolean; codeBlock?: string } = {}): Promise<ActionResult> {
     try {
       const currentState = this.stateManager.getCurrentState();
       const stateHash = currentState?.hash || 'screenshot';
@@ -166,7 +166,7 @@ class Action {
         ariaSnapshotFile,
         iframeURL: frame ? frame.url?.() || 'iframe' : undefined,
       });
-      this.stateManager.updateState(result);
+      this.stateManager.updateState(result, codeBlock);
       return result;
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -313,12 +313,11 @@ class Action {
         await recorder.promise();
       }
 
-      const pageState = await this.capturePageState();
       if (executedSteps.length > 0) {
         codeString = executedSteps.join('\n');
       }
 
-      this.stateManager.updateState(pageState, codeString);
+      const pageState = await this.capturePageState({ codeBlock: codeString });
 
       this.actionResult = pageState;
       this.assertionSteps = assertionSteps;


### PR DESCRIPTION
Implements **plan 008** (`plans/008-single-state-update-per-action.md`) — a P2 bug/refactor on the hot path.

## Problem
Every `Action.execute()` updated the state manager **twice** with the same `ActionResult`:
1. Inside `capturePageState()` — recorded the transition, but with `codeBlock: ''` (the executed code wasn't passed down).
2. `execute()` — carried the real `codeString`, but by then `currentState` **is** that same object, so `hashChanged` is false, `hasDialogAppeared` re-runs on identical snapshots and returns false, and **no transition is recorded**.

Net effect: `StateTransition.codeBlock` was `''` for every action-triggered transition, `nextStateId` burned two ids per action, and dialog detection ran twice. Knowing which code caused a transition is the whole point of the field — consumers (historian, pilot diagnostics) couldn't rely on it.

## Fix
- Thread the code block through `capturePageState({ codeBlock })` to its **single** `updateState(result, codeBlock)` call.
- Reorder `execute()` so the final (step-rewritten) `codeString` exists **before** capture, and delete the redundant second `updateState`. `executedSteps` is filled synchronously during execution and is complete before this point.

All other `capturePageState` callers pass no `codeBlock` → `undefined` → identical prior behavior.

## Verification
- `grep -c updateState src/action.ts` → 1.
- Existing `state-manager.test.ts` / `state-manager-events.test.ts` pin `updateState`'s `codeBlock` contract — still green.
- `bun test tests/unit` → 726 pass, 0 fail; `bun run lint` clean.
- `bun test tests/integration/researcher-browser.test.ts` (drives real `Action.execute` with a browser) → 2 pass, 0 fail.

No action-level unit test added — `Action` requires a live CodeceptJS container (per plan); the grep + state-manager contract tests + the browser integration are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)