### PR TITLE
fix: load existing suite before building planner conversation; fix planner DI (plan 013)

### DIFF
--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import { ActionResult } from '../action-result.ts';
 import { setActivity } from '../activity.ts';
 import { ConfigParser } from '../config.ts';
-import { ExperienceTracker } from '../experience-tracker.ts';
+import type { ExperienceTracker } from '../experience-tracker.ts';
 import type Explorer from '../explorer.ts';
 import { Observability } from '../observability.ts';
 import type { StateManager } from '../state-manager.js';
@@ -63,13 +63,13 @@ export class Planner extends PlannerBase implements Agent {
   researcher: Researcher;
   private fisherman: Fisherman | null = null;
 
-  constructor(explorer: Explorer, provider: Provider) {
+  constructor(explorer: Explorer, provider: Provider, researcher: Researcher) {
     super();
     this.explorer = explorer;
     this.provider = provider;
-    this.researcher = new Researcher(explorer, provider);
+    this.researcher = researcher;
     this.stateManager = explorer.getStateManager();
-    this.experienceTracker = new ExperienceTracker();
+    this.experienceTracker = explorer.getStateManager().getExperienceTracker();
   }
 
   setFisherman(fisherman: Fisherman): void {
@@ -171,6 +171,9 @@ export class Planner extends PlannerBase implements Agent {
 
     const tags = ['planner'];
     if (style) tags.push(style);
+
+    const existingTestScenarios = this.getExistingTestFileScenarios(state.url);
+
     const result = await Observability.run(`planner: ${state.url}`, { tags, sessionId: state.url }, async () => {
       const actionResult = ActionResult.fromState(state);
       const conversation = await this.buildConversation(actionResult, style, parentPlan, feature);
@@ -211,7 +214,6 @@ export class Planner extends PlannerBase implements Agent {
       const defaultStartUrl = this.getDefaultStartUrl(state);
       if (parentPlan) this.currentPlan.parentPlan = parentPlan;
       const allPreviousScenarios = this.getPreviousSessionScenarios();
-      const existingTestScenarios = this.getExistingTestFileScenarios(state.url);
       for (const s of existingTestScenarios) allPreviousScenarios.add(s);
       for (const t of tests) {
         if (allPreviousScenarios.has(t.scenario.toLowerCase())) continue;

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -21,7 +21,7 @@ import { WithSessionDedup } from './planner/session-dedup.ts';
 import { getActiveStyle, getStyles } from './planner/styles.ts';
 import { WithSubPages, getPlannedByStateHash, getRegisteredPlan, registerPlan } from './planner/subpages.ts';
 import type { Provider } from './provider.js';
-import { POSSIBLE_SECTIONS, Researcher } from './researcher.ts';
+import { POSSIBLE_SECTIONS, type Researcher } from './researcher.ts';
 import { findSimilarStateHash } from './researcher/cache.ts';
 import { hasFocusedSection } from './researcher/focus.ts';
 import { capabilityGroundingRule, dataProtectionRules, fileUploadRule } from './rules.ts';
@@ -268,6 +268,7 @@ export class Planner extends PlannerBase implements Agent {
   }
 
   private getExistingTestFileScenarios(currentUrl?: string): Set<string> {
+    this.lastSuite = null;
     if (!currentUrl) return new Set<string>();
     try {
       this.lastSuite = new Suite(currentUrl);

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -194,7 +194,7 @@ export class ExplorBot {
 
   agentPlanner(): Planner {
     if (!this.agents.planner) {
-      this.agents.planner = this.createAgent(({ ai, explorer }) => new Planner(explorer, ai));
+      this.agents.planner = this.createAgent(({ ai, explorer }) => new Planner(explorer, ai, this.agentResearcher()));
       const fisherman = this.agentFisherman();
       if (fisherman) this.agents.planner.setFisherman(fisherman);
     }

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -124,9 +124,7 @@ describe('Planner with aimock', () => {
     clearSessionDedup();
     clearStyleCache();
 
-    planner = new Planner(createMockExplorer(), provider);
-    planner.researcher = { research: async () => taskBoardUiMap } as any;
-    (planner as any).experienceTracker = { getSuccessfulExperience: () => [] };
+    planner = new Planner(createMockExplorer(), provider, { research: async () => taskBoardUiMap } as any);
 
     mock.on({}, { content: JSON.stringify(defaultScenarios) });
   });
@@ -149,6 +147,25 @@ describe('Planner with aimock', () => {
     expect(first.expected).toEqual(['New task card appears in To Do column', 'Success notification is shown']);
     expect(first.plannedSteps).toEqual(['Click Create Task button', 'Fill in Task title', 'Select Assignee', 'Click Save']);
     expect(first.startUrl).toBe('/tasks/board');
+  });
+
+  it('loads the existing test suite before building the conversation', async () => {
+    const order: string[] = [];
+    const origLoad = (planner as any).getExistingTestFileScenarios.bind(planner);
+    const origBuild = (planner as any).buildConversation.bind(planner);
+    (planner as any).getExistingTestFileScenarios = (...args: any[]) => {
+      order.push('load');
+      return origLoad(...args);
+    };
+    (planner as any).buildConversation = (...args: any[]) => {
+      order.push('build');
+      return origBuild(...args);
+    };
+
+    await planner.plan();
+
+    expect(order.indexOf('load')).toBe(0);
+    expect(order.indexOf('build')).toBeGreaterThan(order.indexOf('load'));
   });
 
   it('passes UI map elements in page_research prompt', async () => {


### PR DESCRIPTION
Implements **plan 013** (`plans/013-planner-order-and-di.md`) — a P2 bug + DI fix.

## Problem 1 — ordering bug
The planning prompt's `<existing_automated_tests>` block ("do not propose tests that duplicate these") is built inside `buildConversation` from `this.lastSuite` — but `lastSuite` was only populated by `getExistingTestFileScenarios()`, which ran **after** the AI call and only in the fresh-plan branch. So on the **first** `plan()` of a session the block was silently skipped (already-automated scenarios got re-proposed, then filtered out post-hoc — wasted plan slots), and on **expansion** calls it showed the *previous* invocation's suite.

**Fix**: hoist `getExistingTestFileScenarios(state.url)` to before the `Observability.run` / `buildConversation` block and reuse the hoisted set. The block is now fresh on every `plan()` — the intended, strictly-more-correct behavior.

## Problem 2 — DI violations
The constructor did `new Researcher(...)` and `new ExperienceTracker()`, violating CLAUDE.md's shared-instance rules (a second Researcher carries its own state; a second tracker means a divergent cache).

**Fix**: inject `Researcher` as a 3rd constructor arg, wired via `this.agentResearcher()` in `explorbot.ts` (same pattern as `agentPilot`), and obtain the tracker from `explorer.getStateManager().getExperienceTracker()`. `ExperienceTracker` import is now `import type`.

## Verification
- New test pins the ordering: `getExistingTestFileScenarios` is invoked before `buildConversation`. (This is the plan's sanctioned unit-level fallback — it pins call order, not that the block renders; seeding a real `Suite` in the aimock harness needs generated CodeceptJS files, disproportionately heavy.)
- `bun test tests/integration/planner.test.ts` → 11 pass; full `bun test tests/integration/` → 63 pass; `bun test tests/unit` → 726 pass, 0 fail; `bun run lint` clean.
- `grep`: no `new Researcher`/`new ExperienceTracker` in planner.ts; `new Planner(` only at `explorbot.ts` + the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)