### PR TITLE
fix: honor --incognito by disabling the experience tracker (plan 009)

### DIFF
--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -87,8 +87,8 @@ export class StateManager {
   private knowledgeDir: string;
   private nextStateId = 1;
 
-  constructor() {
-    this.experienceTracker = new ExperienceTracker();
+  constructor(options: { incognito?: boolean } = {}) {
+    this.experienceTracker = new ExperienceTracker({ disabled: options.incognito });
     const configParser = ConfigParser.getInstance();
     const config = configParser.getConfig();
     const configPath = configParser.getConfigPath();

--- a/tests/unit/state-manager.test.ts
+++ b/tests/unit/state-manager.test.ts
@@ -40,6 +40,15 @@ describe('StateManager', () => {
     it('should have zero listeners initially', () => {
       expect(stateManager.getListenerCount()).toBe(0);
     });
+
+    it('disables the experience tracker in incognito mode', () => {
+      const incognito = new StateManager({ incognito: true });
+      expect((incognito.getExperienceTracker() as any).disabled).toBe(true);
+    });
+
+    it('leaves the experience tracker enabled by default', () => {
+      expect((stateManager.getExperienceTracker() as any).disabled).toBe(false);
+    });
   });
 
   describe('updateState', () => {


### PR DESCRIPTION
Implements **plan 009** (`plans/009-*.md`) as a standalone PR off `main`.

`explorbot --incognito` ("run without recording experiences") flowed CLI → ExplorBot → Explorer, and Explorer called `new StateManager({ incognito })` — but `StateManager`'s constructor took **no parameters**, so the flag was silently dropped and the `ExperienceTracker` stayed enabled. Incognito runs read and wrote `./experience` like normal runs.

## Fix
Thread `incognito` into the `StateManager` constructor and pass `{ disabled: options.incognito }` to `ExperienceTracker` (which already supports `disabled`). Argument-less constructions keep today's enabled behavior via `options.disabled ?? false`.

## Verification
`bun test tests/unit` → **757 pass, 0 fail** (incl. 2 new incognito tests); `bunx tsc --noEmit` → 723.

## Note
This is the clean re-do of the mistakenly-stacked #78. It touches only the `StateManager` constructor signature + the `ExperienceTracker` line; plan 010 (#separate PR) touches the same constructor to add `knowledgeTracker`, so whichever of the two merges second needs a one-line constructor merge (`{ incognito?, knowledgeTracker? }`). Both are independently valid off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)