### PR TITLE
chore: dead-code sweep steps 7-10 (agents + trackers)

### DIFF
--- a/src/ai/captain.ts
+++ b/src/ai/captain.ts
@@ -145,15 +145,6 @@ export class Captain extends CaptainBase implements Agent {
     return this.conversation;
   }
 
-  getConversation(): Conversation | null {
-    return this.conversation;
-  }
-
-  cleanConversation(): void {
-    this.conversation = null;
-    tag('info').log('Conversation cleaned');
-  }
-
   private async getPageContext(): Promise<string> {
     const state = this.explorBot.getExplorer().getStateManager().getCurrentState();
     if (!state) {

--- a/src/ai/driller.ts
+++ b/src/ai/driller.ts
@@ -28,7 +28,6 @@ import { createDebug, tag } from '../utils/logger.ts';
 import { loop, pause } from '../utils/loop.ts';
 import { WebElement } from '../utils/web-element.ts';
 import type { Agent } from './agent.ts';
-import type { Conversation } from './conversation.ts';
 import type { Navigator } from './navigator.ts';
 import type { Provider } from './provider.ts';
 import { locatorRule } from './rules.ts';
@@ -85,7 +84,6 @@ export class Driller extends TaskAgent implements Agent {
   private navigator: Navigator;
   private hooksRunner: HooksRunner;
   private currentPlan?: Plan;
-  private currentConversation: Conversation | null = null;
   private allResults: InteractionResult[] = [];
   private verifiedAction: { componentId: string; toolName: string; code?: string; canonicalCode?: string } | null = null;
   private pendingNestedContext: string | null = null;
@@ -323,7 +321,6 @@ export class Driller extends TaskAgent implements Agent {
     this.verifiedAction = null;
     this.pendingNestedContext = null;
     const conversation = this.provider.startConversation(this.getSystemMessage(component), 'driller');
-    this.currentConversation = conversation;
     conversation.addUserText(await this.buildComponentPrompt(originalState, component));
 
     let finished = false;
@@ -788,14 +785,6 @@ export class Driller extends TaskAgent implements Agent {
       const status = test.isSuccessful ? 'PASS' : test.isSkipped ? 'SKIP' : 'FAIL';
       tag('step').log(`  ${status} ${componentTest.component?.name || test.scenario}`);
     }
-  }
-
-  getCurrentPlan(): Plan | undefined {
-    return this.currentPlan;
-  }
-
-  getConversation(): Conversation | null {
-    return this.currentConversation;
   }
 }
 

--- a/src/ai/experience-compactor.ts
+++ b/src/ai/experience-compactor.ts
@@ -12,8 +12,6 @@ import type { Provider } from './provider.js';
 
 const debugLog = createDebug('explorbot:experience-compactor');
 
-export type { ExperienceFile };
-
 interface MergeGroup {
   pattern: string;
   files: ExperienceFile[];

--- a/src/ai/fisherman.ts
+++ b/src/ai/fisherman.ts
@@ -44,10 +44,6 @@ export class Fisherman implements Agent {
     return this.mode !== 'disabled';
   }
 
-  getMode(): string {
-    return this.mode;
-  }
-
   async ensureReady(scopeUrl?: string): Promise<void> {
     await this.detectMode(scopeUrl);
     this.spec ??= await this.specLoader();

--- a/src/ai/historian.ts
+++ b/src/ai/historian.ts
@@ -13,8 +13,6 @@ import { type PlaywrightMethods, WithPlaywright } from './historian/playwright.t
 import { type ScreencastMethods, WithScreencast } from './historian/screencast.ts';
 import type { Provider } from './provider.ts';
 
-export { isNonReusableCode } from '../utils/step-analyzer.ts';
-
 const HistorianBase = WithScreencast(WithPlaywright(WithCodeceptJS(WithExperience(Object as unknown as new (...args: any[]) => object))));
 
 export interface Historian extends ExperienceMethods, CodeceptJSMethods, PlaywrightMethods, ScreencastMethods {}
@@ -52,11 +50,10 @@ export class Historian extends HistorianBase {
     return this.isPlaywrightFramework() ? this.savePlaywrightPlanToFile(plan) : this.saveCodeceptPlanToFile(plan);
   }
 
-  rewriteScenarioInFile(filePath: string, healedSteps: Array<{ test: string; original: string; healed: string }>): void {
+  rewriteScenarioInFile(filePath: string, healedSteps: Array<{ original: string; healed: string }>): void {
     let content = readFileSync(filePath, 'utf-8');
 
     for (const step of healedSteps) {
-      if (!content.includes(step.original)) continue;
       content = content.replace(step.original, step.healed);
     }
 

--- a/src/ai/historian/utils.ts
+++ b/src/ai/historian/utils.ts
@@ -1,5 +1,4 @@
 import type { ToolExecution } from '../conversation.ts';
-export { isNonReusableCode, stripComments } from '../../utils/step-analyzer.ts';
 
 export function escapeString(str: string): string {
   return str.replace(/'/g, "\\'").replace(/\n/g, ' ');

--- a/src/ai/rerunner.ts
+++ b/src/ai/rerunner.ts
@@ -20,7 +20,6 @@ import { Task, Test, TestResult } from '../test-plan.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
 import { RulesLoader } from '../utils/rules-loader.ts';
-import { loadTestSuites, printTestList } from '../utils/test-files.ts';
 import type { Agent } from './agent.ts';
 import { toolExecutionLabel } from './conversation.ts';
 import type { Navigator } from './navigator.ts';
@@ -38,7 +37,7 @@ export class Rerunner extends TaskAgent implements Agent {
   private explorer: Explorer;
   private provider: Provider;
   private agentTools: any;
-  private healedSteps: Array<{ test: string; original: string; healed: string }> = [];
+  private healedSteps: Array<{ original: string; healed: string }> = [];
   private traceDir = '';
   private static pluginsWired = false;
 
@@ -75,10 +74,6 @@ export class Rerunner extends TaskAgent implements Agent {
 
   private get healMaxIterations(): number {
     return this.rerunnerConfig.healMaxIterations ?? 3;
-  }
-
-  listTests(testsDir: string): void {
-    printTestList(loadTestSuites(testsDir));
   }
 
   async rerun(filePath: string, options?: { testIndices?: number[] }): Promise<RerunResult> {
@@ -436,7 +431,7 @@ export class Rerunner extends TaskAgent implements Agent {
         throw new Error(`Could not heal: ${failedCode}`);
       }
 
-      this.healedSteps.push({ test: '', original: failedCode, healed: healedCommand });
+      this.healedSteps.push({ original: failedCode, healed: healedCommand });
       console.log(chalk.green(`    ${figureSet.tick} Healed: ${healedCommand}`));
     };
   }

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -1,4 +1,3 @@
-import { join } from 'node:path';
 import dedent from 'dedent';
 import { ActionResult } from '../action-result.js';
 import { setActivity } from '../activity.ts';

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -544,39 +544,6 @@ export class Researcher extends ResearcherBase implements Agent {
     `;
   }
 
-  async textContent(state: WebPageState): Promise<string> {
-    const actionResult = ActionResult.fromState(state);
-    const html = await actionResult.combinedHtml();
-
-    const prompt = dedent`
-      Transform into markdown.
-      Identify headers, footers, asides, special application parts and main contant.
-      Content should be in markdown format. If it is content: tables must be tables, lists must be lists.
-      Navigation elements should be represented as standalone blocks after the content.
-      Do not summarize content, just transform it into markdown.
-      It is important to list all the content text
-      If it is link it must be linked
-      You can summarize footers/navigation/aside elements.
-      But main conteint should be kept as text and formatted as markdown based on its current markup.
-      Links to external web sites should be avoided in output.
-
-      Break down into sections:
-
-      ## Content Area
-
-      ## Navigation Area
-
-      <page_html>
-      ${html}
-      </page_html>
-    `;
-
-    const model = this.provider.getModelForAgent('researcher');
-    const r = await this.provider.chat([{ role: 'user', content: prompt }], model, { agentName: 'researcher', telemetryFunctionId: 'researcher.textContent' });
-
-    return r.text;
-  }
-
   private getScreenshotFromState(state: WebPageState): { actionResult: ActionResult; image: Buffer } | null {
     const actionResult = ActionResult.fromState(state);
     const image = actionResult.screenshot;

--- a/src/ai/researcher/research-result.ts
+++ b/src/ai/researcher/research-result.ts
@@ -46,24 +46,6 @@ export class ResearchResult {
     }));
   }
 
-  updateSection(sectionName: string, locators: Locator[]): void {
-    const sections = parseResearchSections(this.text);
-    const section = sections.find((s) => s.name === sectionName);
-    if (!section) return;
-
-    for (const el of section.elements) {
-      const elLocators = locators.filter((l) => l.element === el.name);
-      for (const loc of elLocators) {
-        const value = loc.valid === false ? null : loc.locator || null;
-        if (loc.type === 'css') el.css = value;
-        if (loc.type === 'xpath') el.xpath = value;
-        if (loc.type === 'aria') el.aria = value ? parseAriaLocator(value) : null;
-      }
-    }
-
-    this.rebuildSectionInText(section);
-  }
-
   rebuildSectionInText(section: ResearchSection): void {
     if (section.elements.length === 0) return;
     const newTable = rebuildSectionMarkdown(section);

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -5,7 +5,6 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { ActionResult } from '../action-result.ts';
 import { clearActivity, setActivity } from '../activity.ts';
-import { ConfigParser } from '../config.ts';
 import type { ExperienceTracker } from '../experience-tracker.ts';
 import type Explorer from '../explorer.ts';
 import { Observability } from '../observability.ts';

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -9,13 +9,12 @@ import { ConfigParser } from '../config.ts';
 import type { ExperienceTracker } from '../experience-tracker.ts';
 import type Explorer from '../explorer.ts';
 import { Observability } from '../observability.ts';
-import type { StateTransition, WebPageState } from '../state-manager.ts';
+import type { StateTransition } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
-import { type Note, type Test, TestResult, type TestResultType } from '../test-plan.ts';
+import { type Test, TestResult, type TestResultType } from '../test-plan.ts';
 import { detectFocusArea, extractFocusedElement } from '../utils/aria.ts';
 import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { HooksRunner } from '../utils/hooks-runner.ts';
-import { codeToMarkdown } from '../utils/html.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
 import type { Agent } from './agent.ts';
@@ -58,7 +57,6 @@ export class Tester extends TaskAgent implements Agent {
   researcher: Researcher;
   navigator: Navigator;
   agentTools: any;
-  executionLogFile: string | null = null;
   private previousUrl: string | null = null;
   private previousStateHash: string | null = null;
   private pageStateHash: string | null = null;
@@ -150,10 +148,6 @@ export class Tester extends TaskAgent implements Agent {
     const conversation = this.provider.startConversation(this.getSystemMessage(), 'tester');
     conversation.markLastMessageCacheable();
     this.currentConversation = conversation;
-
-    const outputDir = ConfigParser.getInstance().getOutputDir();
-    this.executionLogFile = join(outputDir, `tester_${task.sessionName}.md`);
-    // Note: Markdown saving functionality removed from Conversation class
 
     const scenarioBlock = this.buildScenarioBlock(task, initialState);
     conversation.addUserText(scenarioBlock);
@@ -526,7 +520,6 @@ export class Tester extends TaskAgent implements Agent {
     const currentStateHash = currentState.hash;
 
     const isNewUrl = this.previousUrl !== currentUrl;
-    const isStateChanged = !isNewUrl && this.previousStateHash !== currentStateHash;
 
     this.previousUrl = currentUrl;
     this.previousStateHash = currentStateHash;
@@ -641,27 +634,6 @@ export class Tester extends TaskAgent implements Agent {
       }
     }
 
-    // if (isStateChanged) {
-    //   const combinedHtml = await currentState.combinedHtml();
-    //   context += dedent`
-    //     Context (state changed):
-
-    //     <page>
-    //     CURRENT URL: ${currentState.url}
-    //     CURRENT TITLE: ${currentState.title}
-    //     </page>
-
-    //     <page_html>
-    //     ${combinedHtml}
-    //     </page_html>
-
-    //     <page_aria>
-    //     ${currentState.ariaSnapshot}
-    //     </page_aria>
-    //   `;
-    //   return context;
-    // }
-
     if (context) return context;
 
     if (iteration % 5) return '';
@@ -678,38 +650,6 @@ export class Tester extends TaskAgent implements Agent {
       ${currentState.getInteractiveARIA()}
       </page_aria>
     `;
-  }
-
-  private async promptLogStep(task: Test): Promise<string> {
-    let logPrompt = dedent`
-      <task>
-        Add a note explaining what you achieved with previous action.
-        Use tools to interact with the page to achieve the scenario goal or expected outcomes.
-        Call record tool to explain the last action
-        Format: record([<action performed>, <what has changed>, <what you expect to do next>]) 
-      </task>
-    `;
-
-    if (task.getPrintableNotes()) {
-      logPrompt = dedent`
-        Your interaction log notes:
-        <notes>
-        ${task.getPrintableNotes()}
-        </notes>
-
-        <rules>
-        Use your previous interaction notes to guide your next actions.
-        Do not perform the same checks.
-        </rules>
-      `;
-    }
-
-    const remaining = task.getRemainingExpectations();
-    if (remaining.length > 0) {
-      logPrompt += `\nExpected steps to check: ${remaining.join(', ')}`;
-    }
-
-    return logPrompt;
   }
 
   private finishTest(task: Test): void {

--- a/src/commands/compact-command.ts
+++ b/src/commands/compact-command.ts
@@ -1,6 +1,6 @@
 import { basename } from 'node:path';
 import chalk from 'chalk';
-import type { ExperienceFile } from '../ai/experience-compactor.js';
+import type { ExperienceFile } from '../experience-tracker.js';
 import type { ExperienceTracker } from '../experience-tracker.js';
 import { tag } from '../utils/logger.js';
 import { BaseCommand, type Suggestion } from './base-command.js';

--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -116,21 +116,6 @@ export class ExperienceTracker {
     writeFileSync(filePath, fileContent, 'utf8');
   }
 
-  hasRecentExperience(stateHash: string, prefix = ''): boolean {
-    if (this.disabled) {
-      return false;
-    }
-    if (prefix) {
-      stateHash = `${prefix}_${stateHash}`;
-    }
-    const filePath = this.getExperienceFilePath(stateHash);
-    if (!existsSync(filePath)) {
-      return false;
-    }
-    const stats = statSync(filePath);
-    return stats.mtime.getTime() > Date.now() - 1000 * 60 * 60 * 24;
-  }
-
   private getExperienceFilePath(stateHash: string): string {
     return join(this.experienceDir, `${stateHash}.md`);
   }
@@ -281,14 +266,6 @@ export class ExperienceTracker {
         if (lines.length <= maxLines) return experience;
         return { ...experience, content: lines.slice(0, maxLines).join('\n') };
       });
-  }
-
-  /**
-   * Clean up experience tracker (for testing)
-   */
-  cleanup(): void {
-    // Clear any in-memory state if needed
-    // The actual files will be cleaned up by test cleanup
   }
 
   getSuccessfulExperience(state: ActionResult, options?: { includeDescendants?: boolean; stripCode?: boolean }): string[] {

--- a/src/knowledge-tracker.ts
+++ b/src/knowledge-tracker.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 import matter from 'gray-matter';
 import { ActionResult } from './action-result.js';
 import { ConfigParser } from './config.js';

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -400,11 +400,6 @@ export class StateManager {
     this.stateChangeListeners = [];
     this.nextStateId = 1;
 
-    // Clean up experience tracker if it has cleanup method
-    if (this.experienceTracker && typeof this.experienceTracker.cleanup === 'function') {
-      this.experienceTracker.cleanup();
-    }
-
     debugLog('StateManager cleanup completed');
   }
 }

--- a/tests/unit/experience-compactor.test.ts
+++ b/tests/unit/experience-compactor.test.ts
@@ -76,7 +76,6 @@ describe('ExperienceCompactor', () => {
   });
 
   afterEach(() => {
-    experienceTracker.cleanup();
     mockProvider.reset();
 
     if (existsSync(testDir)) {

--- a/tests/unit/experience-tracker.test.ts
+++ b/tests/unit/experience-tracker.test.ts
@@ -33,8 +33,6 @@ describe('ExperienceTracker', () => {
   });
 
   afterEach(() => {
-    experienceTracker.cleanup();
-
     if (existsSync(testDir)) {
       rmSync(testDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Completes **plan 014** — the remaining steps of the dead-code sweep (steps 1–6 landed in #82). Deletes provably-unreferenced code from the agents and trackers. **~186 deletions**, no behavioral change: every item was grep-verified callerless (including tests) before deletion, and the full suite stays green.

## What's removed
- **`tester.ts`**: unused `promptLogStep()`, the write-only `executionLogFile` field + its assignment/`outputDir`/stale comment, the dead `isStateChanged` computation (its only reader was a commented-out block, also removed), and unused imports (`WebPageState`, `Note`, `codeToMarkdown`, `ConfigParser`).
- **`researcher.ts`**: unused `textContent()` + the unused `node:path` `join` import. **`research-result.ts`**: unused `updateSection()`.
- **`captain.ts`**: unused `getConversation()`/`cleanConversation()` (callers use Tester's). **`driller.ts`**: unused `getCurrentPlan()`/`getConversation()` + `currentConversation` field/assignment + dead `Conversation` import. **`fisherman.ts`**: unused `getMode()`.
- **`rerunner.ts`**: unused `listTests()` + its now-dead import; the always-`''` `test` field dropped from `healedSteps` and from `Historian.rewriteScenarioInFile`'s param type; the redundant `includes` guard removed there (`String.replace` already no-ops when the substring is absent).
- **`historian.ts`** / **`historian/utils.ts`**: the unused `isNonReusableCode`/`stripComments` re-exports (every consumer imports from `step-analyzer` directly).
- **`experience-tracker.ts`**: unused `hasRecentExperience()` and the no-op `cleanup()` (comment-only body) + its `StateManager.cleanup()` call and 2 test calls. **`knowledge-tracker.ts`**: unused `resolve` import. **`experience-compactor.ts`**: the `ExperienceFile` re-export (compact-command repointed to `experience-tracker` directly).

## Skipped (re-verify found them not-dead)
- **`Captain.processExecutionError()`** — production-dead, but its 4 tests **mock** `Explorer.handleExecutionError`, so they can't be retargeted to test real logic (the plan's suggested retarget). Kept method + tests per the plan's STOP guidance.

## Verification
`bun run lint` exit 0; `bunx tsc --noEmit` → **728 = before-count** (not higher); `bun test tests/unit` → **764/0**; `bun test tests/integration` → **63/0**. Diff is deletions + import repoints only. Fable-reviewed (APPROVE after fixing one orphaned import): all deletions confirmed callerless, same-named live methods (Tester.getConversation, ExplorBot.getCurrentPlan, StateManager.cleanup, …) untouched, and the two non-pure-deletions (redundant guard, no-op cleanup) confirmed behavior-neutral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)