### PR TITLE
refactor: consolidate Provider's four generate paths (plan 017)

### DIFF
--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -179,6 +179,50 @@ export class Provider {
     if (reasoning) config.reasoning ??= reasoning;
   }
 
+  private buildGenerateConfig(defaults: Record<string, any>, overrides: Record<string, any>, options: any): Record<string, any> {
+    const telemetry = this.getTelemetry(options);
+    const config = this.mergeProviderOptions(
+      {
+        ...defaults,
+        allowSystemInMessages: true,
+        ...(this.config.config || {}),
+        ...options,
+        ...overrides,
+      },
+      options.agentName
+    );
+    this.finalizeConfig(config, options, telemetry);
+    return config;
+  }
+
+  private recordUsage(agentName: string, modelName: string, usage: any): void {
+    if (!usage) return;
+    Stats.recordTokens(agentName, modelName, {
+      input: usage.inputTokens ?? usage.promptTokens ?? 0,
+      output: usage.outputTokens ?? usage.completionTokens ?? 0,
+      total: usage.totalTokens ?? 0,
+      cached: extractCachedTokens(usage),
+    });
+  }
+
+  private async raceWithIdleTimeout<T>(fn: (signal: AbortSignal) => Promise<T>, timeoutMs: number): Promise<T> {
+    const cancel = { cancelled: false };
+    const controller = new AbortController();
+    const combinedSignal = combinedAbortSignal(controller);
+    try {
+      return await Promise.race([fn(combinedSignal), abortAfterIdle(timeoutMs, cancel, controller)]);
+    } finally {
+      cancel.cancelled = true;
+    }
+  }
+
+  private async recoverFromContextLength(error: any, messages: ModelMessage[], options: any, retry: (messages: ModelMessage[], options: any) => Promise<any>): Promise<any> {
+    const reduced = this.tryReduceMessages(messages, options._contextRetryLevel || 0);
+    if (!reduced) throw new ContextLengthError(error.message || error.toString());
+    tag('warning').log('Context length exceeded, retrying with reduced messages...');
+    return retry(reduced.messages, { ...options, _contextRetryLevel: reduced.nextLevel });
+  }
+
   private initLangfuse() {
     const langfuseConfig = this.config.langfuse;
     const publicKey = langfuseConfig?.publicKey || process.env.LANGFUSE_PUBLIC_KEY;
@@ -277,19 +321,7 @@ export class Provider {
     setActivity(`🤖 Asking ${modelName}`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
-    const telemetry = this.getTelemetry(options);
-    const config = this.mergeProviderOptions(
-      {
-        maxOutputTokens: 16384,
-        allowSystemInMessages: true,
-        ...(this.config.config || {}),
-        ...options,
-        model,
-        abortSignal: executionController.getAbortSignal(),
-      },
-      options.agentName
-    );
-    this.finalizeConfig(config, options, telemetry);
+    const config = this.buildGenerateConfig({ maxOutputTokens: 16384 }, { model, abortSignal: executionController.getAbortSignal() }, options);
 
     promptLog(messages[messages.length - 1].content);
     try {
@@ -311,14 +343,7 @@ export class Provider {
       clearActivity();
       responseLog(response.text);
 
-      if (response.usage) {
-        Stats.recordTokens(options.agentName || 'unknown', modelName, {
-          input: response.usage.inputTokens ?? response.usage.promptTokens ?? 0,
-          output: response.usage.outputTokens ?? response.usage.completionTokens ?? 0,
-          total: response.usage.totalTokens ?? 0,
-          cached: extractCachedTokens(response.usage),
-        });
-      }
+      this.recordUsage(options.agentName || 'unknown', modelName, response.usage);
 
       return response;
     } catch (error: any) {
@@ -326,12 +351,7 @@ export class Provider {
       if (error?.name === 'AbortError') throw error;
       if (error instanceof ContextLengthError) throw error;
       if (Provider.isContextLengthError(error)) {
-        const reduced = this.tryReduceMessages(messages, options._contextRetryLevel || 0);
-        if (reduced) {
-          tag('warning').log('Context length exceeded, retrying with reduced messages...');
-          return this.chat(reduced.messages, model, { ...options, _contextRetryLevel: reduced.nextLevel });
-        }
-        throw new ContextLengthError(error.message || error.toString());
+        return this.recoverFromContextLength(error, messages, options, (m, o) => this.chat(m, model, o));
       }
       const message = error.message || error.toString();
       if (message !== 'No response text from AI') {
@@ -351,49 +371,19 @@ export class Provider {
     promptLog('Available tools:', toolNames);
     promptLog(messages[messages.length - 1].content);
 
-    const telemetry = this.getTelemetry(options);
     const maxRoundtrips = options.maxToolRoundtrips ?? 5;
     const extraStop = options.stopWhen;
     const stopConditions: any[] = [isStepCount(maxRoundtrips)];
     if (extraStop) stopConditions.push(extraStop);
-    const { stopWhen: _ignoredStopWhen, ...optionsWithoutStop } = options;
-    const config = this.mergeProviderOptions(
-      {
-        tools,
-        maxOutputTokens: 16384,
-        toolChoice: 'auto',
-        allowSystemInMessages: true,
-        ...(this.config.config || {}),
-        ...optionsWithoutStop,
-        stopWhen: stopConditions,
-        model,
-      },
-      options.agentName
-    );
-    this.finalizeConfig(config, options, telemetry);
+    const config = this.buildGenerateConfig({ tools, maxOutputTokens: 16384, toolChoice: 'auto' }, { stopWhen: stopConditions, model }, options);
     try {
       const response = await withRetry(async () => {
-        const timeout = config.timeout || 30000;
-        const cancel = { cancelled: false };
-        const controller = new AbortController();
-        const combinedSignal = combinedAbortSignal(controller);
-        try {
-          const result = (await Promise.race([
-            generateText({
-              messages,
-              ...config,
-              abortSignal: combinedSignal,
-            }),
-            abortAfterIdle(timeout, cancel, controller),
-          ])) as any;
-          const hasToolCall = (result.toolCalls?.length || 0) > 0;
-          if (!result.text && !hasToolCall && result.finishReason === 'length') {
-            throw new ContextLengthError('AI response empty: output truncated at maxTokens. Increase maxOutputTokens in config or use a model with higher output capacity.');
-          }
-          return result;
-        } finally {
-          cancel.cancelled = true;
+        const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
+        const hasToolCall = (result.toolCalls?.length || 0) > 0;
+        if (!result.text && !hasToolCall && result.finishReason === 'length') {
+          throw new ContextLengthError('AI response empty: output truncated at maxTokens. Increase maxOutputTokens in config or use a model with higher output capacity.');
         }
+        return result;
       }, this.getRetryOptions(options));
 
       clearActivity();
@@ -408,14 +398,7 @@ export class Provider {
 
       responseLog(response.text);
 
-      if (response.usage) {
-        Stats.recordTokens(options.agentName || 'unknown', modelName, {
-          input: response.usage.inputTokens ?? response.usage.promptTokens ?? 0,
-          output: response.usage.outputTokens ?? response.usage.completionTokens ?? 0,
-          total: response.usage.totalTokens ?? 0,
-          cached: extractCachedTokens(response.usage),
-        });
-      }
+      this.recordUsage(options.agentName || 'unknown', modelName, response.usage);
 
       return response;
     } catch (error: any) {
@@ -426,12 +409,7 @@ export class Provider {
       if (error?.name === 'AbortError') throw error;
       if (error instanceof ContextLengthError) throw error;
       if (Provider.isContextLengthError(error)) {
-        const reduced = this.tryReduceMessages(messages, options._contextRetryLevel || 0);
-        if (reduced) {
-          tag('warning').log('Context length exceeded, retrying with reduced messages...');
-          return this.generateWithTools(reduced.messages, model, tools, { ...options, _contextRetryLevel: reduced.nextLevel });
-        }
-        throw new ContextLengthError(error.message || error.toString());
+        return this.recoverFromContextLength(error, messages, options, (m, o) => this.generateWithTools(m, model, tools, o));
       }
       if (error.constructor?.name === 'AI_APICallError') {
         responseLog(error.message);
@@ -447,51 +425,18 @@ export class Provider {
     setActivity(`🤖 Asking ${modelName} for structured output`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
-    const telemetry = this.getTelemetry(options);
-    const config = this.mergeProviderOptions(
-      {
-        schema,
-        allowSystemInMessages: true,
-        ...(this.config.config || {}),
-        ...options,
-        model: modelToUse,
-      },
-      options.agentName
-    );
-    this.finalizeConfig(config, options, telemetry);
+    const config = this.buildGenerateConfig({ schema }, { model: modelToUse }, options);
 
     try {
       promptLog(messages[messages.length - 1].content);
       const response = await withRetry(async () => {
-        const timeout = config.timeout || 30000;
-        const cancel = { cancelled: false };
-        const controller = new AbortController();
-        const combinedSignal = combinedAbortSignal(controller);
-        try {
-          return (await Promise.race([
-            generateObject({
-              messages,
-              ...config,
-              abortSignal: combinedSignal,
-            }),
-            abortAfterIdle(timeout, cancel, controller),
-          ])) as any;
-        } finally {
-          cancel.cancelled = true;
-        }
+        return (await this.raceWithIdleTimeout((signal) => generateObject({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
       }, this.getRetryOptions(options));
 
       clearActivity();
       responseLog(response.object);
 
-      if (response.usage) {
-        Stats.recordTokens(options.agentName || 'unknown', modelName, {
-          input: response.usage.inputTokens ?? response.usage.promptTokens ?? 0,
-          output: response.usage.outputTokens ?? response.usage.completionTokens ?? 0,
-          total: response.usage.totalTokens ?? 0,
-          cached: extractCachedTokens(response.usage),
-        });
-      }
+      this.recordUsage(options.agentName || 'unknown', modelName, response.usage);
 
       return response;
     } catch (error: any) {
@@ -499,12 +444,7 @@ export class Provider {
       if (error?.name === 'AbortError') throw error;
       if (error instanceof ContextLengthError) throw error;
       if (Provider.isContextLengthError(error)) {
-        const reduced = this.tryReduceMessages(messages, options._contextRetryLevel || 0);
-        if (reduced) {
-          tag('warning').log('Context length exceeded, retrying with reduced messages...');
-          return this.generateObject(reduced.messages, schema, model, { ...options, _contextRetryLevel: reduced.nextLevel });
-        }
-        throw new ContextLengthError(error.message || error.toString());
+        return this.recoverFromContextLength(error, messages, options, (m, o) => this.generateObject(m, schema, model, o));
       }
       throw new AiError(error.message || error.toString());
     }
@@ -683,13 +623,7 @@ export class Provider {
       clearActivity();
       responseLog(response.text);
 
-      if (response.usage) {
-        Stats.recordTokens('vision', this.getModelName(this.config.visionModel), {
-          input: response.usage.inputTokens ?? response.usage.promptTokens ?? 0,
-          output: response.usage.outputTokens ?? response.usage.completionTokens ?? 0,
-          total: response.usage.totalTokens ?? 0,
-        });
-      }
+      this.recordUsage('vision', this.getModelName(this.config.visionModel), response.usage);
 
       return response;
     } catch (error: any) {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -382,6 +382,36 @@ describe('Provider', () => {
     });
   });
 
+  describe('context length recovery', () => {
+    it('reduces messages and retries when a context-length error is thrown', async () => {
+      let calls = 0;
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'ctx-model',
+        doGenerate: async () => {
+          calls++;
+          if (calls === 1) throw new Error('context length exceeded');
+          return {
+            text: 'recovered',
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 5, outputTokens: 5 },
+            content: [{ type: 'text' as const, text: 'recovered' }],
+          };
+        },
+      });
+      const messages: ModelMessage[] = [
+        { role: 'system', content: 'system' },
+        { role: 'user', content: `<data>${'x'.repeat(5000)}</data>` },
+        { role: 'assistant', content: 'response' },
+      ];
+
+      const response = await provider.chat(messages, model, { maxRetries: 1 });
+
+      expect(response.text).toBe('recovered');
+      expect(calls).toBe(2);
+    });
+  });
+
   describe('abort on idle timeout', () => {
     it('aborts the in-flight request when the idle timeout fires', async () => {
       const capture: { signal?: AbortSignal } = {};


### PR DESCRIPTION
## Plan 017 — Consolidate the four duplicated generate paths in Provider

`src/ai/provider.ts` had four near-identical generate paths (`chat`, `generateWithTools`, `generateObject`, `processImage`) each re-implementing config assembly, usage recording, the idle-timeout race, and context-length recovery. This extracts four private helpers:

- **`recordUsage(agentName, modelName, usage)`** — single `Stats.recordTokens` call site (was 4). Also adds the `cached` token field to `processImage` (was the only path missing it).
- **`recoverFromContextLength(error, messages, options, retry)`** — single context-length reduce+retry, retry callback stays method-specific.
- **`buildGenerateConfig(defaults, overrides, options)`** — shared `mergeProviderOptions` + `finalizeConfig` assembly.
- **`raceWithIdleTimeout(fn, timeoutMs)`** — single `Promise.race` against the idle abort.

### Drift reconciliation
This plan was written at `9e22b0d`; since then **plan 005** (abort in-flight request on idle timeout, PR #73) and **plan 007** (PR #75) reshaped these methods. Per the plan's Step 4 guidance, plan 005's per-attempt `AbortController` + `combinedAbortSignal` is folded **inside** `raceWithIdleTimeout` — one controller per retry attempt (the helper is called inside the `withRetry` callback), signature `(signal) => generateX({ ...config, abortSignal: signal })`.

### Behavior-preserving
- Config spread order is preserved **per site**: `defaults` land before `...(this.config.config)` (so user config can still override the `maxOutputTokens: 16384` default), `overrides` (`model`/`abortSignal`/`stopWhen`) land after `...options`.
- `generateWithTools` no longer strips `stopWhen` from options — `stopWhen: stopConditions` in `overrides` already wins over `...options`, and `stopConditions` still folds in `options.stopWhen` via `extraStop`. Identical result.

### Deliberately NOT changed (behavior changes wanting their own review)
- `chat()` still has **no** idle-timeout race.
- `processImage()` still skips context-length recovery and keeps its minimal config path (routing it through `buildGenerateConfig` would change agent-level provider-option behavior).

### Verification
- `bun test tests/unit` → **765 pass / 0 fail** (+1 new context-length-recovery-through-helper test).
- `bun test tests/integration/` → **63 pass / 0 fail**.
- `bun run lint` → clean.
- `tsc` errors: **639 → 636** total (provider.ts 10 → 6) — refactor removed 4 `promptTokens`/`completionTokens` TS2339s; no new errors.
- Greps: `Stats.recordTokens` ×1, `tryReduceMessages` ×2, `abortAfterIdle` ×2, `Promise.race` ×1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)