### PR TITLE
refactor: single owners for knowledge/experience prompt blocks (plan 019)

### DIFF
--- a/src/ai/navigator.ts
+++ b/src/ai/navigator.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { ActionResult } from '../action-result.js';
 import type Action from '../action.ts';
-import { ExperienceTracker, renderExperienceToc } from '../experience-tracker.js';
+import type { ExperienceTracker } from '../experience-tracker.js';
 import Explorer from '../explorer.ts';
 import { KnowledgeTracker } from '../knowledge-tracker.js';
 import { normalizeUrl } from '../state-manager.js';
@@ -191,18 +191,8 @@ class Navigator implements Agent {
     const action = opts?.action ?? this.explorer.createAction();
     const expectedUrl = opts?.expectedUrl;
 
-    let knowledge = '';
+    const knowledge = this.knowledgeTracker.renderRelevantKnowledge(actionResult);
     let experience = '';
-
-    const relevantKnowledge = this.knowledgeTracker.getRelevantKnowledge(actionResult);
-    if (relevantKnowledge.length > 0) {
-      const knowledgeContent = relevantKnowledge.map((k) => k.content).join('\n\n');
-      knowledge = `
-      <hint>
-      Here is relevant knowledge for this page:
-      ${knowledgeContent}
-      </hint>`;
-    }
 
     if (!actionResult.isInsideIframe) {
       const successful = this.experienceTracker.getSuccessfulExperience(actionResult);
@@ -638,26 +628,11 @@ class Navigator implements Agent {
       return { verified: cachedVerification, successfulCodes: [], assertionSteps: [], totalAttempted: 0 };
     }
 
-    let knowledge = '';
+    const knowledge = this.knowledgeTracker.renderRelevantKnowledge(actionResult);
     let experience = '';
 
-    const relevantKnowledge = this.knowledgeTracker.getRelevantKnowledge(actionResult);
-    if (relevantKnowledge.length > 0) {
-      const knowledgeContent = relevantKnowledge.map((k) => k.content).join('\n\n');
-      knowledge = `
-      <hint>
-      Here is relevant knowledge for this page:
-      ${knowledgeContent}
-      </hint>`;
-    }
-
     if (!actionResult.isInsideIframe) {
-      const toc = this.experienceTracker.getExperienceTableOfContents(actionResult);
-      if (toc.length > 0) {
-        const totalSections = toc.reduce((sum, entry) => sum + entry.sections.length, 0);
-        tag('operation').log(`Found ${toc.length} experience ${pluralize(toc.length, 'file')} (${totalSections} sections) for: ${actionResult.url}`);
-        experience = renderExperienceToc(toc);
-      }
+      experience = this.experienceTracker.renderExperienceTocFor(actionResult);
     }
 
     const priorVerifications = Object.entries(actionResult.verifications ?? {});

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -3,7 +3,7 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { ActionResult } from '../action-result.ts';
 import { ConfigParser } from '../config.ts';
-import { type ExperienceTracker, renderExperienceToc } from '../experience-tracker.ts';
+import type { ExperienceTracker } from '../experience-tracker.ts';
 import type Explorer from '../explorer.ts';
 import { type Test, TestResult } from '../test-plan.ts';
 import { collectInteractiveNodes, detectFocusArea, extractFocusedElement } from '../utils/aria.ts';
@@ -606,9 +606,7 @@ export class Pilot implements Agent {
     if (!this.experienceTracker) return '';
     const state = this.explorer.getStateManager().getCurrentState();
     if (!state) return '';
-    const actionResult = ActionResult.fromState(state);
-    const toc = this.experienceTracker.getExperienceTableOfContents(actionResult);
-    return renderExperienceToc(toc);
+    return this.experienceTracker.renderExperienceTocFor(ActionResult.fromState(state));
   }
 
   private pickPlanningTools() {

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -15,7 +15,7 @@ import { diffAriaSnapshots } from '../utils/aria.ts';
 import { ErrorPageError, detectPageCondition } from '../utils/error-page.ts';
 import { HooksRunner } from '../utils/hooks-runner.ts';
 import { isBodyEmpty } from '../utils/html.ts';
-import { createDebug, pluralize, tag } from '../utils/logger.js';
+import { createDebug, tag } from '../utils/logger.js';
 import { mdq } from '../utils/markdown-query.ts';
 import { RulesLoader } from '../utils/rules-loader.ts';
 import type { Agent } from './agent.js';
@@ -470,23 +470,7 @@ export class Researcher extends ResearcherBase implements Agent {
     if (!this.actionResult) throw new Error('actionResult is not set');
 
     const html = await this.actionResult.combinedHtml();
-    const knowledgeFiles = this.stateManager.getRelevantKnowledge();
-
-    let knowledge = '';
-    if (knowledgeFiles.length > 0) {
-      const knowledgeContent = knowledgeFiles
-        .map((k) => k.content)
-        .filter((k) => !!k)
-        .join('\n\n');
-
-      tag('operation').log(`Found ${knowledgeFiles.length} relevant knowledge ${pluralize(knowledgeFiles.length, 'file')} for: ${this.actionResult.url}`);
-      knowledge = `
-        <hint>
-        Here is relevant knowledge for this page:
-
-        ${knowledgeContent}
-        </hint>`;
-    }
+    const knowledge = this.explorer.getKnowledgeTracker().renderRelevantKnowledge(this.actionResult);
 
     const ariaSnapshot = this.actionResult.getCompactARIA();
 

--- a/src/ai/task-agent.ts
+++ b/src/ai/task-agent.ts
@@ -1,10 +1,6 @@
-import dedent from 'dedent';
 import type { ActionResult } from '../action-result.js';
-import { type ExperienceTracker, renderExperienceToc } from '../experience-tracker.js';
+import type { ExperienceTracker } from '../experience-tracker.js';
 import type { KnowledgeTracker } from '../knowledge-tracker.js';
-import { createDebug, pluralize, tag } from '../utils/logger.js';
-
-const debugLog = createDebug('explorbot:task-agent');
 import { Historian } from './historian.js';
 import type { Navigator } from './navigator.js';
 import type { Provider } from './provider.js';
@@ -35,34 +31,11 @@ export abstract class TaskAgent {
   protected abstract getProvider(): Provider;
 
   protected getKnowledge(actionResult: ActionResult): string {
-    const knowledgeFiles = this.getKnowledgeTracker().getRelevantKnowledge(actionResult);
-
-    if (knowledgeFiles.length === 0) return '';
-
-    const knowledgeContent = knowledgeFiles
-      .map((k) => k.content)
-      .filter((k) => !!k)
-      .join('\n\n');
-
-    tag('operation').log(`Found ${knowledgeFiles.length} relevant knowledge ${pluralize(knowledgeFiles.length, 'file')}`);
-    return dedent`
-      <knowledge>
-      Here is relevant knowledge for this page:
-
-      ${knowledgeContent}
-      </knowledge>
-    `;
+    return this.getKnowledgeTracker().renderRelevantKnowledge(actionResult);
   }
 
   protected getExperience(actionResult: ActionResult): string {
-    const tracker = this.getExperienceTracker();
-    const toc = tracker.getExperienceTableOfContents(actionResult);
-    if (toc.length === 0) return '';
-
-    const totalSections = toc.reduce((sum, entry) => sum + entry.sections.length, 0);
-    debugLog(`injecting experience TOC (${toc.length} files, ${totalSections} sections)`);
-    tag('operation').log(`Found ${toc.length} experience ${pluralize(toc.length, 'file')} (${totalSections} sections)`);
-    return renderExperienceToc(toc);
+    return this.getExperienceTracker().renderExperienceTocFor(actionResult);
   }
 
   setHistorian(historian: Historian): void {

--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -6,7 +6,7 @@ import type { ActionResult } from './action-result.js';
 import { ConfigParser } from './config.js';
 import { KnowledgeTracker } from './knowledge-tracker.js';
 import type { WebPageState } from './state-manager.js';
-import { createDebug, tag } from './utils/logger.js';
+import { createDebug, pluralize, tag } from './utils/logger.js';
 import { mdq } from './utils/markdown-query.js';
 import { isNonReusableCode } from './utils/step-analyzer.ts';
 import { extractStatePath } from './utils/url-matcher.js';
@@ -329,6 +329,16 @@ export class ExperienceTracker {
     });
 
     return this.buildToc(sorted);
+  }
+
+  renderExperienceTocFor(state: ActionResult): string {
+    const toc = this.getExperienceTableOfContents(state);
+    if (toc.length === 0) return '';
+
+    const totalSections = toc.reduce((sum, entry) => sum + entry.sections.length, 0);
+    debugLog(`injecting experience TOC (${toc.length} files, ${totalSections} sections)`);
+    tag('operation').log(`Found ${toc.length} experience ${pluralize(toc.length, 'file')} (${totalSections} sections)`);
+    return renderExperienceToc(toc);
   }
 
   getExperienceSection(fileTag: string, sectionIndex: number, state: ActionResult, options?: { includeDescendantExperience?: boolean }): { title: string; url: string; content: string } | null {

--- a/src/knowledge-tracker.ts
+++ b/src/knowledge-tracker.ts
@@ -1,10 +1,11 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
+import dedent from 'dedent';
 import matter from 'gray-matter';
 import { ActionResult } from './action-result.js';
 import { ConfigParser } from './config.js';
 import { getCliName } from './utils/cli-name.ts';
-import { createDebug } from './utils/logger.js';
+import { createDebug, pluralize, tag } from './utils/logger.js';
 
 const debugLog = createDebug('explorbot:knowledge-tracker');
 
@@ -76,6 +77,25 @@ export class KnowledgeTracker {
     return this.knowledgeFiles.filter((knowledge) => {
       return state.isMatchedBy(knowledge);
     });
+  }
+
+  renderRelevantKnowledge(state: ActionResult): string {
+    const knowledgeFiles = this.getRelevantKnowledge(state);
+    if (knowledgeFiles.length === 0) return '';
+
+    const knowledgeContent = knowledgeFiles
+      .map((k) => k.content)
+      .filter((k) => !!k)
+      .join('\n\n');
+
+    tag('operation').log(`Found ${knowledgeFiles.length} relevant knowledge ${pluralize(knowledgeFiles.length, 'file')}`);
+    return dedent`
+      <knowledge>
+      Here is relevant knowledge for this page:
+
+      ${knowledgeContent}
+      </knowledge>
+    `;
   }
 
   addKnowledge(urlPattern: string, description: string): { filename: string; filePath: string; isNewFile: boolean } {

--- a/tests/integration/researcher-browser.test.ts
+++ b/tests/integration/researcher-browser.test.ts
@@ -94,7 +94,7 @@ describe('Researcher with real browser + aimock', () => {
     };
     return {
       getStateManager: () => mockStateManager,
-      getKnowledgeTracker: () => ({ getRelevantKnowledge: () => [] }),
+      getKnowledgeTracker: () => ({ getRelevantKnowledge: () => [], renderRelevantKnowledge: () => '' }),
       getConfig: () => ConfigParser.getInstance().getConfig(),
       visit: async () => {},
       annotateElements: async () => (await annotatePageElements(page)).elements,

--- a/tests/integration/researcher-sections.test.ts
+++ b/tests/integration/researcher-sections.test.ts
@@ -38,7 +38,7 @@ function createMockExplorer(configOverrides: Record<string, unknown> = {}, playw
   };
   return {
     getStateManager: () => stateManager,
-    getKnowledgeTracker: () => ({ getRelevantKnowledge: () => [] }),
+    getKnowledgeTracker: () => ({ getRelevantKnowledge: () => [], renderRelevantKnowledge: () => '' }),
     getConfig: () => config,
     visit: async () => {},
     annotateElements: async () => [],

--- a/tests/integration/researcher.test.ts
+++ b/tests/integration/researcher.test.ts
@@ -55,6 +55,7 @@ function createMockExplorer(state = fakeState) {
   };
   const mockKnowledgeTracker = {
     getRelevantKnowledge: () => [],
+    renderRelevantKnowledge: () => '',
   };
   const mockStateManager = {
     getCurrentState: () => state,

--- a/tests/unit/experience-tracker.test.ts
+++ b/tests/unit/experience-tracker.test.ts
@@ -47,6 +47,27 @@ describe('ExperienceTracker', () => {
     });
   });
 
+  describe('renderExperienceTocFor', () => {
+    it('returns empty string when no experience matches the page', () => {
+      const state = new ActionResult({ url: 'https://example.com/empty', html: '<html></html>', title: 'Empty' });
+      expect(experienceTracker.renderExperienceTocFor(state)).toBe('');
+    });
+
+    it('renders the experience TOC for a page with recorded experience', () => {
+      const actionResult = new ActionResult({
+        html: '<html><body>Dashboard</body></html>',
+        url: 'https://example.com/dashboard',
+        title: 'Dashboard',
+      });
+      experienceTracker.writeAction(actionResult, { title: 'Navigate to dashboard', code: 'I.click("Dashboard")' });
+
+      const rendered = experienceTracker.renderExperienceTocFor(actionResult);
+
+      expect(rendered).toContain('<experience>');
+      expect(rendered).toContain('ACTION: navigate to dashboard');
+    });
+  });
+
   describe('writeAction', () => {
     it('should save action to experience file', () => {
       const actionResult = new ActionResult({

--- a/tests/unit/knowledge-tracker.test.ts
+++ b/tests/unit/knowledge-tracker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { existsSync, rmSync } from 'node:fs';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import matter from 'gray-matter';
+import { ActionResult } from '../../src/action-result.js';
 import { ConfigParser } from '../../src/config';
 import { KnowledgeTracker } from '../../src/knowledge-tracker';
 
@@ -33,6 +34,26 @@ describe('KnowledgeTracker', () => {
     const fileContent = matter.stringify(content, { url });
     writeFileSync(`${knowledgeDir}/${filename}`, fileContent, 'utf8');
   }
+
+  describe('renderRelevantKnowledge', () => {
+    it('returns empty string when no knowledge matches the page', () => {
+      const tracker = new KnowledgeTracker();
+      const state = new ActionResult({ url: '/nothing-here', html: '<html></html>' });
+      expect(tracker.renderRelevantKnowledge(state)).toBe('');
+    });
+
+    it('renders a tagged knowledge block for a matching page', () => {
+      writeKnowledgeFile('login.md', '/login', 'Use admin credentials');
+      const tracker = new KnowledgeTracker();
+      const state = new ActionResult({ url: '/login', html: '<html></html>' });
+
+      const rendered = tracker.renderRelevantKnowledge(state);
+
+      expect(rendered).toContain('<knowledge>');
+      expect(rendered).toContain('Use admin credentials');
+      expect(rendered).toContain('</knowledge>');
+    });
+  });
 
   describe('interpolateVars', () => {
     it('should replace ${env.VAR} with environment variable value', () => {

--- a/tests/unit/tester-error-page.test.ts
+++ b/tests/unit/tester-error-page.test.ts
@@ -45,10 +45,12 @@ describe('Tester error page handling', () => {
         clearHistory: () => {},
         getExperienceTracker: () => ({
           getExperienceTableOfContents: () => [],
+          renderExperienceTocFor: () => '',
         }),
       }),
       getKnowledgeTracker: () => ({
         getRelevantKnowledge: () => [],
+        renderRelevantKnowledge: () => '',
       }),
       getRequestStore: () => null,
       playwrightHelper: {
@@ -101,10 +103,12 @@ describe('Tester error page handling', () => {
         clearHistory: () => {},
         getExperienceTracker: () => ({
           getExperienceTableOfContents: () => [],
+          renderExperienceTocFor: () => '',
         }),
       }),
       getKnowledgeTracker: () => ({
         getRelevantKnowledge: () => [],
+        renderRelevantKnowledge: () => '',
       }),
       getRequestStore: () => null,
       hasOtherTabs: () => false,

--- a/tests/unit/tester-focus-scope.test.ts
+++ b/tests/unit/tester-focus-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 import { ActionResult } from '../../src/action-result.ts';
 import { Tester } from '../../src/ai/tester.ts';
+import { renderExperienceToc } from '../../src/experience-tracker.ts';
 import { Test } from '../../src/test-plan.ts';
 
 function buildTester(): Tester {
@@ -9,10 +10,12 @@ function buildTester(): Tester {
     getStateManager: () => ({
       getExperienceTracker: () => ({
         getExperienceTableOfContents: () => [],
+        renderExperienceTocFor: () => '',
       }),
     }),
     getKnowledgeTracker: () => ({
       getRelevantKnowledge: () => [],
+      renderRelevantKnowledge: () => '',
     }),
     getCurrentIframeInfo: () => null,
     hasOtherTabs: () => false,
@@ -29,22 +32,25 @@ function buildTester(): Tester {
 }
 
 function buildTesterWithExperience(): Tester {
+  const experienceToc = [
+    {
+      fileTag: 'A',
+      fileHash: 'abc123',
+      url: '/page',
+      sections: [{ index: 1, level: 2, title: 'FLOW: create item' }],
+    },
+  ];
   const explorer: any = {
     getConfig: () => ({ files: {} }),
     getStateManager: () => ({
       getExperienceTracker: () => ({
-        getExperienceTableOfContents: () => [
-          {
-            fileTag: 'A',
-            fileHash: 'abc123',
-            url: '/page',
-            sections: [{ index: 1, level: 2, title: 'FLOW: create item' }],
-          },
-        ],
+        getExperienceTableOfContents: () => experienceToc,
+        renderExperienceTocFor: () => renderExperienceToc(experienceToc),
       }),
     }),
     getKnowledgeTracker: () => ({
       getRelevantKnowledge: () => [],
+      renderRelevantKnowledge: () => '',
     }),
   };
   const provider: any = {};


### PR DESCRIPTION
## Plan 019 — One owner for knowledge/experience prompt blocks

The "render relevant knowledge" and "render experience TOC" prompt blocks were re-implemented in **5 places** with two different tag names (`<knowledge>` in the base class vs `<hint>` in Navigator/Researcher). This moves each to its owning tracker (per the CLAUDE.md Code Ownership Map):

- **`KnowledgeTracker.renderRelevantKnowledge(state)`**
- **`ExperienceTracker.renderExperienceTocFor(state)`**

Consumers now delegate:
- `TaskAgent.getKnowledge` / `getExperience` → one-line delegations (kept for subclasses).
- `Navigator.resolveState` + `Navigator.verifyState` knowledge/TOC blocks.
- `Researcher.buildResearchPrompt` — also switches the knowledge **source** from the StateManager copy to `explorer.getKnowledgeTracker()` (already `${env.*}`-interpolated via plan 010).
- `Pilot.getExperienceToc`.

**Tag unified on `<knowledge>`** (Navigator/Researcher previously emitted `<hint>`). No prompt wording changed beyond the tag.

### Drift reconciliation
This plan was written at `9e22b0d`. Since then:
- **Step 2 (shared tracker instances)** is already done in main — Navigator uses `explorer.getKnowledgeTracker()` / `getStateManager().getExperienceTracker()`, Captain uses `explorBot.experienceTracker()`. No `new KnowledgeTracker()`/`new ExperienceTracker()` remain in these files.
- **Step 3 (historian per-call `new KnowledgeTracker()`)** — already gone from `historian/`.

### Deferred
- **Step 4 (deletion-scope + stop-meta dedup)** — deferred; touches tester/pilot/test-plan and is a separable concern.
- **Step 5 (`Navigator.visitOnce` → `Explorer.visit`)** — DEFERRED: behavioral (AI navigation would start honoring knowledge `wait`/`waitForElement` hints); wants its own review, as the plan's checkbox allows.

### Verification
- `bun test tests/unit` → **768 pass / 0 fail** (+4 renderer tests).
- `bun test tests/integration/` → **63 pass / 0 fail**.
- `bun run lint` → clean; `tsc` in touched files neutral vs main (21).
- `grep -rn "<hint>" src/ai/` → 0.
- Tracker mocks in tester/researcher tests updated to expose the new render methods (documented test change — no `<hint>` assertions existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)