### PR TITLE
refactor: consolidate dir/slug/error/heading/sleep helpers (plan 020)

### DIFF
--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -7,6 +7,7 @@ import { TTLCache } from './utils/cache.ts';
 import { type HtmlDiffPart, type HtmlDiffResult, htmlDiff } from './utils/html-diff.ts';
 import { extractHeadings, extractLinks, extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, minifyHtml } from './utils/html.ts';
 import { createDebug } from './utils/logger.ts';
+import { slugify } from './utils/strings.ts';
 import { extractStatePath, matchesUrl } from './utils/url-matcher.ts';
 
 const debugLog = createDebug('explorbot:state');
@@ -497,13 +498,7 @@ export class ActionResult implements ActionResultData {
       }
     }
 
-    let stateString = parts
-      .map((part) => part.substring(0, 100))
-      .join('_')
-      .replace(/[^a-zA-Z0-9_]/g, '_')
-      .replace(/_+/g, '_')
-      .replace(/^_|_$/g, '')
-      .toLowerCase();
+    let stateString = slugify(parts.map((part) => part.substring(0, 100)).join('_'));
 
     if (stateString.length > 200) {
       stateString = stateString.substring(0, 200);

--- a/src/action.ts
+++ b/src/action.ts
@@ -10,10 +10,10 @@ import type { ExplorbotConfig } from './config.js';
 import { Observability } from './observability.ts';
 import type { PlaywrightRecorder } from './playwright-recorder.ts';
 import type { StateManager } from './state-manager.js';
-import { isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
+import { browserErrorMessage, isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
 import { captureHtmlForSnapshot, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
 import { createDebug, setStepSpanParent, tag } from './utils/logger.js';
-import { waitForPageReadiness } from './utils/page-readiness.ts';
+import { sleep, waitForPageReadiness } from './utils/page-readiness.ts';
 import { codeceptJSSandbox, hasPlaywrightCommands, playwrightSandbox, sanitizeCodeBlock } from './utils/web-sandbox.ts';
 import { safeFilename } from './utils/strings.ts';
 
@@ -155,7 +155,7 @@ class Action {
       this.stateManager.updateState(result, codeBlock);
       return result;
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
+      const msg = browserErrorMessage(err);
       if (isFatalBrowserError(err)) throw err;
       debugLog('capturePageState failed with non-fatal error:', msg);
       const url = this.playwrightHelper.page?.url?.() || '';
@@ -389,10 +389,6 @@ async function captureTitle(page: any, actor: any): Promise<string> {
   if (page?.title) return page.title();
   if (actor?.grabTitle) return actor.grabTitle();
   return '';
-}
-
-function sleep(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 const ASSERTION_STEP_NAMES = new Set(['see', 'dontSee', 'seeElement', 'dontSeeElement', 'seeInField', 'dontSeeInField', 'seeInCurrentUrl', 'dontSeeInCurrentUrl']);

--- a/src/ai/captain.ts
+++ b/src/ai/captain.ts
@@ -6,6 +6,7 @@ import { ExperienceTracker } from '../experience-tracker.js';
 import type { ExplorBot } from '../explorbot.ts';
 import type { WebPageState } from '../state-manager.ts';
 import { Task, Test } from '../test-plan.ts';
+import { formatHeadings } from '../utils/context-formatter.ts';
 import { HooksRunner } from '../utils/hooks-runner.ts';
 import { startLogCapture, stopLogCapture, tag } from '../utils/logger.js';
 import { loop } from '../utils/loop.js';
@@ -164,11 +165,7 @@ export class Captain extends CaptainBase implements Agent {
     const knowledge = this.getKnowledge(actionResult);
     const experience = this.getExperience(actionResult);
 
-    const headingLines: string[] = [];
-    if (state.h1) headingLines.push(`H1: ${state.h1}`);
-    if (state.h2) headingLines.push(`H2: ${state.h2}`);
-    if (state.h3) headingLines.push(`H3: ${state.h3}`);
-    if (state.h4) headingLines.push(`H4: ${state.h4}`);
+    const headingLines = formatHeadings(state);
     const headingsBlock = headingLines.join('\n');
 
     let pageSummary = '';

--- a/src/ai/experience-compactor.ts
+++ b/src/ai/experience-compactor.ts
@@ -1,4 +1,5 @@
 import { unlinkSync } from 'node:fs';
+import { basename } from 'node:path';
 import dedent from 'dedent';
 import { type Tokens, marked } from 'marked';
 import { z } from 'zod';
@@ -12,6 +13,8 @@ import type { Provider } from './provider.js';
 
 const debugLog = createDebug('explorbot:experience-compactor');
 
+export const COMPACT_MAX_LENGTH = 5000;
+
 export type { ExperienceFile };
 
 interface MergeGroup {
@@ -23,7 +26,6 @@ export class ExperienceCompactor implements Agent {
   emoji = '🗜️';
   private provider: Provider;
   private experienceTracker: ExperienceTracker;
-  private MAX_LENGTH = 5000;
 
   constructor(provider: Provider, experienceTracker: ExperienceTracker) {
     this.provider = provider;
@@ -32,7 +34,7 @@ export class ExperienceCompactor implements Agent {
 
   async compactExperience(experience: string): Promise<string> {
     const stripped = this.stripNonUsefulEntries(experience);
-    if (stripped.length < this.MAX_LENGTH) {
+    if (stripped.length < COMPACT_MAX_LENGTH) {
       return stripped;
     }
 
@@ -129,7 +131,7 @@ export class ExperienceCompactor implements Agent {
       if (!url || url.startsWith('~')) continue;
       const generalized = generalizeUrl(url);
       if (generalized === url) continue;
-      const stateHash = file.filePath.split('/').pop()?.replace('.md', '') || '';
+      const stateHash = basename(file.filePath, '.md');
       const newData = { ...file.data, url: `~${generalized}~`, mergedFrom: [url] };
       this.experienceTracker.writeExperienceFile(stateHash, file.content, newData);
       tag('substep').log(`Generalized URL: ${url} → ~${generalized}~`);
@@ -139,7 +141,7 @@ export class ExperienceCompactor implements Agent {
   }
 
   async compactFiles(files: ExperienceFile[], options?: { skipSmall?: boolean }): Promise<number> {
-    const workingSet = options?.skipSmall ? files.filter((f) => f.content.length >= this.MAX_LENGTH) : files;
+    const workingSet = options?.skipSmall ? files.filter((f) => f.content.length >= COMPACT_MAX_LENGTH) : files;
 
     let compactedCount = 0;
     const total = workingSet.length;
@@ -151,7 +153,7 @@ export class ExperienceCompactor implements Agent {
 
     for (let i = 0; i < workingSet.length; i++) {
       const experience = workingSet[i];
-      const shortName = experience.filePath.split('/').pop() || experience.filePath;
+      const shortName = basename(experience.filePath);
       const willReview = this.isRecent(experience);
 
       if (total > 1 && willReview) {
@@ -164,8 +166,8 @@ export class ExperienceCompactor implements Agent {
         content = await this.reviewExperienceQuality(content, experience.data);
       }
 
-      if (content.length >= this.MAX_LENGTH) {
-        if (total > 1) tag('substep').log(`[${i + 1}/${total}] compacting ${shortName} (over ${this.MAX_LENGTH} chars)`);
+      if (content.length >= COMPACT_MAX_LENGTH) {
+        if (total > 1) tag('substep').log(`[${i + 1}/${total}] compacting ${shortName} (over ${COMPACT_MAX_LENGTH} chars)`);
         const prompt = this.buildCompactionPrompt(content);
         const model = this.provider.getModelForAgent('experience-compactor');
         const response = await this.provider.chat(
@@ -181,7 +183,7 @@ export class ExperienceCompactor implements Agent {
 
       if (content === experience.content) continue;
 
-      const stateHash = experience.filePath.split('/').pop()?.replace('.md', '') || '';
+      const stateHash = basename(experience.filePath, '.md');
       this.experienceTracker.writeExperienceFile(stateHash, content, experience.data);
       debugLog('Experience file compacted:', experience.filePath);
       compactedCount++;
@@ -314,7 +316,7 @@ export class ExperienceCompactor implements Agent {
     const [targetFile, ...sourceFiles] = group.files;
     const combinedContent = group.files.map((f) => f.content).join('\n\n---\n\n');
 
-    const targetStateHash = targetFile.filePath.split('/').pop()?.replace('.md', '') || '';
+    const targetStateHash = basename(targetFile.filePath, '.md');
     const newFrontmatter = {
       ...targetFile.data,
       url: group.pattern,
@@ -350,7 +352,7 @@ export class ExperienceCompactor implements Agent {
       <rules>
       - Use markdown h2 headers only (##) - NO XML tags or wrappers in output
       - Merge similar flows to remove duplicates
-      - Keep output under ${this.MAX_LENGTH} characters
+      - Keep output under ${COMPACT_MAX_LENGTH} characters
       - Be explicit and short - no proposals or explanations
 
       KEEP only:

--- a/src/ai/rerunner.ts
+++ b/src/ai/rerunner.ts
@@ -17,6 +17,7 @@ import type Explorer from '../explorer.ts';
 import type { KnowledgeTracker } from '../knowledge-tracker.ts';
 import { Stats } from '../stats.ts';
 import { Task, Test, TestResult } from '../test-plan.ts';
+import { formatHeadings } from '../utils/context-formatter.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
 import { RulesLoader } from '../utils/rules-loader.ts';
@@ -481,11 +482,7 @@ export class Rerunner extends TaskAgent implements Agent {
     const state = this.explorer.getStateManager().getCurrentState();
     const actionResult = state ? ActionResult.fromState(state) : null;
 
-    const headings: string[] = [];
-    if (state?.h1) headings.push(`H1: ${state.h1}`);
-    if (state?.h2) headings.push(`H2: ${state.h2}`);
-    if (state?.h3) headings.push(`H3: ${state.h3}`);
-    if (state?.h4) headings.push(`H4: ${state.h4}`);
+    const headings = formatHeadings(state || {});
 
     return dedent`
       A test step failed and needs healing.

--- a/src/commands/compact-command.ts
+++ b/src/commands/compact-command.ts
@@ -1,11 +1,9 @@
 import { basename } from 'node:path';
 import chalk from 'chalk';
-import type { ExperienceFile } from '../ai/experience-compactor.js';
+import { COMPACT_MAX_LENGTH, type ExperienceFile } from '../ai/experience-compactor.js';
 import type { ExperienceTracker } from '../experience-tracker.js';
 import { tag } from '../utils/logger.js';
 import { BaseCommand, type Suggestion } from './base-command.js';
-
-const COMPACT_THRESHOLD = 5000;
 
 export class CompactCommand extends BaseCommand {
   name = 'compact';
@@ -62,7 +60,7 @@ export class CompactCommand extends BaseCommand {
   private buildDryRunSuggestions(compactor: ReturnType<typeof this.explorBot.agentExperienceCompactor>, files: ExperienceFile[], target?: string): Suggestion[] {
     const wouldTouch = files.filter((f) => {
       const stripped = compactor.stripNonUsefulEntries(f.content);
-      return stripped !== f.content || stripped.length >= COMPACT_THRESHOLD || compactor.isRecent(f);
+      return stripped !== f.content || stripped.length >= COMPACT_MAX_LENGTH || compactor.isRecent(f);
     });
     if (wouldTouch.length === 0) return [];
     const argsPart = target ? ` ${target}` : '';
@@ -119,7 +117,7 @@ export class CompactCommand extends BaseCommand {
       const charsRemoved = chars - strippedChars;
       const willStrip = stripped !== file.content;
       const willReview = compactor.isRecent(file);
-      const willAi = strippedChars >= COMPACT_THRESHOLD;
+      const willAi = strippedChars >= COMPACT_MAX_LENGTH;
 
       if (willStrip) wouldStrip++;
       if (willReview) wouldAiReview++;
@@ -148,7 +146,7 @@ export class CompactCommand extends BaseCommand {
     lines.push(`  ${chalk.dim('Files matched:')}      ${chalk.bold(String(files.length))}`);
     lines.push(`  ${chalk.dim('Would strip:')}        ${chalk.bold(String(wouldStrip))} ${chalk.dim('(remove legacy / FAILED / Visual click, rename to FLOW/ACTION)')}`);
     lines.push(`  ${chalk.dim('Would ai-review:')}    ${chalk.bold(String(wouldAiReview))} ${chalk.dim('(recent files ≤30d — quality/reusability check)')}`);
-    lines.push(`  ${chalk.dim('Would ai-compact:')}   ${chalk.bold(String(wouldAiCompact))} ${chalk.dim(`(over ${COMPACT_THRESHOLD} chars after strip)`)}`);
+    lines.push(`  ${chalk.dim('Would ai-compact:')}   ${chalk.bold(String(wouldAiCompact))} ${chalk.dim(`(over ${COMPACT_MAX_LENGTH} chars after strip)`)}`);
     lines.push(`  ${chalk.dim('Total chars:')}        ${chalk.bold(String(totalChars))}`);
 
     tag('info').log(lines.join('\n'));

--- a/src/config.ts
+++ b/src/config.ts
@@ -362,6 +362,18 @@ export class ConfigParser {
     return path.join(path.dirname(configPath), config.dirs?.output || 'output');
   }
 
+  public getProjectRoot(): string {
+    const configPath = this.getConfigPath();
+    if (configPath) return path.dirname(configPath);
+    return process.cwd();
+  }
+
+  public resolveProjectDir(relativeDir: string): string {
+    const configPath = this.getConfigPath();
+    if (!configPath) return relativeDir;
+    return path.join(path.dirname(configPath), relativeDir);
+  }
+
   public getStatesDir(): string {
     return outputPath('states');
   }

--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs';
-import { basename, dirname, join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
 import matter from 'gray-matter';
 import { type Tokens, marked } from 'marked';
 import type { ActionResult } from './action-result.js';
@@ -7,6 +7,7 @@ import { ConfigParser } from './config.js';
 import { KnowledgeTracker } from './knowledge-tracker.js';
 import type { WebPageState } from './state-manager.js';
 import { createDebug, tag } from './utils/logger.js';
+import { loadMarkdownFiles } from './utils/markdown-files.js';
 import { mdq } from './utils/markdown-query.js';
 import { isNonReusableCode } from './utils/step-analyzer.ts';
 import { extractStatePath } from './utils/url-matcher.js';
@@ -41,17 +42,11 @@ export class ExperienceTracker {
   constructor(knowledgeTracker: KnowledgeTracker, options: { disabled?: boolean } = {}) {
     const configParser = ConfigParser.getInstance();
     const config = configParser.getConfig();
-    const configPath = configParser.getConfigPath();
     this.disabled = options.disabled ?? false;
     this.knowledgeTracker = knowledgeTracker;
 
     // Resolve experience directory relative to the config file location (project root)
-    if (configPath) {
-      const projectRoot = dirname(configPath);
-      this.experienceDir = join(projectRoot, config.dirs?.experience || 'experience');
-    } else {
-      this.experienceDir = config.dirs?.experience || 'experience';
-    }
+    this.experienceDir = configParser.resolveProjectDir(config.dirs?.experience || 'experience');
 
     if (!this.disabled) {
       this.ensureDirectory(this.experienceDir);
@@ -233,25 +228,7 @@ export class ExperienceTracker {
       }
 
       try {
-        const files = readdirSync(experienceDir)
-          .filter((file: string) => file.endsWith('.md'))
-          .map((file: string) => join(experienceDir, file));
-
-        for (const file of files) {
-          try {
-            const content = readFileSync(file, 'utf8');
-            const parsed = matter(content);
-            const mtime = statSync(file).mtime;
-            allFiles.push({
-              filePath: file,
-              data: parsed.data,
-              content: parsed.content,
-              mtime,
-            });
-          } catch (error) {
-            debugLog(`Failed to read experience file ${file}:`, error);
-          }
-        }
+        allFiles.push(...loadMarkdownFiles(experienceDir));
       } catch (error) {
         debugLog(`Failed to read experience directory ${experienceDir}:`, error);
       }

--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -228,7 +228,11 @@ export class ExperienceTracker {
       }
 
       try {
-        allFiles.push(...loadMarkdownFiles(experienceDir));
+        allFiles.push(
+          ...loadMarkdownFiles(experienceDir, {
+            onError: (filePath, error) => debugLog(`Failed to read experience file ${filePath}:`, error),
+          })
+        );
       } catch (error) {
         debugLog(`Failed to read experience directory ${experienceDir}:`, error);
       }

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -28,6 +28,7 @@ import { WebPageState } from './state-manager.ts';
 import { Stats } from './stats.ts';
 import type { Suite } from './suite.ts';
 import { Plan, type Test } from './test-plan.ts';
+import { browserErrorMessage } from './utils/browser-errors.ts';
 import { setVerboseMode, tag } from './utils/logger.ts';
 import { relativeToCwd } from './utils/next-steps.ts';
 import { sanitizeFilename } from './utils/strings.ts';
@@ -94,7 +95,7 @@ export class ExplorBot {
         await this.agentExperienceCompactor().autocompact();
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = browserErrorMessage(error);
       console.error('\nFailed to start:', message);
       process.exit(1);
     }
@@ -487,7 +488,7 @@ export class ExplorBot {
 
       this.lastReportedTestCount = tests.length;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = browserErrorMessage(error);
       tag('warning').log(`Session analysis failed: ${message}`);
     }
   }

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -21,10 +21,10 @@ import { PlaywrightRecorder } from './playwright-recorder.ts';
 import { Reporter } from './reporter.ts';
 import { StateManager } from './state-manager.js';
 import { Test, TestResult } from './test-plan.ts';
-import { BrowserRecoveryError, isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
+import { BrowserRecoveryError, browserErrorMessage, isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
 import { ELEMENT_EXTRACTION_CONFIG, getElementDataExtractorSource } from './utils/html.ts';
 import { createDebug, log, tag } from './utils/logger.js';
-import { waitForPageReadiness } from './utils/page-readiness.ts';
+import { sleep, waitForPageReadiness } from './utils/page-readiness.ts';
 import { WebElement } from './utils/web-element.ts';
 
 declare global {
@@ -90,8 +90,7 @@ class Explorer {
     try {
       // Use project root for output directory, not current working directory
       const configParser = ConfigParser.getInstance();
-      const configPath = configParser.getConfigPath();
-      const projectRoot = configPath ? path.dirname(configPath) : process.cwd();
+      const projectRoot = configParser.getProjectRoot();
       (global as any).output_dir = path.join(projectRoot, 'output', 'states');
       (global as any).codecept_dir = projectRoot;
 
@@ -154,8 +153,7 @@ class Explorer {
     };
 
     if (this.config.stepsFile) {
-      const configPath = ConfigParser.getInstance().getConfigPath();
-      const projectRoot = configPath ? path.dirname(configPath) : process.cwd();
+      const projectRoot = ConfigParser.getInstance().getProjectRoot();
       codeceptConfig.include = { I: path.resolve(projectRoot, this.config.stepsFile) };
     }
 
@@ -371,7 +369,7 @@ class Explorer {
       try {
         await action.execute(`I.amOnPage(${serializedUrl})`);
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
+        const msg = browserErrorMessage(err);
         if (!RECOVERABLE_NAVIGATION_ERRORS.test(msg)) throw err;
         tag('warning').log(`Navigation warning (continuing after load): ${msg.split('\n')[0]}`);
         await this.waitForPageReadiness();
@@ -420,7 +418,7 @@ class Explorer {
       return result;
     } catch (error) {
       if (this.isFatalBrowserError(error)) {
-        tag('warning').log(`getEidxInContainer: ${error instanceof Error ? error.message : error}`);
+        tag('warning').log(`getEidxInContainer: ${browserErrorMessage(error)}`);
         await this.recoverFromBrowserError();
       }
       return [];
@@ -435,7 +433,7 @@ class Explorer {
       return await el.first().getAttribute(ELEMENT_EXTRACTION_CONFIG.attrs.eidx);
     } catch (error) {
       if (this.isFatalBrowserError(error)) {
-        tag('warning').log(`getEidxByLocator: ${error instanceof Error ? error.message : error}`);
+        tag('warning').log(`getEidxByLocator: ${browserErrorMessage(error)}`);
         await this.recoverFromBrowserError();
       }
       return null;
@@ -486,7 +484,7 @@ class Explorer {
       await this.playwrightHelper.page.reload({ waitUntil: 'domcontentloaded', timeout: 10000 });
       return this.waitForPageReadiness();
     } catch (err) {
-      tag('error').log(`Browser recovery failed: ${err instanceof Error ? err.message : err}`);
+      tag('error').log(`Browser recovery failed: ${browserErrorMessage(err)}`);
       return false;
     }
   }
@@ -530,7 +528,7 @@ class Explorer {
       tag('success').log('Browser restarted');
       return true;
     } catch (err) {
-      tag('error').log(`Browser restart failed: ${err instanceof Error ? err.message : err}`);
+      tag('error').log(`Browser restart failed: ${browserErrorMessage(err)}`);
       return false;
     }
   }
@@ -562,7 +560,7 @@ class Explorer {
       return await page.evaluate(() => window.top !== window.self);
     } catch (error) {
       if (this.isFatalBrowserError(error)) {
-        tag('warning').log(`isInsideIframe: ${error instanceof Error ? error.message : error}`);
+        tag('warning').log(`isInsideIframe: ${browserErrorMessage(error)}`);
         await this.recoverFromBrowserError();
       }
       return false;
@@ -735,7 +733,7 @@ class Explorer {
   }
 
   async handleExecutionError(error: unknown): Promise<BrowserExecutionErrorResult> {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = browserErrorMessage(error);
     tag('error').log(`Browser execution error: ${message}`);
 
     if (error instanceof Error && error.name === 'AbortError') {
@@ -849,7 +847,7 @@ class Explorer {
       return await pwLocator.count();
     } catch (error) {
       if (this.isFatalBrowserError(error)) {
-        tag('warning').log(`playwrightLocatorCount: ${error instanceof Error ? error.message : error}`);
+        tag('warning').log(`playwrightLocatorCount: ${browserErrorMessage(error)}`);
         await this.recoverFromBrowserError();
       }
       throw error;
@@ -871,7 +869,7 @@ class Explorer {
 
       this.stateManager.updateStateFromBasic(newUrl, newTitle, 'navigation');
 
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      await sleep(500);
     });
   }
 

--- a/src/knowledge-tracker.ts
+++ b/src/knowledge-tracker.ts
@@ -1,10 +1,12 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import matter from 'gray-matter';
 import { ActionResult } from './action-result.js';
 import { ConfigParser } from './config.js';
 import { getCliName } from './utils/cli-name.ts';
 import { createDebug } from './utils/logger.js';
+import { loadMarkdownFiles } from './utils/markdown-files.js';
+import { slugify } from './utils/strings.js';
 
 const debugLog = createDebug('explorbot:knowledge-tracker');
 
@@ -23,14 +25,7 @@ export class KnowledgeTracker {
   constructor() {
     const configParser = ConfigParser.getInstance();
     const config = configParser.getConfig();
-    const configPath = configParser.getConfigPath();
-
-    if (configPath) {
-      const projectRoot = dirname(configPath);
-      this.knowledgeDir = join(projectRoot, config.dirs?.knowledge || 'knowledge');
-    } else {
-      this.knowledgeDir = config.dirs?.knowledge || 'knowledge';
-    }
+    this.knowledgeDir = configParser.resolveProjectDir(config.dirs?.knowledge || 'knowledge');
 
     if (!existsSync(this.knowledgeDir)) {
       mkdirSync(this.knowledgeDir, { recursive: true });
@@ -42,29 +37,13 @@ export class KnowledgeTracker {
 
     this.knowledgeFiles = [];
 
-    if (!existsSync(this.knowledgeDir)) {
-      return;
-    }
-
-    const files = readdirSync(this.knowledgeDir, { recursive: true })
-      .filter((file) => typeof file === 'string' && file.endsWith('.md'))
-      .map((file) => join(this.knowledgeDir, file as string));
-
-    for (const filePath of files) {
-      try {
-        const fileContent = readFileSync(filePath, 'utf8');
-        const parsed = matter(fileContent);
-        const urlPattern = parsed.data.url || parsed.data.path || '*';
-
-        this.knowledgeFiles.push({
-          filePath,
-          url: urlPattern,
-          content: this.interpolateVars(parsed.content),
-          ...parsed.data,
-        });
-      } catch (error) {
-        // Skip invalid files
-      }
+    for (const entry of loadMarkdownFiles(this.knowledgeDir, { recursive: true })) {
+      this.knowledgeFiles.push({
+        filePath: entry.filePath,
+        url: entry.data.url || entry.data.path || '*',
+        content: this.interpolateVars(entry.content),
+        ...entry.data,
+      });
     }
 
     this.isLoaded = true;
@@ -80,23 +59,19 @@ export class KnowledgeTracker {
 
   addKnowledge(urlPattern: string, description: string): { filename: string; filePath: string; isNewFile: boolean } {
     const configParser = ConfigParser.getInstance();
-    const config = configParser.getConfig();
     const configPath = configParser.getConfigPath();
 
     if (!configPath) {
       throw new Error(`No explorbot configuration found. Please run "${getCliName()} init" first.`);
     }
 
-    const projectRoot = dirname(configPath);
-    const knowledgeDir = join(projectRoot, config.dirs?.knowledge || 'knowledge');
-
-    if (!existsSync(knowledgeDir)) {
-      mkdirSync(knowledgeDir, { recursive: true });
+    if (!existsSync(this.knowledgeDir)) {
+      mkdirSync(this.knowledgeDir, { recursive: true });
     }
 
     const normalizedUrl = this.normalizeUrl(urlPattern);
     const filename = this.generateFilename(normalizedUrl);
-    const filePath = join(knowledgeDir, filename);
+    const filePath = join(this.knowledgeDir, filename);
 
     const isNewFile = !existsSync(filePath);
 
@@ -154,12 +129,7 @@ export class KnowledgeTracker {
   }
 
   private generateFilename(url: string): string {
-    let filename = url
-      .replace(/https?:\/\//g, '')
-      .replace(/[^a-zA-Z0-9_]/g, '_')
-      .replace(/_+/g, '_')
-      .replace(/^_|_$/g, '')
-      .toLowerCase();
+    let filename = slugify(url.replace(/https?:\/\//g, ''));
 
     if (!filename || filename === '*') {
       filename = 'general';

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -3,6 +3,7 @@ import { ExperienceTracker } from './experience-tracker.js';
 import { KnowledgeTracker, type Knowledge } from './knowledge-tracker.js';
 import { detectFocusArea } from './utils/aria.js';
 import { createDebug } from './utils/logger.js';
+import { slugify } from './utils/strings.js';
 import { extractStatePath } from './utils/url-matcher.js';
 
 const debugLog = createDebug('explorbot:state');
@@ -209,13 +210,7 @@ export class StateManager {
       parts.push(`title_${title}`);
     }
 
-    return parts
-      .join('_')
-      .replace(/[^a-zA-Z0-9_]/g, '_')
-      .replace(/_+/g, '_')
-      .replace(/^_|_$/g, '')
-      .toLowerCase()
-      .substring(0, 200);
+    return slugify(parts.join('_')).substring(0, 200);
   }
 
   /**

--- a/src/utils/context-formatter.ts
+++ b/src/utils/context-formatter.ts
@@ -29,6 +29,15 @@ function indent(text: string): string {
     .join('\n');
 }
 
+export function formatHeadings(headings: { h1?: string; h2?: string; h3?: string; h4?: string }): string[] {
+  const lines: string[] = [];
+  if (headings.h1) lines.push(`H1: ${headings.h1}`);
+  if (headings.h2) lines.push(`H2: ${headings.h2}`);
+  if (headings.h3) lines.push(`H3: ${headings.h3}`);
+  if (headings.h4) lines.push(`H4: ${headings.h4}`);
+  return lines;
+}
+
 export type ContextMode = 'attached' | 'compact' | 'full';
 
 export function formatContextSummary(data: ContextData, mode: ContextMode = 'compact'): string {
@@ -51,11 +60,7 @@ function formatContextAttached(data: ContextData): string {
   }
   lines.push('');
 
-  const headingLines: string[] = [];
-  if (data.headings.h1) headingLines.push(`H1: ${data.headings.h1}`);
-  if (data.headings.h2) headingLines.push(`H2: ${data.headings.h2}`);
-  if (data.headings.h3) headingLines.push(`H3: ${data.headings.h3}`);
-  if (data.headings.h4) headingLines.push(`H4: ${data.headings.h4}`);
+  const headingLines = formatHeadings(data.headings);
 
   if (headingLines.length > 0) {
     lines.push(section('HEADINGS') + chalk.gray(' (Auto-attached)'));
@@ -116,11 +121,7 @@ function formatContextCompact(data: ContextData): string {
   }
   lines.push('');
 
-  const headingLines: string[] = [];
-  if (data.headings.h1) headingLines.push(`H1: ${data.headings.h1}`);
-  if (data.headings.h2) headingLines.push(`H2: ${data.headings.h2}`);
-  if (data.headings.h3) headingLines.push(`H3: ${data.headings.h3}`);
-  if (data.headings.h4) headingLines.push(`H4: ${data.headings.h4}`);
+  const headingLines = formatHeadings(data.headings);
 
   if (headingLines.length > 0) {
     lines.push(section('HEADINGS') + chalk.gray(' (Auto-attached)'));
@@ -177,11 +178,7 @@ function formatContextFull(data: ContextData): string {
   }
   lines.push('');
 
-  const headingLines: string[] = [];
-  if (data.headings.h1) headingLines.push(`H1: ${data.headings.h1}`);
-  if (data.headings.h2) headingLines.push(`H2: ${data.headings.h2}`);
-  if (data.headings.h3) headingLines.push(`H3: ${data.headings.h3}`);
-  if (data.headings.h4) headingLines.push(`H4: ${data.headings.h4}`);
+  const headingLines = formatHeadings(data.headings);
 
   if (headingLines.length > 0) {
     lines.push(section('HEADINGS') + chalk.gray(' (Auto-attached)'));

--- a/src/utils/markdown-files.ts
+++ b/src/utils/markdown-files.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import matter from 'gray-matter';
 
-export function loadMarkdownFiles(dir: string, options: { recursive?: boolean } = {}): MarkdownFile[] {
+export function loadMarkdownFiles(dir: string, options: { recursive?: boolean; onError?: (filePath: string, error: unknown) => void } = {}): MarkdownFile[] {
   if (!existsSync(dir)) return [];
 
   const results: MarkdownFile[] = [];
@@ -14,7 +14,9 @@ export function loadMarkdownFiles(dir: string, options: { recursive?: boolean } 
     try {
       const parsed = matter(readFileSync(filePath, 'utf8'));
       results.push({ filePath, content: parsed.content, data: parsed.data, mtime: statSync(filePath).mtime });
-    } catch {}
+    } catch (error) {
+      options.onError?.(filePath, error);
+    }
   }
 
   return results;

--- a/src/utils/markdown-files.ts
+++ b/src/utils/markdown-files.ts
@@ -1,0 +1,28 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import matter from 'gray-matter';
+
+export function loadMarkdownFiles(dir: string, options: { recursive?: boolean } = {}): MarkdownFile[] {
+  if (!existsSync(dir)) return [];
+
+  const results: MarkdownFile[] = [];
+  const files = readdirSync(dir, { recursive: options.recursive === true })
+    .filter((file): file is string => typeof file === 'string' && file.endsWith('.md'))
+    .map((file) => join(dir, file));
+
+  for (const filePath of files) {
+    try {
+      const parsed = matter(readFileSync(filePath, 'utf8'));
+      results.push({ filePath, content: parsed.content, data: parsed.data, mtime: statSync(filePath).mtime });
+    } catch {}
+  }
+
+  return results;
+}
+
+export interface MarkdownFile {
+  filePath: string;
+  content: string;
+  data: Record<string, any>;
+  mtime: Date;
+}

--- a/src/utils/page-readiness.ts
+++ b/src/utils/page-readiness.ts
@@ -49,7 +49,7 @@ function waitForPageBodyContent(page: any, timeout: number): Promise<void> {
     .catch(() => {});
 }
 
-function sleep(ms: number): Promise<void> {
+export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -6,6 +6,14 @@ export function truncateJson(input: any): string {
   return str.length <= 80 ? str : `${str.slice(0, 77)}...`;
 }
 
+export function slugify(text: string): string {
+  return text
+    .replace(/[^a-zA-Z0-9_]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .toLowerCase();
+}
+
 export function sanitizeFilename(name: string): string {
   return name
     .toLowerCase()

--- a/tests/unit/markdown-files.test.ts
+++ b/tests/unit/markdown-files.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { loadMarkdownFiles } from '../../src/utils/markdown-files.ts';
+
+it('reports unreadable markdown files and continues loading', () => {
+  const dir = mkdtempSync(join(process.cwd(), '.markdown-files-'));
+  const unreadablePath = join(dir, 'unreadable.md');
+  const errors: Array<{ filePath: string; error: unknown }> = [];
+
+  try {
+    writeFileSync(join(dir, 'valid.md'), '---\nurl: /page\n---\nContent');
+    mkdirSync(unreadablePath);
+
+    const files = loadMarkdownFiles(dir, {
+      onError: (filePath, error) => errors.push({ filePath, error }),
+    });
+
+    expect(files).toHaveLength(1);
+    expect(files[0].data.url).toBe('/page');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].filePath).toBe(unreadablePath);
+    expect(errors[0].error).toBeInstanceOf(Error);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/unit/strings-slugify.test.ts
+++ b/tests/unit/strings-slugify.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'bun:test';
+import { ActionResult } from '../../src/action-result.ts';
+import { slugify } from '../../src/utils/strings.ts';
+
+describe('slugify', () => {
+  it('sanitizes a URL path with query into an underscore slug', () => {
+    expect(slugify('/users/42?tab=info')).toBe('users_42_tab_info');
+  });
+
+  it('replaces unicode and punctuation and collapses separators', () => {
+    expect(slugify('Café — Menu!')).toBe('caf_menu');
+  });
+
+  it('trims leading and trailing separators', () => {
+    expect(slugify('  Hello World  ')).toBe('hello_world');
+    expect(slugify('--hello--world--')).toBe('hello_world');
+  });
+
+  it('leaves an already-clean slug unchanged', () => {
+    expect(slugify('already_clean_slug')).toBe('already_clean_slug');
+  });
+
+  it('keeps ActionResult.getStateHash stable (disk file names must not change)', () => {
+    const result = new ActionResult({ url: 'https://example.com/admin/users', html: '<h1>User List</h1>' });
+    expect(result.getStateHash()).toBe('admin_users_h1_user_list');
+  });
+});


### PR DESCRIPTION
## Plan 020 — Consolidate small-but-everywhere duplications into shared utils

Seven tiny patterns were copy-pasted across the codebase. Each is now a single owner (per the CLAUDE.md Code Ownership Map). **Every change is output-identical.**

| Pattern | Owner | Copies removed |
|---|---|---|
| Project-dir resolution | `ConfigParser.getProjectRoot()` / `resolveProjectDir()` | 6 |
| On-disk slug chain | `utils/strings.slugify()` | 3 |
| `error instanceof Error ?` → message | `browserErrorMessage()` (existing) | 11 |
| H1–H4 heading ladder | `context-formatter.formatHeadings()` | 5 |
| `sleep()` | one exported `page-readiness.sleep` | 3 |
| Markdown-dir loading loop | `utils/markdown-files.loadMarkdownFiles()` | 2 |
| Compactor 5000-char threshold | exported `COMPACT_MAX_LENGTH` + `basename()` | — |

### Byte-identity gate
`getStateHash` names files on disk — a changed hash orphans existing state/experience/cache files. New `tests/unit/strings-slugify.test.ts` pins `slugify` against hardcoded old-chain expectations **and** asserts `getStateHash` returns its exact pre-refactor value (`admin_users_h1_user_list`). Each adopter keeps its own pre/post steps (100-char pre-slice + 200-cap in `getStateHash`; protocol-strip + `general` fallback in `generateFilename`; `.substring(0,200)` in `generateBasicHash`).

### Deviations from the plan (both forced)
1. **Step 5 config-defaulting skipped.** The plan wanted `waitForPageReadiness` to read config internally and collapse the wrappers. But `page-readiness.test.ts` runs with **no config loaded** and `ConfigParser.getConfig()` throws there — the plan's own STOP condition. Only the `sleep` consolidation was done; both wrappers keep passing their explicit config options.
2. **`loadMarkdownFiles` gained an opt-in `recursive` flag.** knowledge-tracker scans recursively; experience-tracker does not. The flag preserves both behaviors exactly.

### Out of scope (coordinated)
- `src/ai/tools.ts` — owned by plan 018 (#89).
- StateManager knowledge loading — deleted by plan 010 (already in main); only `generateBasicHash`'s slug was touched.

### Verification
- `bun test tests/unit` → **769 pass / 0 fail** (+5 slugify tests).
- `bun test tests/integration/` → **63 pass / 0 fail**.
- `bun run lint` → clean; `tsc` total **641 → 640** (no new errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)