### PR TITLE
refactor: style-rule cleanup in isolated files (plan 016, partial)

### DIFF
--- a/src/ai/fisherman-tools.ts
+++ b/src/ai/fisherman-tools.ts
@@ -158,7 +158,7 @@ function extractKeyFields(body: any, result: Record<string, any> = {}, depth = 0
   }
 
   for (const [key, value] of Object.entries(body)) {
-    if (value === null || value === undefined) continue;
+    if (value == null) continue;
     if (typeof value === 'object') {
       extractKeyFields(value, result, depth + 1);
       continue;

--- a/src/ai/quartermaster.ts
+++ b/src/ai/quartermaster.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { z } from 'zod';
 import type { ActionResult } from '../action-result.ts';
-import { ConfigParser } from '../config.ts';
+import { outputPath } from '../config.ts';
 import type { StateManager, StateTransition, WebPageState } from '../state-manager.ts';
 import type { Task } from '../test-plan.ts';
 import { createDebug, tag } from '../utils/logger.ts';
@@ -11,36 +11,6 @@ import type { Conversation, ToolExecution } from './conversation.ts';
 import type { Provider } from './provider.ts';
 
 const debugLog = createDebug('explorbot:quartermaster');
-
-interface AxeViolation {
-  id: string;
-  impact: 'critical' | 'serious' | 'moderate' | 'minor';
-  description: string;
-  helpUrl: string;
-  nodes: Array<{ html: string; target: string[] }>;
-}
-
-interface PageAnalysis {
-  url: string;
-  stateHash: string;
-  timestamp: string;
-  axeViolations: AxeViolation[];
-}
-
-interface SemanticIssue {
-  type: 'unclear_intention' | 'confusing_naming' | 'hard_to_interact';
-  element: string;
-  issue: string;
-  suggestion: string;
-}
-
-interface AnalysisReport {
-  scenario: string;
-  timestamp: string;
-  url: string;
-  axeViolations: AxeViolation[];
-  semanticIssues: SemanticIssue[];
-}
 
 export class Quartermaster {
   private provider: Provider;
@@ -55,13 +25,12 @@ export class Quartermaster {
     this.provider = provider;
     this.model = options?.model;
 
-    const configParser = ConfigParser.getInstance();
-    this.outputDir = join(configParser.getOutputDir(), 'a11y');
+    this.outputDir = outputPath('a11y');
   }
 
   start(playwrightHelper: any, stateManager: StateManager): void {
     this.playwrightHelper = playwrightHelper;
-    this.ensureDirectory();
+    mkdirSync(this.outputDir, { recursive: true });
 
     this.unsubscribe = stateManager.onStateChange((event) => {
       this.onPageChange(event);
@@ -76,12 +45,6 @@ export class Quartermaster {
       this.unsubscribe = null;
     }
     debugLog('Quartermaster stopped');
-  }
-
-  private ensureDirectory(): void {
-    if (!existsSync(this.outputDir)) {
-      mkdirSync(this.outputDir, { recursive: true });
-    }
   }
 
   private onPageChange(event: StateTransition): void {
@@ -283,4 +246,34 @@ Focus on what would confuse a real user or caused the agent to make mistakes.`;
 
     return content;
   }
+}
+
+interface AxeViolation {
+  id: string;
+  impact: 'critical' | 'serious' | 'moderate' | 'minor';
+  description: string;
+  helpUrl: string;
+  nodes: Array<{ html: string; target: string[] }>;
+}
+
+interface PageAnalysis {
+  url: string;
+  stateHash: string;
+  timestamp: string;
+  axeViolations: AxeViolation[];
+}
+
+interface SemanticIssue {
+  type: 'unclear_intention' | 'confusing_naming' | 'hard_to_interact';
+  element: string;
+  issue: string;
+  suggestion: string;
+}
+
+interface AnalysisReport {
+  scenario: string;
+  timestamp: string;
+  url: string;
+  axeViolations: AxeViolation[];
+  semanticIssues: SemanticIssue[];
 }


### PR DESCRIPTION
## Plan 016 — Mechanical style batch (PARTIAL — see deferral)

Plan 016 is the **run-last** style sweep (private-method reordering, types-at-end, ternary/conditional-spread removal across ~20 core files). Its own dependency: *"run last to avoid merge churn — pure-move reorderings conflict with every other diff."*

All six of this session's refactor PRs (#88–#93) plus #85/#86/#87 are still open and touch nearly every file 016 targets. Doing the reordering now would conflict with all of them. **So this PR does only the items in files that no open PR touches**, and defers the rest until the batch merges.

### Done here (non-conflicting)
- `fisherman-tools.ts`: `value === null || value === undefined` → `value == null` (kept `== null` rather than `!value` because `0`/`''`/`false` are valid field values).
- `quartermaster.ts`: 4 interfaces moved to end of file (CLAUDE.md "types at end"); `outputPath('a11y')` instead of `join(configParser.getOutputDir(), 'a11y')`; dropped the `existsSync` guard (`mkdirSync` recursive tolerates an existing dir) and inlined `ensureDirectory` away.

### Deferred (until #85–#93 merge)
Private-method reordering, type-moves, and the ternary/conditional-spread/one-liner cleanups in tester, tools, provider, pilot, driller, conversation, planner, researcher, captain, experience-tracker, experience-compactor, state-manager, explorer, etc. — every one of those files is modified by an open PR, so 016's reorderings must wait to avoid conflicts.

### Verification
- `bun test tests/unit` → **764 pass / 0 fail**; `bun test tests/integration/` → **63 pass / 0 fail**.
- `bun run lint` → clean; `tsc` no new errors in the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)