### PR TITLE
State transition diagram for doc collector

### DIFF
--- a/boat/doc-collector/src/ai/documentarian.ts
+++ b/boat/doc-collector/src/ai/documentarian.ts
@@ -5,7 +5,7 @@ import type Explorer from '../../../../src/explorer.ts';
 import type { WebPageState } from '../../../../src/state-manager.ts';
 import { tag } from '../../../../src/utils/logger.ts';
 import type { DocbotConfig } from '../config.ts';
-import { collectDocInteractions } from './tools.ts';
+import { type CaptureInteractionState, type DocStateTransition, collectDocInteractions } from './tools.ts';
 
 class Documentarian {
   private provider: AIProvider;
@@ -18,7 +18,7 @@ class Documentarian {
     this.explorer = explorer;
   }
 
-  async document(state: WebPageState, research: string): Promise<PageDocumentation> {
+  async document(state: WebPageState, research: string, captureState?: CaptureInteractionState): Promise<PageDocumentation> {
     const interactiveEnabled = this.config.docs?.interactive === true && this.explorer;
     if (!interactiveEnabled) {
       tag('info').log('Documentarian: Using static mode (interactive disabled or no explorer)');
@@ -26,7 +26,7 @@ class Documentarian {
     }
 
     tag('info').log('Documentarian: Using interactive mode with tools');
-    return this.documentWithInteraction(state, research);
+    return this.documentWithInteraction(state, research, captureState);
   }
 
   private async documentStatic(state: WebPageState, research: string): Promise<PageDocumentation> {
@@ -41,12 +41,13 @@ class Documentarian {
     }
   }
 
-  private async documentWithInteraction(state: WebPageState, research: string): Promise<PageDocumentation> {
+  private async documentWithInteraction(state: WebPageState, research: string, captureState?: CaptureInteractionState): Promise<PageDocumentation> {
+    let meaningfulInteractions: StateTransition[] = [];
     try {
       tag('info').log('Starting interactive exploration...');
 
-      const deterministicInteractions = await collectDocInteractions(this.explorer!, state, research, this.config);
-      const meaningfulInteractions = this.getMeaningfulInteractions(deterministicInteractions);
+      const deterministicInteractions = await collectDocInteractions(this.explorer!, state, research, this.config, captureState);
+      meaningfulInteractions = this.getMeaningfulInteractions(deterministicInteractions);
       if (meaningfulInteractions.length > 0) {
         tag('success').log(`Collected ${meaningfulInteractions.length} deterministic interactions`);
         return await this.generateDocumentationWithInteractions(state, research, meaningfulInteractions);
@@ -61,7 +62,20 @@ class Documentarian {
       return this.documentStatic(state, research);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      tag('warning').log(`Interactive documentation failed: ${message}. Falling back to static.`);
+      tag('warning').log(`Interactive documentation failed: ${message}.`);
+      if (meaningfulInteractions.length > 0) {
+        tag('info').log(`Preserving ${meaningfulInteractions.length} observed interaction(s) without AI summary.`);
+        return this.normalizeDocumentation(
+          {
+            summary: `Observed ${meaningfulInteractions.length} interaction(s); AI-generated summary was unavailable.`,
+            can: [],
+            might: [],
+            interactions: meaningfulInteractions,
+          },
+          state,
+          research
+        );
+      }
       return this.documentStatic(state, research);
     }
   }
@@ -354,26 +368,7 @@ const pageDocumentationSchema = z.object({
   interactions: z.array(stateTransitionSchema).nullable(),
 });
 
-type StateTransition = {
-  action: string;
-  before: string;
-  after: string;
-  targetUrl?: string | null;
-  discoveredUrls?: string[] | null;
-  newCapabilities?: string[] | null;
-  element?: {
-    role: string;
-    name: string;
-    section: string;
-    container?: string | null;
-    locator?: string | null;
-  } | null;
-  changes?: {
-    urlChanged: boolean;
-    newElements: number;
-    removedElements: number;
-  } | null;
-};
+type StateTransition = DocStateTransition;
 type PageDocumentation = Omit<z.infer<typeof pageDocumentationSchema>, 'interactions'> & {
   interactions?: StateTransition[];
   qualityNotes?: string[];

--- a/boat/doc-collector/src/ai/tools.ts
+++ b/boat/doc-collector/src/ai/tools.ts
@@ -1,6 +1,7 @@
 import { type ResearchElement, parseResearchSections } from '../../../../src/ai/researcher/parser.ts';
 import type Explorer from '../../../../src/explorer.ts';
 import type { WebPageState } from '../../../../src/state-manager.ts';
+import { detectFocusArea } from '../../../../src/utils/aria.ts';
 import type { DocbotConfig } from '../config.ts';
 
 export interface DocStateTransition {
@@ -12,6 +13,8 @@ export interface DocStateTransition {
   newCapabilities?: string[];
   element?: InteractionElement;
   changes?: InteractionChanges;
+  targetState?: InteractionState;
+  screenshot?: InteractionScreenshot;
 }
 
 interface InteractionCandidate {
@@ -35,6 +38,19 @@ interface InteractionChanges {
   removedElements: number;
 }
 
+export interface InteractionState {
+  kind: 'page' | 'dialog' | 'modal' | 'section';
+  label: string;
+  url: string;
+}
+
+export interface InteractionScreenshot {
+  title: string;
+  relativePath: string;
+}
+
+export type CaptureInteractionState = (state: WebPageState, transition: DocStateTransition) => Promise<InteractionScreenshot | null>;
+
 const DEFAULT_MAX_PRIMARY_CANDIDATES = 3;
 const DEFAULT_MAX_INTERACTIONS = 5;
 const MAX_LINKS = 15;
@@ -42,14 +58,14 @@ const DEFAULT_WAIT_MS = 700;
 const TAB_WAIT_MS = 500;
 const DEFAULT_DENIED_ACTION_LABELS = ['delete', 'remove', 'destroy', 'archive', 'discard', 'logout', 'sign out', 'signout', 'sign_out', 'erase', 'drop'];
 
-export async function collectDocInteractions(explorer: Explorer, state: WebPageState, research: string, config: DocbotConfig = {}): Promise<DocStateTransition[]> {
+export async function collectDocInteractions(explorer: Explorer, state: WebPageState, research: string, config: DocbotConfig = {}, captureState?: CaptureInteractionState): Promise<DocStateTransition[]> {
   const sections = parseResearchSections(research);
   const transitions: DocStateTransition[] = [];
   const maxInteractions = getPositiveConfigNumber(config.docs?.maxInteractions, DEFAULT_MAX_INTERACTIONS);
   const tabGroup = findTabGroup(sections);
 
   if (tabGroup) {
-    transitions.push(...(await exploreTabGroup(explorer, tabGroup, state.url, maxInteractions)));
+    transitions.push(...(await exploreTabGroup(explorer, tabGroup, state.url, maxInteractions, captureState)));
   }
 
   for (const candidate of findActionCandidates(sections, config)) {
@@ -57,7 +73,7 @@ export async function collectDocInteractions(explorer: Explorer, state: WebPageS
       break;
     }
 
-    const transition = await executeInteraction(explorer, candidate, state.url, DEFAULT_WAIT_MS);
+    const transition = await executeInteraction(explorer, candidate, state.url, DEFAULT_WAIT_MS, captureState);
     if (!transition) {
       continue;
     }
@@ -76,7 +92,7 @@ export function pickDocActionCandidates(research: string, config: DocbotConfig =
   }));
 }
 
-async function exploreTabGroup(explorer: Explorer, tabGroup: { elements: ResearchElement[]; container?: string; sectionName: string }, restoreUrl: string, maxInteractions: number): Promise<DocStateTransition[]> {
+async function exploreTabGroup(explorer: Explorer, tabGroup: { elements: ResearchElement[]; container?: string; sectionName: string }, restoreUrl: string, maxInteractions: number, captureState?: CaptureInteractionState): Promise<DocStateTransition[]> {
   const transitions: DocStateTransition[] = [];
 
   for (const element of tabGroup.elements) {
@@ -93,7 +109,8 @@ async function exploreTabGroup(explorer: Explorer, tabGroup: { elements: Researc
         sectionName: tabGroup.sectionName,
       },
       restoreUrl,
-      TAB_WAIT_MS
+      TAB_WAIT_MS,
+      captureState
     );
     if (!transition) {
       continue;
@@ -106,7 +123,7 @@ async function exploreTabGroup(explorer: Explorer, tabGroup: { elements: Researc
   return transitions;
 }
 
-async function executeInteraction(explorer: Explorer, candidate: InteractionCandidate, restoreUrl: string, waitMs: number): Promise<DocStateTransition | null> {
+async function executeInteraction(explorer: Explorer, candidate: InteractionCandidate, restoreUrl: string, waitMs: number, captureState?: CaptureInteractionState): Promise<DocStateTransition | null> {
   const beforeState = explorer.getStateManager().getCurrentState();
   if (!beforeState) {
     return null;
@@ -132,7 +149,14 @@ async function executeInteraction(explorer: Explorer, candidate: InteractionCand
     removedElements: ariaChanges.removedCount,
   });
 
-  if (urlChanged) {
+  if (captureState && isMeaningfulStateTransition(transition)) {
+    const screenshot = await captureState(afterState, transition);
+    if (screenshot) {
+      transition.screenshot = screenshot;
+    }
+  }
+
+  if (urlChanged || ariaChanges.newCount > 0) {
     await restoreInteractionState(explorer, restoreUrl);
   }
 
@@ -175,6 +199,7 @@ function buildTransition(candidate: InteractionCandidate, beforeState: WebPageSt
     newCapabilities: collectDiscoveryNotes(afterState, changes),
     element: buildInteractionElement(candidate),
     changes,
+    targetState: describeTargetState(beforeState, afterState, candidate),
   };
 
   if (changes.urlChanged) {
@@ -182,6 +207,38 @@ function buildTransition(candidate: InteractionCandidate, beforeState: WebPageSt
   }
 
   return transition;
+}
+
+function describeTargetState(beforeState: WebPageState, afterState: WebPageState, candidate: InteractionCandidate): InteractionState {
+  const beforeFocus = detectFocusArea(beforeState.ariaSnapshot || null);
+  const afterFocus = detectFocusArea(afterState.ariaSnapshot || null);
+  if (afterFocus.detected && (!beforeFocus.detected || beforeFocus.name !== afterFocus.name)) {
+    return {
+      kind: afterFocus.type || 'dialog',
+      label: afterFocus.name || candidate.element.name.trim(),
+      url: afterState.url,
+    };
+  }
+
+  const beforePath = beforeState.url.split('?')[0].split('#')[0];
+  const afterPath = afterState.url.split('?')[0].split('#')[0];
+  const headings = collectHeadings(afterState);
+  let kind: InteractionState['kind'] = 'page';
+  if (beforePath === afterPath) {
+    kind = 'section';
+  }
+  return {
+    kind,
+    label: headings[0] || afterState.title || candidate.element.name.trim(),
+    url: afterState.url,
+  };
+}
+
+function isMeaningfulStateTransition(transition: DocStateTransition): boolean {
+  if (transition.targetUrl || transition.changes?.urlChanged) {
+    return true;
+  }
+  return (transition.changes?.newElements || 0) > 0;
 }
 
 function buildInteractionElement(candidate: InteractionCandidate): InteractionElement {

--- a/boat/doc-collector/src/docbot.ts
+++ b/boat/doc-collector/src/docbot.ts
@@ -8,9 +8,10 @@ import { sanitizeFilename } from '../../../src/utils/strings.ts';
 import { Documentarian, type PageDocumentation } from './ai/documentarian.ts';
 import { type DocbotConfig, DocbotConfigParser } from './config.ts';
 import { type DocumentedPage, type SkippedPage, renderPageDocumentation, renderSpecIndex } from './docs-renderer.ts';
+import { renderMermaidBody } from './state-diagram.ts';
 import { getDocPageKey, shouldCrawlDocPath } from './path-filter.ts';
 import { extractResearchNavigationTargets } from './research-navigation.ts';
-import { type DocumentationScreenshot, captureDocumentationScreenshots } from './screenshots.ts';
+import { type DocumentationScreenshot, captureDocumentationScreenshots, captureInteractionScreenshot } from './screenshots.ts';
 
 class DocBot {
   private explorBot: ExplorBot;
@@ -111,7 +112,17 @@ class DocBot {
           screenshot: this.shouldUseScreenshots(),
           force: true,
         });
-        const documentation = await this.documentarian.document(state, research);
+        const pagePath = this.getPageFilePath(state.url);
+        const documentation = await this.documentarian.document(state, research, async (interactionState, transition) => {
+          if (!this.shouldUseScreenshots()) {
+            return null;
+          }
+          return captureInteractionScreenshot(this.explorBot.getExplorer(), interactionState, transition, {
+            pageFilePath: pagePath,
+            screenshotsDir: this.getScreenshotsDir(),
+            config: this.config,
+          });
+        });
         const lowSignalReason = this.getLowSignalReason(documentation, research);
         if (lowSignalReason) {
           skipped.push({
@@ -134,6 +145,7 @@ class DocBot {
           mightActions: documentation.might.map((item) => item.action),
           interactionActions: (documentation.interactions || []).map((item) => item.action),
           qualityNotes: documentation.qualityNotes || [],
+          interactions: documentation.interactions || [],
           filePath,
         });
         documented.add(pageKey);
@@ -159,12 +171,13 @@ class DocBot {
       }
     }
 
-    const indexPath = this.saveIndex(effectiveStartPath, pages, skipped, effectiveMaxPages);
+    const { indexPath, diagramPath } = this.saveIndex(effectiveStartPath, pages, skipped, effectiveMaxPages);
 
     return {
       pages,
       skipped,
       indexPath,
+      diagramPath,
       outputDir: this.configParser.getOutputDir(),
     };
   }
@@ -385,6 +398,10 @@ class DocBot {
       return null;
     }
 
+    if ((documentation.interactions || []).length > 0) {
+      return null;
+    }
+
     const interactiveCount = this.countInteractiveElements(research);
     if (interactiveCount >= minInteractiveElements) {
       return null;
@@ -417,10 +434,13 @@ class DocBot {
     });
   }
 
-  private saveIndex(startPath: string, pages: DocumentedPage[], skipped: SkippedPage[], maxPages: number): string {
-    const indexPath = path.join(this.configParser.getOutputDir(), 'spec.md');
-    writeFileSync(indexPath, renderSpecIndex(this.configParser.getOutputDir(), startPath, pages, skipped, maxPages), 'utf8');
-    return indexPath;
+  private saveIndex(startPath: string, pages: DocumentedPage[], skipped: SkippedPage[], maxPages: number): { indexPath: string; diagramPath: string } {
+    const outputDir = this.configParser.getOutputDir();
+    const indexPath = path.join(outputDir, 'index.md');
+    writeFileSync(indexPath, renderSpecIndex(outputDir, startPath, pages, skipped, maxPages), 'utf8');
+    const diagramPath = path.join(outputDir, 'state-diagram.mmd');
+    writeFileSync(diagramPath, renderMermaidBody(outputDir, pages), 'utf8');
+    return { indexPath, diagramPath };
   }
 
   private getPagesDir(): string {
@@ -461,6 +481,7 @@ interface CollectionResult {
   pages: DocumentedPage[];
   skipped: SkippedPage[];
   indexPath: string;
+  diagramPath: string;
   outputDir: string;
 }
 

--- a/boat/doc-collector/src/docs-renderer.ts
+++ b/boat/doc-collector/src/docs-renderer.ts
@@ -1,7 +1,9 @@
 import path from 'node:path';
-import type { WebPageState } from '../../../src/state-manager.ts';
+import { type WebPageState } from '../../../src/state-manager.ts';
 import type { PageDocumentation, StateTransition } from './ai/documentarian.ts';
 import type { DocumentationScreenshot } from './screenshots.ts';
+import { buildStateGraph, renderMermaidFromGraph, renderStateMapFromGraph, type DocumentedPage, type SkippedPage } from './state-diagram.ts';
+import { normalizeInlineText } from '../../../src/utils/strings.ts';
 
 function renderPageDocumentation(state: WebPageState, documentation: PageDocumentation, screenshots: DocumentationScreenshot[] = []): string {
   const lines: string[] = [];
@@ -46,6 +48,10 @@ function renderPageDocumentation(state: WebPageState, documentation: PageDocumen
         for (const cap of transition.newCapabilities) {
           lines.push(`- ${cap}`);
         }
+        lines.push('');
+      }
+      if (transition.screenshot) {
+        lines.push(`![${normalizeInlineText(transition.screenshot.title)}](${transition.screenshot.relativePath})`);
         lines.push('');
       }
     }
@@ -109,6 +115,18 @@ function renderSpecIndex(outputDir: string, startPath: string, pages: Documented
   lines.push(`Pages skipped: ${skipped.length}`);
   lines.push(`Max pages: ${maxPages}`);
   lines.push('');
+  const graph = buildStateGraph(outputDir, pages);
+  lines.push('## State Transitions');
+  lines.push('');
+  lines.push(`\`\`\`mermaid\n${renderMermaidFromGraph(graph)}\n\`\`\``);
+  lines.push('');
+  const stateMap = renderStateMapFromGraph(graph);
+  if (stateMap) {
+    lines.push('### State Index');
+    lines.push('');
+    lines.push(stateMap);
+    lines.push('');
+  }
   lines.push('## Pages');
   lines.push('');
 
@@ -225,29 +243,6 @@ function ensureSentence(text: string): string {
     return trimmed;
   }
   return `${trimmed}.`;
-}
-
-function normalizeInlineText(text: string): string {
-  return text.normalize('NFKC').replace(/\s+/g, ' ').trim();
-}
-
-interface DocumentedPage {
-  url: string;
-  title: string;
-  summary: string;
-  canCount: number;
-  mightCount: number;
-  interactionCount: number;
-  canActions: string[];
-  mightActions: string[];
-  interactionActions: string[];
-  qualityNotes: string[];
-  filePath: string;
-}
-
-interface SkippedPage {
-  url: string;
-  reason: string;
 }
 
 export { renderPageDocumentation, renderSpecIndex, ensureSentence, normalizeAction };

--- a/boat/doc-collector/src/screenshots.ts
+++ b/boat/doc-collector/src/screenshots.ts
@@ -3,7 +3,9 @@ import path from 'node:path';
 import { parseResearchSections } from '../../../src/ai/researcher/parser.ts';
 import type Explorer from '../../../src/explorer.ts';
 import type { WebPageState } from '../../../src/state-manager.ts';
+import { detectFocusArea } from '../../../src/utils/aria.ts';
 import { safeFilename, sanitizeFilename } from '../../../src/utils/strings.ts';
+import type { DocStateTransition } from './ai/tools.ts';
 import type { DocbotConfig } from './config.ts';
 
 const DEFAULT_MAX_SECTION_SCREENSHOTS = 8;
@@ -59,6 +61,36 @@ export function getScreenshotSections(research: string): ScreenshotSection[] {
   return sections;
 }
 
+export async function captureInteractionScreenshot(explorer: Explorer, state: WebPageState, transition: DocStateTransition, options: DocumentationScreenshotOptions): Promise<DocumentationScreenshot | null> {
+  const page = explorer.playwrightHelper?.page;
+  if (!page) {
+    return null;
+  }
+
+  mkdirSync(options.screenshotsDir, { recursive: true });
+  const pageName = sanitizeFilename(state.url || 'page') || 'page';
+  const stateName = sanitizeFilename(transition.targetState?.label || transition.action) || 'state';
+  const filePath = path.join(options.screenshotsDir, safeFilename(`${pageName}_${stateName}`, '.png'));
+  const focus = detectFocusArea(state.ariaSnapshot || null);
+
+  try {
+    if (focus.detected) {
+      await page.locator('[role="dialog"], [role="alertdialog"], [aria-modal="true"]').last().screenshot({ path: filePath });
+    } else {
+      await page.screenshot({ path: filePath });
+    }
+  } catch {
+    return null;
+  }
+
+  return {
+    title: transition.targetState?.label || transition.action,
+    path: filePath,
+    relativePath: toMarkdownPath(options.pageFilePath, filePath),
+    kind: 'state',
+  };
+}
+
 async function captureFullPageScreenshot(page: any, pageName: string, options: DocumentationScreenshotOptions): Promise<DocumentationScreenshot | null> {
   const filePath = path.join(options.screenshotsDir, safeFilename(`${pageName}_page`, '.png'));
   try {
@@ -110,7 +142,7 @@ export interface DocumentationScreenshot {
   title: string;
   path: string;
   relativePath: string;
-  kind: 'page' | 'section';
+  kind: 'page' | 'section' | 'state';
   selector?: string;
 }
 

--- a/boat/doc-collector/src/state-diagram.ts
+++ b/boat/doc-collector/src/state-diagram.ts
@@ -1,0 +1,281 @@
+import path from 'node:path';
+import { normalizeUrl } from '../../../src/state-manager.ts';
+import { normalizeInlineText } from '../../../src/utils/strings.ts';
+import type { StateTransition } from './ai/documentarian.ts';
+
+function buildStateGraph(outputDir: string, pages: DocumentedPage[]): StateGraph {
+  const pageIds = new Map<string, string>();
+  const pageNodes: StateNode[] = [];
+  const adjacency = new Map<string, Set<string>>();
+  const classAssignment = new Map<StateClass, string[]>([
+    ['page', []],
+    ['dialog', []],
+    ['section', []],
+  ]);
+
+  for (const [index, page] of pages.entries()) {
+    const id = `page${index}`;
+    pageIds.set(normalizeUrl(page.url), id);
+    adjacency.set(id, new Set());
+    classAssignment.get('page')?.push(id);
+    pageNodes.push({ id, kind: 'page', label: page.title || page.url, subLabel: page.url, filePath: page.filePath });
+  }
+
+  const stateKeys = new Map<string, string>();
+  const transientByPage = new Map<string, StateNode[]>();
+  const clicks: StateClick[] = [];
+  const edges: StateEdge[] = [];
+  const drawnBack = new Set<string>();
+  let stateIndex = 0;
+
+  for (const [pageIndex, page] of pages.entries()) {
+    const sourceId = `page${pageIndex}`;
+    for (const transition of page.interactions || []) {
+      const targetState = transition.targetState;
+      if (!targetState) {
+        continue;
+      }
+
+      const normalizedTarget = normalizeUrl(targetState.url);
+      const isPageTarget = targetState.kind === 'page';
+      let pageTargetId: string | undefined;
+      if (isPageTarget) {
+        pageTargetId = pageIds.get(normalizedTarget);
+      }
+      let targetId: string | undefined;
+      if (pageTargetId && pageTargetId !== sourceId) {
+        targetId = pageTargetId;
+      }
+
+      if (!targetId) {
+        const stateKey = `${sourceId}:${targetState.kind}:${normalizeInlineText(targetState.label)}:${normalizedTarget}`;
+        targetId = stateKeys.get(stateKey);
+        if (!targetId) {
+          targetId = `state${stateIndex++}`;
+          stateKeys.set(stateKey, targetId);
+          adjacency.set(targetId, new Set());
+          classAssignment.get(classForKind(targetState.kind))?.push(targetId);
+          const list = transientByPage.get(sourceId) ?? [];
+          list.push({ id: targetId, kind: targetState.kind, label: targetState.label, subLabel: targetState.kind, parentPageId: sourceId });
+          transientByPage.set(sourceId, list);
+          if (transition.screenshot) {
+            const screenshotPath = path.resolve(path.dirname(page.filePath), transition.screenshot.relativePath);
+            clicks.push({ node: targetId, target: path.relative(outputDir, screenshotPath).replaceAll('\\', '/'), tooltip: 'Open state screenshot' });
+          }
+        }
+      }
+
+      if (!targetId) {
+        continue;
+      }
+
+      const pairKey = `${sourceId}>${targetId}`;
+      if (adjacency.get(targetId)?.has(sourceId)) {
+        if (drawnBack.has(pairKey)) {
+          continue;
+        }
+        drawnBack.add(pairKey);
+        edges.push({ source: sourceId, target: targetId, action: transition.action, isBack: true });
+        continue;
+      }
+
+      if (adjacency.get(sourceId)?.has(targetId) || createsCycle(sourceId, targetId, adjacency)) {
+        continue;
+      }
+      adjacency.get(sourceId)?.add(targetId);
+      edges.push({ source: sourceId, target: targetId, action: transition.action, isBack: false });
+    }
+  }
+
+  const pageClicks: StateClick[] = [];
+  for (const pageNode of pageNodes) {
+    const filePath = pageNode.filePath;
+    if (!filePath) {
+      continue;
+    }
+    const relativeFile = path.relative(outputDir, filePath).replaceAll('\\', '/');
+    pageClicks.push({ node: pageNode.id, target: relativeFile, tooltip: `Open ${pageNode.label}` });
+  }
+
+  return { pages: pageNodes, transientByPage, edges, clicks: [...pageClicks, ...clicks], classAssignment };
+}
+
+function renderMermaidBody(outputDir: string, pages: DocumentedPage[]): string {
+  return renderMermaidFromGraph(buildStateGraph(outputDir, pages));
+}
+
+function renderMermaidFromGraph(graph: StateGraph): string {
+  const lines: string[] = ['flowchart TD'];
+  if (graph.pages.length === 0) {
+    lines.push('  empty["No documented states"]');
+    return lines.join('\n');
+  }
+
+  for (const page of graph.pages) {
+    lines.push(`  ${renderNodeLine(page)}`);
+    const children = graph.transientByPage.get(page.id);
+    if (!children || children.length === 0) {
+      continue;
+    }
+    lines.push(`  subgraph sg_${page.id} ["${escapeMermaidLabel(page.label)} — transient states"]`);
+    for (const child of children) {
+      lines.push(`    ${renderNodeLine(child)}`);
+    }
+    lines.push('  end');
+  }
+
+  for (const edge of graph.edges) {
+    let arrow = '-->';
+    if (edge.isBack) {
+      arrow = '-.->';
+    }
+    lines.push(`  ${edge.source} ${arrow}|"${escapeMermaidLabel(edge.action)}"| ${edge.target}`);
+  }
+
+  lines.push('  classDef page fill:#dbeafe,stroke:#2563eb,color:#0f172a;');
+  lines.push('  classDef dialog fill:#ffedd5,stroke:#ea580c,color:#0f172a;');
+  lines.push('  classDef section fill:#f3e8ff,stroke:#9333ea,color:#0f172a;');
+  for (const [className, ids] of graph.classAssignment) {
+    if (ids.length === 0) {
+      continue;
+    }
+    lines.push(`  class ${ids.join(',')} ${className};`);
+  }
+
+  for (const click of graph.clicks) {
+    lines.push(`  click ${click.node} "${click.target}" "${escapeMermaidLabel(click.tooltip)}"`);
+  }
+
+  return lines.join('\n');
+}
+
+function renderStateMapFromGraph(graph: StateGraph): string {
+  if (graph.pages.length === 0) {
+    return '';
+  }
+  const clickByNode = new Map(graph.clicks.map((click) => [click.node, click]));
+  const rows = ['| State | Type | Open |', '| --- | --- | --- |'];
+  for (const pageNode of graph.pages) {
+    const pageClick = clickByNode.get(pageNode.id);
+    let openCell = '—';
+    if (pageClick) {
+      openCell = `[open page](${pageClick.target})`;
+    }
+    rows.push(`| ${escapeTable(pageNode.label)} | page | ${openCell} |`);
+    for (const child of graph.transientByPage.get(pageNode.id) ?? []) {
+      const childClick = clickByNode.get(child.id);
+      let childCell = '—';
+      if (childClick) {
+        childCell = `[view screenshot](${childClick.target})`;
+      }
+      rows.push(`| ${escapeTable(child.label)} | ${child.kind} | ${childCell} |`);
+    }
+  }
+  return rows.join('\n');
+}
+
+function renderNodeLine(node: StateNode): string {
+  const label = `${escapeMermaidLabel(node.label)}<br/>${escapeMermaidLabel(node.subLabel)}`;
+  if (node.kind === 'dialog' || node.kind === 'modal') {
+    return `${node.id}{{"${label}"}}`;
+  }
+  if (node.kind === 'section') {
+    return `${node.id}("${label}")`;
+  }
+  return `${node.id}["${label}"]`;
+}
+
+function createsCycle(sourceId: string, targetId: string, adjacency: Map<string, Set<string>>): boolean {
+  if (sourceId === targetId) {
+    return true;
+  }
+
+  const pending = [targetId];
+  const visited = new Set<string>();
+  while (pending.length > 0) {
+    const nodeId = pending.pop();
+    if (!nodeId || visited.has(nodeId)) {
+      continue;
+    }
+    if (nodeId === sourceId) {
+      return true;
+    }
+    visited.add(nodeId);
+    pending.push(...(adjacency.get(nodeId) || []));
+  }
+  return false;
+}
+
+function escapeMermaidLabel(value: string): string {
+  return normalizeInlineText(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('|', '&#124;');
+}
+
+function escapeTable(value: string): string {
+  return normalizeInlineText(value).replaceAll('|', '\\|');
+}
+
+function classForKind(kind: StateKind): StateClass {
+  if (kind === 'section') {
+    return 'section';
+  }
+  if (kind === 'page') {
+    return 'page';
+  }
+  return 'dialog';
+}
+
+interface DocumentedPage {
+  url: string;
+  title: string;
+  summary: string;
+  canCount: number;
+  mightCount: number;
+  interactionCount: number;
+  canActions: string[];
+  mightActions: string[];
+  interactionActions: string[];
+  qualityNotes: string[];
+  interactions?: StateTransition[];
+  filePath: string;
+}
+
+interface SkippedPage {
+  url: string;
+  reason: string;
+}
+
+type StateKind = 'page' | 'dialog' | 'modal' | 'section';
+type StateClass = 'page' | 'dialog' | 'section';
+
+interface StateNode {
+  id: string;
+  kind: StateKind;
+  label: string;
+  subLabel: string;
+  filePath?: string;
+  parentPageId?: string;
+}
+
+interface StateEdge {
+  source: string;
+  target: string;
+  action: string;
+  isBack: boolean;
+}
+
+interface StateClick {
+  node: string;
+  target: string;
+  tooltip: string;
+}
+
+interface StateGraph {
+  pages: StateNode[];
+  transientByPage: Map<string, StateNode[]>;
+  edges: StateEdge[];
+  clicks: StateClick[];
+  classAssignment: Map<StateClass, string[]>;
+}
+
+export { buildStateGraph, renderMermaidBody, renderMermaidFromGraph, renderStateMapFromGraph };
+export type { DocumentedPage, SkippedPage, StateGraph, StateNode, StateEdge, StateClick };

--- a/docs/doc-collection/basics.md
+++ b/docs/doc-collection/basics.md
@@ -69,12 +69,15 @@ When the run finishes it prints how many pages were documented, how many were sk
 
 ```
 output/docs/
-├── spec.md         # index of everything documented
-├── pages/          # one markdown file per page
-└── screenshots/    # full-page and section captures
+├── index.md         # state map and index of everything documented
+├── state-diagram.mmd # raw Mermaid state-transition artifact (reusable by other agents)
+├── pages/           # one markdown file per page
+└── screenshots/     # full-page and section captures
 ```
 
-`spec.md` opens with run stats (start page, pages documented, pages skipped), then lists every page with its purpose and capabilities, linking to the page files. Pages that were skipped are listed at the bottom with reasons.
+`index.md` opens with run stats and a Mermaid state-transition map, then lists every page with its purpose and capabilities. Page nodes in the diagram link to their documentation. Transient dialogs, modals, tabs, and expanded screen areas appear as child states when interactive collection observes them. Pages that were skipped are listed at the bottom with reasons.
+
+`state-diagram.mmd` is the same state-transition map as a standalone Mermaid file (no markdown fences), so other agents can embed or post-process it without re-rendering `index.md`.
 
 Each page file follows the same shape:
 

--- a/docs/doc-collection/interactive-mode.md
+++ b/docs/doc-collection/interactive-mode.md
@@ -39,7 +39,7 @@ URLs discovered through clicks join the crawl queue, so interactive mode can rea
 The collector does not click everything:
 
 - **Tabs first.** If research found a tab group (2 to 6 tabs), each tab is clicked to capture the page's alternate states.
-- **Then primary actions.** Up to `maxPrimaryCandidates` (default 3) of the most promising links and buttons from the page's content and control sections. Navigation menus, headers, footers, and modal overlays are excluded — clicking those documents the site chrome, not this page.
+- **Then primary actions.** Up to `maxPrimaryCandidates` (default 3) of the most promising links and buttons from the page's content and control sections. Navigation menus, headers, and footers are excluded. Controls that open dialogs or change a local screen area are recorded as child states; controls inside an already open overlay are not explored recursively.
 - **Hard cap.** `maxInteractions` (default 5) limits total clicks per page, tabs included.
 
 Raise the numbers for control-dense pages you want covered deeply; lower them to speed up large crawls:
@@ -67,7 +67,7 @@ Some crawled pages have nothing worth documenting: empty states, redirect stubs,
 - it yields fewer proven actions than `minCanActions` (default 1), and
 - research found fewer interactive elements than `minInteractiveElements` (default 3)
 
-Skipped pages appear at the end of `spec.md` with the reason. This filter applies in static and interactive mode alike. If real pages are being dropped, lower the thresholds; `minCanActions: 0` keeps every page.
+Skipped pages appear at the end of `index.md` with the reason. This filter applies in static and interactive mode alike. If real pages are being dropped, lower the thresholds; `minCanActions: 0` keeps every page.
 
 ## Screenshots
 
@@ -77,6 +77,8 @@ Screenshots are on by default (`screenshot: true`) in both modes. For every docu
 - one screenshot per section the [Researcher](../web-testing/researcher.md) identified — a sidebar, a data table, a filter bar — capped by `maxSectionScreenshots` (default 8)
 
 Images land in `output/docs/screenshots/` and are embedded in the page files, each section shot labeled with the CSS selector it was taken from.
+
+Interactive states are captured before the collector restores the original page. A dialog is cropped to its active overlay when semantic dialog markup is available; other changed screen areas receive a viewport screenshot.
 
 ```ts
 docs: {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -6,6 +6,10 @@ export function truncateJson(input: any): string {
   return str.length <= 80 ? str : `${str.slice(0, 77)}...`;
 }
 
+export function normalizeInlineText(text: string): string {
+  return text.normalize('NFKC').replace(/\s+/g, ' ').trim();
+}
+
 export function sanitizeFilename(name: string): string {
   return name
     .toLowerCase()

--- a/tests/unit/doc-collector.test.ts
+++ b/tests/unit/doc-collector.test.ts
@@ -4,6 +4,7 @@ import { Documentarian } from '../../boat/doc-collector/src/ai/documentarian.ts'
 import { pickDocActionCandidates } from '../../boat/doc-collector/src/ai/tools.ts';
 import { DocBot } from '../../boat/doc-collector/src/docbot.ts';
 import { normalizeAction, renderPageDocumentation, renderSpecIndex } from '../../boat/doc-collector/src/docs-renderer.ts';
+import { renderMermaidBody } from '../../boat/doc-collector/src/state-diagram.ts';
 import { getDocPageKey, shouldCrawlDocPath } from '../../boat/doc-collector/src/path-filter.ts';
 import { extractResearchNavigationTargets } from '../../boat/doc-collector/src/research-navigation.ts';
 import { captureDocumentationScreenshots, getScreenshotSections } from '../../boat/doc-collector/src/screenshots.ts';
@@ -194,6 +195,156 @@ describe('doc-collector renderer', () => {
     expect(markdown).toContain('- Coverage is complete for the visible sign-in form.');
     expect(markdown).toContain('## Skipped');
     expect(markdown).toContain('/users/auth/google_oauth2. Reason: redirected into external auth flow.');
+  });
+
+  it('renders a clickable acyclic Mermaid state map with transient states', () => {
+    const markdown = renderSpecIndex(
+      'D:/project/output/docs',
+      '/suites',
+      [
+        {
+          url: '/suites',
+          title: 'Suites',
+          summary: 'Test suites',
+          canCount: 1,
+          mightCount: 0,
+          interactionCount: 2,
+          canActions: [],
+          mightActions: [],
+          interactionActions: [],
+          qualityNotes: [],
+          interactions: [
+            {
+              action: 'Clicked button: Import tests',
+              before: 'Suites',
+              after: 'Import tests',
+              targetState: { kind: 'dialog', label: 'Import tests', url: '/suites' },
+              screenshot: { title: 'Import tests', relativePath: '../screenshots/suites_import_tests.png' },
+            },
+            {
+              action: 'Clicked link: Suite',
+              before: 'Suites',
+              after: 'Suite details',
+              targetUrl: '/suites/123',
+              targetState: { kind: 'page', label: 'Suite details', url: '/suites/123' },
+            },
+          ],
+          filePath: 'D:/project/output/docs/pages/suites.md',
+        },
+        {
+          url: '/suites/123',
+          title: 'Suite details',
+          summary: 'Suite details',
+          canCount: 1,
+          mightCount: 0,
+          interactionCount: 1,
+          canActions: [],
+          mightActions: [],
+          interactionActions: [],
+          qualityNotes: [],
+          interactions: [
+            {
+              action: 'Clicked link: Back',
+              before: 'Suite details',
+              after: 'Suites',
+              targetUrl: '/suites',
+              targetState: { kind: 'page', label: 'Suites', url: '/suites' },
+            },
+          ],
+          filePath: 'D:/project/output/docs/pages/suite-details.md',
+        },
+      ],
+      [],
+      20
+    );
+
+    expect(markdown).toContain('```mermaid');
+    expect(markdown).toContain('page0 -->|"Clicked button: Import tests"| state0');
+    expect(markdown).toContain('page0 -->|"Clicked link: Suite"| page1');
+    expect(markdown).not.toContain('page1 -->|"Clicked link: Back"| page0');
+    expect(markdown).toContain('page1 -.->|"Clicked link: Back"| page0');
+    expect(markdown).toContain('subgraph sg_page0');
+    expect(markdown).toContain('state0{{"');
+    expect(markdown).toContain('classDef dialog');
+    expect(markdown).toContain('class state0 dialog');
+    expect(markdown).toContain('click page0 "pages/suites.md" "Open Suites"');
+    expect(markdown).toContain('click state0 "screenshots/suites_import_tests.png" "Open state screenshot"');
+    expect(markdown).toContain('| State | Type | Open |');
+    expect(markdown).toContain('[open page](pages/suites.md)');
+    expect(markdown).toContain('[view screenshot](screenshots/suites_import_tests.png)');
+  });
+
+  it('renders a reverse transition as a dotted back-edge without keyword matching', () => {
+    const mermaid = renderMermaidBody('D:/project/output/docs', [
+      {
+        url: '/x',
+        title: 'X',
+        summary: 'X',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 1,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [{ action: 'Open Y', before: 'X', after: 'Y', targetState: { kind: 'page', label: 'Y', url: '/y' } }],
+        filePath: 'D:/project/output/docs/pages/x.md',
+      },
+      {
+        url: '/y',
+        title: 'Y',
+        summary: 'Y',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 1,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [{ action: 'Open X', before: 'Y', after: 'X', targetState: { kind: 'page', label: 'X', url: '/x' } }],
+        filePath: 'D:/project/output/docs/pages/y.md',
+      },
+    ]);
+
+    expect(mermaid).toContain('page0 -->|"Open Y"| page1');
+    expect(mermaid).toContain('page1 -.->|"Open X"| page0');
+  });
+
+  it('exposes a fence-free Mermaid artifact via renderMermaidBody', () => {
+    const mermaid = renderMermaidBody('D:/project/output/docs', [
+      {
+        url: '/a',
+        title: 'Page A',
+        summary: 'A',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 1,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [{ action: 'Open B', before: 'A', after: 'B', targetState: { kind: 'page', label: 'B', url: '/b' } }],
+        filePath: 'D:/project/output/docs/pages/a.md',
+      },
+      {
+        url: '/b',
+        title: 'Page B',
+        summary: 'B',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 0,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [],
+        filePath: 'D:/project/output/docs/pages/b.md',
+      },
+    ]);
+
+    expect(mermaid.startsWith('flowchart TD')).toBe(true);
+    expect(mermaid).not.toContain('```');
+    expect(mermaid).toContain('page0 -->|"Open B"| page1');
   });
 
   it('normalizes might-actions without duplicating prefixes', () => {
@@ -569,6 +720,96 @@ describe('documentarian interactive mode', () => {
     expect(result.can).toHaveLength(1);
   });
 
+  it('records a named dialog as a transient target state', async () => {
+    const states = [
+      { url: '/suites', title: 'Suites', h1: 'Suites', ariaSnapshot: '- heading "Suites"\n- button "Import tests"' },
+      { url: '/suites', title: 'Suites', h1: 'Suites', ariaSnapshot: '- heading "Suites"\n- dialog "Import tests":\n  - heading "Import tests"' },
+    ];
+    let stateIndex = 0;
+    const provider = {
+      async generateObject() {
+        return {
+          object: {
+            summary: 'Suites page',
+            can: [{ action: 'user can import tests', scope: 'page-level', evidence: 'dialog observed' }],
+            might: [],
+            interactions: null,
+          },
+        };
+      },
+    } as any;
+    const explorer = {
+      getStateManager() {
+        return { getCurrentState: () => states[stateIndex] };
+      },
+      createAction() {
+        return {
+          async attempt(command: string) {
+            stateIndex = command.startsWith('I.amOnPage') ? 0 : 1;
+            return true;
+          },
+        };
+      },
+    } as any;
+    const documentarian = new Documentarian(provider, { docs: { interactive: true } }, explorer);
+    const result = await documentarian.document(
+      states[0],
+      `## Content Controls
+
+| Element | Type | ARIA | CSS |
+|------|------|------|------|
+| 'Import tests' | button | { role: 'button', text: 'Import tests' } | 'button.import' |`
+    );
+
+    expect(result.interactions?.[0]?.targetState).toEqual({ kind: 'dialog', label: 'Import tests', url: '/suites' });
+    expect(stateIndex).toBe(0);
+  });
+
+  it('classifies pagination as a section of the same page', async () => {
+    const states = [
+      { url: '/films', title: 'Films', h1: 'Films', ariaSnapshot: '- heading "Films"\n- link "Page 2"' },
+      { url: '/films?page=2', title: 'Films', h1: 'Films', ariaSnapshot: '- heading "Films"\n- link "Item B"' },
+    ];
+    let stateIndex = 0;
+    const provider = {
+      async generateObject() {
+        return {
+          object: {
+            summary: 'Films page',
+            can: [{ action: 'user can browse films', scope: 'list of items', evidence: 'film tiles visible' }],
+            might: [],
+            interactions: null,
+          },
+        };
+      },
+    } as any;
+    const explorer = {
+      getStateManager() {
+        return { getCurrentState: () => states[stateIndex] };
+      },
+      createAction() {
+        return {
+          async attempt(command: string) {
+            stateIndex = command.startsWith('I.amOnPage') ? 0 : 1;
+            return true;
+          },
+        };
+      },
+    } as any;
+    const documentarian = new Documentarian(provider, { docs: { interactive: true } }, explorer);
+    const result = await documentarian.document(
+      states[0],
+      `## Content
+
+| Element | Type | ARIA | CSS |
+|------|------|------|------|
+| 'Page 2' | link | { role: 'link', text: 'Page 2' } | 'a.page-next' |`
+    );
+
+    expect(result.interactions?.[0]?.targetState?.kind).toBe('section');
+    expect(result.interactions?.[0]?.targetState?.url).toBe('/films?page=2');
+  });
+
   it('uses static mode when explorer is not provided', async () => {
     const provider = {
       async generateObject() {
@@ -739,7 +980,7 @@ describe('documentarian interactive mode', () => {
     expect(result.summary).toBe('Static fallback');
   });
 
-  it('falls back to static mode when interactive documentation fails JSON validation', async () => {
+  it('preserves observed interactions when interactive documentation fails JSON validation', async () => {
     const provider = {
       async generateObject(messages: Array<{ role: string; content: string }>) {
         const prompt = messages[1].content;
@@ -815,8 +1056,8 @@ describe('documentarian interactive mode', () => {
 `
     );
 
-    expect(result.summary).toBe('Static fallback');
-    expect((result as any).interactions).toBeUndefined();
+    expect(result.summary).toBe('Observed 1 interaction(s); AI-generated summary was unavailable.');
+    expect(result.interactions).toHaveLength(1);
   });
 
   it('does not call tool fallback when deterministic interactions are unavailable', async () => {


### PR DESCRIPTION
## Summary

Generates a Mermaid state-transition map as the primary doc-collector output, with typed nodes (page/dialog/modal/section), `subgraph` grouping, acyclic edges with dotted back-paths, a standalone `state-diagram.mmd` artifact, and a clickable State Index. 

State classification is purely structural (ARIA focus-area + URL pathname) — no hardcodes or regex — and observed interactions are preserved even when the model fails, so the diagram always reflects real transitions.

https://github.com/testomatio/explorbot/issues/67

### Example
<img width="2123" height="641" alt="image" src="https://github.com/user-attachments/assets/977227f2-b646-4c8a-8502-7847aff01314" />
<img width="1311" height="584" alt="image" src="https://github.com/user-attachments/assets/d9586664-2cfd-421a-bcce-daaadeb05861" />
