### PR TITLE
fix: drop maxOutputTokens from AI connection check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-07-17
+
+### Changes
+- Fixed startup failing with `AI connection failed: Invalid 'max_output_tokens'` on models that reject a one-token response. The check that verifies your AI credentials at startup no longer caps the reply length, so it works with every provider regardless of their minimum.
+
 ## 2026-07-10
 
 ### Changes

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -97,7 +97,6 @@ export class Provider {
       await generateText({
         model: this.config.model,
         prompt: 'hi',
-        maxOutputTokens: 1,
       });
     } catch (error: any) {
       throw new AiError(`AI connection failed: ${error.message}`);


### PR DESCRIPTION
validateConnection() pinged the model with maxOutputTokens: 1, which OpenAI's Responses API rejects (minimum 16), so startup failed with "AI connection failed" even when credentials were valid. Sending no cap at all is provider-agnostic — no minimum can reject an absent parameter.