### PR TITLE
fix: drop the >80%-broken-locators full re-research retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2026-07-17
 
 ### Changes
+- Research is significantly faster on pages where the AI picks an imprecise container selector. Previously, if more than 80% of the researched locators failed validation, Explorbot threw away the finished UI map and regenerated it from scratch — roughly doubling the time spent on the page. Because a single bad container marks all of its child elements broken, this triggered easily, and the re-research usually just corrected the container anyway. Broken locators now go straight to the repair step that fixes them in place, cutting research on affected pages by about a third.
 - Fixed startup failing with `AI connection failed: Invalid 'max_output_tokens'` on models that reject a one-token response. The check that verifies your AI credentials at startup no longer caps the reply length, so it works with every provider regardless of their minimum.
 
 ## 2026-07-10

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -226,14 +226,6 @@ export class Researcher extends ResearcherBase implements Agent {
 
         const toTest = result.locators.filter((l) => l.valid === null);
         await this.testLocators(toTest);
-
-        const brokenCount = result.locators.filter((l) => l.valid === false).length;
-        const brokenRatio = result.locators.length > 0 ? brokenCount / result.locators.length : 0;
-        if (brokenRatio > 0.8 && retriesLeft > 0) {
-          tag('warning').log(`${Math.round(brokenRatio * 100)}% locators broken, waiting 3s and retrying research (${maxRetries - retriesLeft + 1}/${maxRetries})...`);
-          await new Promise((r) => setTimeout(r, 3000));
-          return this.research(state, { ...opts, force: true, _retriesLeft: retriesLeft - 1 } as any);
-        }
       }
 
       // Stage 3: Fix broken sections via AI conversation continuation


### PR DESCRIPTION
## Problem

Trace `d9fd5d5a14aba27bc86cf925f57dc8a1` spent **67s** opening the New Step page, because the researcher **researched the same URL twice** — a `researcher: /steps/new` span containing a nested `researcher` span for the identical URL against the identical DOM:

```
researcher: /steps/new                       67s
  ├── invoke_agent  28s   ← full research report (58 locators, 4 containers)
  └── researcher: /steps/new                 35s   ← re-research, SAME url, SAME DOM
        ├── invoke_agent  21s   ← report regenerated from scratch
        └── invoke_agent  13s   ← fixBrokenSections
```

Two of the four containers were imprecise: `'nav'` matched more than one element (`testLocators` requires `count === 1`) and `'.detail.detail-view-resizable'` matched zero. Those cascade to their child locators, which get marked broken **without ever being tested** — inflating `brokenRatio` past `0.8` and tripping the guard that threw away a usable 28s report.

The regenerated report only swapped `'nav'` → `'.mainnav-menu-body'` and `'.detail.detail-view-resizable'` → `'.detail-view-resizable'`. That's a container correction — precisely what `fixBrokenSections` does by continuing the existing conversation instead of regenerating. It ran anyway, 13s later, and is what actually fixed things.

## Fix

Delete the `brokenRatio > 0.8` retry (8 lines). Broken locators fall through to Stage 3 `fixBrokenSections`, the mechanism built for them. `brokenCount`/`brokenRatio` had no other consumers, and the cascade stops mattering because it was their only input.

Expected: **67s → ~41s** on affected pages, with no nested research span.

## Trade-off

If a page's DOM is genuinely stale when researched, the deleted 3s sleep + regeneration could recover where `fixBrokenSections` will now repair against that same stale DOM. The two catastrophe guards — nothing parsed, *every* container broken — still retry, so only the partially-valid case changes behavior.

## Note for the reviewer

The trace doesn't record *which* retry branch fired, so I inferred it from the 3.243s gap between the first report finishing and the retry starting (3s sleep + locator testing) plus the container evidence. It fits the `brokenRatio` branch and not the other two, but a debug-log replay would confirm it outright.

## Testing

- `bun test tests/unit/` — 808 pass, 0 fail
- `bun test tests/integration/` — 63 pass, 0 fail
- `bun run check:fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)