### PR TITLE
fix: reduce Captain token consumption by 3x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2026-07-17
 
 ### Changes
+- [Captain] Answers now finish as soon as the request is fulfilled — previously every completed request triggered one extra AI call with the full conversation context that produced nothing, roughly doubling token usage per request.
+- [Captain] No longer attaches the full page HTML to every request. Only the ARIA snapshot is kept fresh in the conversation; the AI fetches HTML on demand via the context() tool when it actually needs it.
+- [Captain] The slash-command tool now lists only command names instead of the full help text of every command, shrinking the prompt sent on each request.
 - Fixed startup failing with `AI connection failed: Invalid 'max_output_tokens'` on models that reject a one-token response. The check that verifies your AI credentials at startup no longer caps the reply length, so it works with every provider regardless of their minimum.
 
 ## 2026-07-10

--- a/src/ai/captain.ts
+++ b/src/ai/captain.ts
@@ -221,10 +221,9 @@ export class Captain extends CaptainBase implements Agent {
   }
 
   private async reinjectContextIfNeeded(conversation: Conversation, currentState: WebPageState): Promise<void> {
-    if (conversation.hasTag('page_html', 5)) return Promise.resolve();
+    if (conversation.hasTag('page_aria', 5)) return;
 
     const actionResult = ActionResult.fromState(currentState);
-    const html = await actionResult.combinedHtml();
     const context = dedent`
         Context:
 
@@ -236,13 +235,8 @@ export class Captain extends CaptainBase implements Agent {
         <page_aria>
         ${actionResult.getInteractiveARIA()}
         </page_aria>
-
-        <page_html>
-        ${html}
-        </page_html>
       `;
     conversation.addUserText(context);
-    return Promise.resolve();
   }
 
   private coreTools(task: Task, onDone: (summary: string) => void) {
@@ -273,15 +267,8 @@ export class Captain extends CaptainBase implements Agent {
       runCommand: tool({
         description: dedent`
           Execute a TUI command. Returns log output from command execution.
-          Use only when the user explicitly asks to run a slash command.
-          Never use this to analyze files, reports, logs, plans, generated tests, knowledge, or experience.
-          Never run a slash command unless the user request itself starts with that slash command.
-          ${this.commandDescriptions
-            .map((c) => {
-              const opts = c.options ? ` (${c.options})` : '';
-              return `${c.name} — ${c.description}${opts}`;
-            })
-            .join('\n')}
+          Use only when the user request itself starts with a slash command; pass it through verbatim.
+          Available commands: ${this.commandDescriptions.map((c) => c.name).join(', ')}
         `,
         inputSchema: z.object({
           command: z.string().describe('Slash command to execute, e.g. "/research", "/plan authentication", "/test brave-fox123"'),
@@ -477,6 +464,7 @@ export class Captain extends CaptainBase implements Agent {
         const result = await this.explorBot.getProvider().invokeConversation(conversation, tools, {
           maxToolRoundtrips: 5,
           toolChoice: 'auto',
+          stopWhen: () => isDone,
         });
 
         if (!result) {


### PR DESCRIPTION
## Problem

A Langfuse trace of a single read-only Captain request ("whats on this page") consumed **32,821 tokens** across two ~16K-input generations. Diagnosis showed three independent sources of waste:

1. **A no-op roundtrip after `done()`** — the SDK loop only stopped on `stepCount`, so after `done()` resolved the request, the full 16.4K context was re-sent for a generation that produced 1 token (an empty assistant message). 50% of the trace.
2. **Unconditional full-HTML injection** — `reinjectContextIfNeeded` guarded on `page_html` (which the initial prompt never contains), so it always fired on the first iteration, adding ~4.5K tokens of raw HTML plus a duplicate copy of the ARIA snapshot the initial prompt had just sent.
3. **`runCommand` description inlined the entire `/help` text** (3,720 chars ≈ 1K tokens per call) even though `isExplicitSlashRequest` programmatically restricts the tool to verbatim pass-through of user-typed slash commands.

## Fix

- Pass `stopWhen: () => isDone` to `invokeConversation` — the loop halts the moment `done()` succeeds. A rejected `done()` (missing details) doesn't flip `isDone`, so retries still happen within the same invocation.
- `reinjectContextIfNeeded` now guards on `page_aria` and injects URL/title + ARIA only. HTML remains available on demand via the web-mode `context()` tool.
- `runCommand` description trimmed to a one-line rule plus command names.

## Impact

For the traced request: one generation instead of two, at ~10K input instead of ~16K — **~10K total vs 32.8K**. Savings apply to every Captain roundtrip (no prompt caching on this model tier, so context is repaid in full each step).

## Testing

- `bun test tests/unit/captain-artifacts.test.ts tests/unit/captain-mode.test.ts` — 19 pass
- `bun test tests/integration/` — 63 pass
- `bun run format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)