### PR TITLE
Fixes intermittent failures in tests

### DIFF
--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -58,6 +58,7 @@ class Explorer {
   private testPageErrorHandler: ((error: Error) => void) | null = null;
   private testConsoleHandler: ((message: any) => void) | null = null;
   private testDialogHandler: ((dialog: any) => void) | null = null;
+  private eventDispatcher = codeceptjs.event.dispatcher;
 
   constructor(config: ExplorbotConfig, options: ExplorerOptions | undefined, deps: ExplorerDeps) {
     this.config = config;
@@ -215,17 +216,17 @@ class Explorer {
       stepHandler(step, 'failed', error?.message || String(error), error?.stack);
     };
     const onTestAfter = () => {
-      codeceptjs.event.dispatcher.off('step.passed', onStepPassed);
-      codeceptjs.event.dispatcher.off('step.failed', onStepFailed);
-      codeceptjs.event.dispatcher.off('test.after', onTestAfter);
+      this.eventDispatcher.off('step.passed', onStepPassed);
+      this.eventDispatcher.off('step.failed', onStepFailed);
+      this.eventDispatcher.off('test.after', onTestAfter);
       this.unwatchActiveTestPages();
     };
 
-    codeceptjs.event.dispatcher.emit('test.before', codeceptjsTest);
-    codeceptjs.event.dispatcher.emit('test.start', codeceptjsTest);
-    codeceptjs.event.dispatcher.on('step.passed', onStepPassed);
-    codeceptjs.event.dispatcher.on('step.failed', onStepFailed);
-    codeceptjs.event.dispatcher.on('test.after', onTestAfter);
+    this.eventDispatcher.emit('test.before', codeceptjsTest);
+    this.eventDispatcher.emit('test.start', codeceptjsTest);
+    this.eventDispatcher.on('step.passed', onStepPassed);
+    this.eventDispatcher.on('step.failed', onStepFailed);
+    this.eventDispatcher.on('test.after', onTestAfter);
 
     return { started: true, stop: (meta) => this.finishTest(test, meta) };
   }
@@ -665,17 +666,17 @@ class Explorer {
 
     if (test.isSuccessful) {
       codeceptjsTest.state = 'passed';
-      codeceptjs.event.dispatcher.emit('test.passed', codeceptjsTest);
+      this.eventDispatcher.emit('test.passed', codeceptjsTest);
     } else if (test.isSkipped) {
       codeceptjsTest.state = 'skipped';
-      codeceptjs.event.dispatcher.emit('test.skipped', codeceptjsTest);
+      this.eventDispatcher.emit('test.skipped', codeceptjsTest);
     } else {
       codeceptjsTest.state = 'failed';
-      codeceptjs.event.dispatcher.emit('test.failed', codeceptjsTest);
+      this.eventDispatcher.emit('test.failed', codeceptjsTest);
     }
 
-    codeceptjs.event.dispatcher.emit('test.finish', codeceptjsTest);
-    codeceptjs.event.dispatcher.emit('test.after', codeceptjsTest);
+    this.eventDispatcher.emit('test.finish', codeceptjsTest);
+    this.eventDispatcher.emit('test.after', codeceptjsTest);
   }
 
   private watchActiveTestPage(page = this.playwrightHelper?.page): void {

--- a/tests/unit/explorer-step-listeners.test.ts
+++ b/tests/unit/explorer-step-listeners.test.ts
@@ -1,37 +1,10 @@
 import { describe, expect, it } from 'bun:test';
-import * as codeceptjs from 'codeceptjs';
+import { EventEmitter } from 'node:events';
 import Explorer from '../../src/explorer.ts';
 
-const dispatcher = (codeceptjs as any).event.dispatcher;
-const TRACKED_EVENTS = ['step.passed', 'step.failed', 'test.after'];
-
-// The CodeceptJS dispatcher's listener introspection (listenerCount/listeners) is
-// unreliable under the bun version CI runs, so track live registrations by wrapping
-// on()/off() (which work everywhere). registered[event] holds the handlers currently
-// attached — the leak bug leaves a handler behind because off() used the wrong ref.
-function trackRegistrations(): { registered: Map<string, Set<any>>; restore: () => void } {
-  const registered = new Map<string, Set<any>>(TRACKED_EVENTS.map((event) => [event, new Set()]));
-  const realOn = dispatcher.on.bind(dispatcher);
-  const realOff = dispatcher.off.bind(dispatcher);
-  dispatcher.on = (event: string, fn: any) => {
-    registered.get(event)?.add(fn);
-    return realOn(event, fn);
-  };
-  dispatcher.off = (event: string, fn: any) => {
-    registered.get(event)?.delete(fn);
-    return realOff(event, fn);
-  };
-  return {
-    registered,
-    restore: () => {
-      dispatcher.on = realOn;
-      dispatcher.off = realOff;
-    },
-  };
-}
-
-function buildExplorer() {
+function buildExplorer(dispatcher: EventEmitter) {
   const explorer = Object.assign(Object.create(Explorer.prototype), {
+    eventDispatcher: dispatcher,
     reporter: { reportTestStart: async () => {} },
     stateManager: { getCurrentState: () => null, otherTabs: [] },
     playwrightHelper: { page: { isClosed: () => false } },
@@ -54,34 +27,26 @@ function buildTest() {
 
 describe('Explorer step listener cleanup', () => {
   it('removes every listener it registers after a test lifecycle', async () => {
-    const { registered, restore } = trackRegistrations();
-    try {
-      await buildExplorer().beginTest(buildTest());
-      expect(registered.get('step.passed')!.size).toBe(1);
-      expect(registered.get('test.after')!.size).toBe(1);
+    const dispatcher = new EventEmitter();
+    await buildExplorer(dispatcher).beginTest(buildTest());
+    expect(dispatcher.listenerCount('step.passed')).toBe(1);
+    expect(dispatcher.listenerCount('test.after')).toBe(1);
 
-      dispatcher.emit('test.after');
+    dispatcher.emit('test.after');
 
-      expect(registered.get('step.passed')!.size).toBe(0);
-      expect(registered.get('step.failed')!.size).toBe(0);
-      expect(registered.get('test.after')!.size).toBe(0);
-    } finally {
-      restore();
-    }
+    expect(dispatcher.listenerCount('step.passed')).toBe(0);
+    expect(dispatcher.listenerCount('step.failed')).toBe(0);
+    expect(dispatcher.listenerCount('test.after')).toBe(0);
   });
 
   it('does not accumulate listeners across repeated startTest cycles', async () => {
-    const { registered, restore } = trackRegistrations();
-    try {
-      for (let i = 0; i < 5; i++) {
-        await buildExplorer().beginTest(buildTest());
-        dispatcher.emit('test.after');
-      }
-      expect(registered.get('step.passed')!.size).toBe(0);
-      expect(registered.get('step.failed')!.size).toBe(0);
-      expect(registered.get('test.after')!.size).toBe(0);
-    } finally {
-      restore();
+    const dispatcher = new EventEmitter();
+    for (let i = 0; i < 5; i++) {
+      await buildExplorer(dispatcher).beginTest(buildTest());
+      dispatcher.emit('test.after');
     }
+    expect(dispatcher.listenerCount('step.passed')).toBe(0);
+    expect(dispatcher.listenerCount('step.failed')).toBe(0);
+    expect(dispatcher.listenerCount('test.after')).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

  Fix flaky Explorer listener cleanup tests by replacing global CodeceptJS dispatcher mocking with an isolated event emitter.
  Keep production behavior unchanged while preventing races during parallel test execution.