### PR TITLE
Prima boat — high-level browser driver for orchestrating agents

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
     - name: Verify CLI on Node.js
       run: node dist/bin/explorbot-cli.js --help
 
+    - name: Verify prima CLI on Node.js
+      run: node dist/boat/prima/bin/prima-cli.js --help
+
     - name: Set version from tag
       id: check
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ npx explorbot prima verify "the confirmation page shows an order number"
 - **Attaching to playwright-cli** — prima never launches a browser. By default it attaches to the playwright-cli browser of the current workspace and works on the tabs already open there, so both tools drive the same session. `--pw-session <title>` picks between several open sessions, `--endpoint <ep>` attaches to a browser server directly. Stopping prima disconnects and leaves the browser open.
 - **Named instances** — `prima browser start` runs a prima-owned browser when no playwright-cli session is open, and `--instance <name>` says which one a command talks to, so parallel work gets a browser each. `prima browser list` shows both kinds.
 - **Without a config file** — `EXPLORBOT_AI_PROVIDER=groq npx explorbot prima go https://app.example.com` is enough to start. `pw` still works when no model is usable at all, and the commands that need one say so and point at the fallback.
+- **Runtime** — prima reaches its browser over a Playwright browser-server endpoint, and that client needs the Node build: run it as `npx explorbot prima …` or through the published `prima` bin. Driving a browser by running the CLI from source under Bun does not connect.
 
 Prima also ships as a standalone `prima` bin. See [Commands](docs/reference/commands.md#prima-boat) for the full reference.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## 2026-08-04
+
+### Prima
+
+`explorbot prima` drives a browser that is already open, one command per process, and reports back in plain text. It is meant for coding agents that keep the browser themselves: the agent decides the next step, prima performs it and describes what changed.
+
+```bash
+playwright-cli open https://app.example.com
+npx explorbot prima research
+npx explorbot prima pw "({ page }) => page.click('[data-test=submit]')"
+npx explorbot prima verify "the confirmation page shows an order number"
+```
+
+- **Commands** — `pw` runs a Playwright function expression built from a locator you already verified, `click` and `fill` take one action described in words, `do` runs several described steps tester-style, `go` navigates, `research` maps the page into verified locators, `ask` answers a question about the page, `verify` asserts a statement, and `browser` manages the browsers prima drives.
+- **The envelope** — every page command prints `### Result`, `### Page`, `### Changes`, `### Instance`, and `### Artifacts` on stdout, and exits `0` when the envelope says `ok: true`, `1` when it does not. `used:` holds the code that actually executed, ready to paste into a test. A failure adds the error and the compact ARIA of the page, so the next locator can be picked from the output itself; the full aria, html, and network dumps are written beside it.
+- **Healing** — a failed action is retried along a different route, and `healed: true` means the outcome was reached another way. `--no-heal` fails fast instead.
+- **Attaching to playwright-cli** — prima never launches a browser. By default it attaches to the playwright-cli browser of the current workspace and works on the tabs already open there, so both tools drive the same session. `--pw-session <title>` picks between several open sessions, `--endpoint <ep>` attaches to a browser server directly. Stopping prima disconnects and leaves the browser open.
+- **Named instances** — `prima browser start` runs a prima-owned browser when no playwright-cli session is open, and `--instance <name>` says which one a command talks to, so parallel work gets a browser each. `prima browser list` shows both kinds.
+- **Without a config file** — `EXPLORBOT_AI_PROVIDER=groq npx explorbot prima go https://app.example.com` is enough to start. `pw` still works when no model is usable at all, and the commands that need one say so and point at the fallback.
+
+Prima also ships as a standalone `prima` bin. See [Commands](docs/reference/commands.md#prima-boat) for the full reference.
+
+### New CLI Options
+
+- **`--instance <name>`** — Which named browser server to start, stop, or check. Parallel runs get a browser each instead of sharing one.
+  ```bash
+  explorbot browser start --instance staging
+  explorbot browser status --instance staging
+  explorbot browser stop --instance staging
+  ```
+
+### Configuration
+
+- **`~/.explorbot/config.js|mjs|ts`** — Global configuration, used when the working directory has no `explorbot.config.*`. Lookup order: `--config`, the project config, the global config, then `EXPLORBOT_*` variables.
+- **`~/.explorbot/.env`** — Loaded after the working directory's `.env`, for keys that are not set yet. API keys can live there once instead of in every project.
+
+### Environment Variables
+
+- **`EXPLORBOT_EPHEMERAL`** — Keep no state between runs: output goes to a fresh temp directory instead of the per-host state directory. `prima --ephemeral` sets it for a single command.
+
+### Changes
+
+- Config-free runs now keep their output in a per-host state directory, `~/.explorbot/state/<host>/`, instead of a fresh temp directory every time — states, plans, research, and reports for the same app collect in one place. `EXPLORBOT_OUTPUT` still overrides the location, and `EXPLORBOT_EPHEMERAL=1` restores the throwaway behavior.
+- `explorbot browser start` now stays in the foreground until Ctrl+C. Previously the process could exit as soon as it had printed the endpoint.
+
 ## 2026-07-22
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Prima also ships as a standalone `prima` bin. See [Commands](docs/reference/comm
 ### Changes
 
 - Config-free runs now keep their output in a per-host state directory, `~/.explorbot/state/<host>/`, instead of a fresh temp directory every time — states, plans, research, and reports for the same app collect in one place. `EXPLORBOT_OUTPUT` still overrides the location, and `EXPLORBOT_EPHEMERAL=1` restores the throwaway behavior.
+- Config-free runs now write experience into that state directory, so what worked on a page is remembered for the next run against the same host. Ephemeral runs still write none.
 - `explorbot browser start` now stays in the foreground until Ctrl+C. Previously the process could exit as soon as it had printed the endpoint.
 
 ## 2026-07-22

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ EXPLORBOT_KNOWLEDGE="Log in as admin@example.com / secret123" \
   npx explorbot explore /admin/users --max-tests 3
 ```
 
-Output lands in a temp directory and nothing is written to your project. See [Agentic Usage](docs/workflow/agentic-usage.md).
+Output lands in a per-host state directory, `~/.explorbot/state/<host>/`, so runs against the same app collect in one place and nothing is written to your project. Set `EXPLORBOT_EPHEMERAL=1` to keep nothing between runs. See [Agentic Usage](docs/workflow/agentic-usage.md).
 
 ## Teaching Explorbot
 

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -744,7 +744,7 @@ browserCmd
   .option('-c, --config <path>', 'Path to configuration file')
   .option('-p, --path <path>', 'Working directory path')
   .action(async (options) => {
-    const { launchServer, removeEndpointFile } = await import('../src/browser-server.js');
+    const { launchServer, removeEndpointFile, keepServerRunning } = await import('../src/browser-server.js');
     await ConfigParser.getInstance().loadConfig({
       config: options.config,
       path: options.path,
@@ -763,17 +763,10 @@ browserCmd
       options.instance
     );
 
-    console.log('Browser server is running. Press Ctrl+C to stop.');
-
-    const cleanup = () => {
-      console.log('\nStopping browser server...');
-      server.close();
+    keepServerRunning(async () => {
+      await server.close();
       removeEndpointFile(options.instance);
-      process.exit(0);
-    };
-
-    process.on('SIGINT', cleanup);
-    process.on('SIGTERM', cleanup);
+    });
   });
 
 browserCmd
@@ -869,8 +862,10 @@ program
 
 import { createApiCommands } from '../boat/api-tester/src/cli.ts';
 import { createDocsCommands } from '../boat/doc-collector/src/cli.ts';
+import { createPrimaCommands } from '../boat/prima/src/cli.ts';
 program.addCommand(createApiCommands('api'));
 program.addCommand(createDocsCommands('docs'));
+program.addCommand(createPrimaCommands('prima'));
 
 const envHelp = () => {
   const width = Math.max(...EXPLORBOT_ENV_VARS.map((v) => v.name.length));

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -740,6 +740,7 @@ browserCmd
   .description('Launch a persistent browser server')
   .option('-s, --show', 'Launch browser in headed mode (visible window)')
   .option('--headless', 'Launch browser in headless mode')
+  .option('--instance <name>', 'Named browser instance (lowercase letters, digits, dashes)')
   .option('-c, --config <path>', 'Path to configuration file')
   .option('-p, --path <path>', 'Working directory path')
   .action(async (options) => {
@@ -754,17 +755,20 @@ browserCmd
     if (options.show !== undefined) show = true;
     if (options.headless !== undefined) show = false;
 
-    const server = await launchServer({
-      browser: config.playwright.browser,
-      show,
-    });
+    const server = await launchServer(
+      {
+        browser: config.playwright.browser,
+        show,
+      },
+      options.instance
+    );
 
     console.log('Browser server is running. Press Ctrl+C to stop.');
 
     const cleanup = () => {
       console.log('\nStopping browser server...');
       server.close();
-      removeEndpointFile();
+      removeEndpointFile(options.instance);
       process.exit(0);
     };
 
@@ -775,6 +779,7 @@ browserCmd
 browserCmd
   .command('stop')
   .description('Stop a running browser server')
+  .option('--instance <name>', 'Named browser instance (lowercase letters, digits, dashes)')
   .option('-c, --config <path>', 'Path to configuration file')
   .option('-p, --path <path>', 'Working directory path')
   .action(async (options) => {
@@ -784,7 +789,7 @@ browserCmd
       path: options.path,
     });
 
-    const endpoint = await getAliveEndpoint();
+    const endpoint = await getAliveEndpoint(options.instance);
     if (!endpoint) {
       console.log('No running browser server found.');
       process.exit(0);
@@ -796,13 +801,14 @@ browserCmd
       await browser.close();
     } catch {}
 
-    removeEndpointFile();
+    removeEndpointFile(options.instance);
     console.log('Browser server stopped.');
   });
 
 browserCmd
   .command('status')
   .description('Check if a browser server is running')
+  .option('--instance <name>', 'Named browser instance (lowercase letters, digits, dashes)')
   .option('-c, --config <path>', 'Path to configuration file')
   .option('-p, --path <path>', 'Working directory path')
   .action(async (options) => {
@@ -812,7 +818,7 @@ browserCmd
       path: options.path,
     });
 
-    const endpoint = await getAliveEndpoint();
+    const endpoint = await getAliveEndpoint(options.instance);
     if (endpoint) {
       console.log(`Browser server is running at: ${endpoint}`);
     } else {

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -783,25 +783,17 @@ browserCmd
   .option('-c, --config <path>', 'Path to configuration file')
   .option('-p, --path <path>', 'Working directory path')
   .action(async (options) => {
-    const { getAliveEndpoint, removeEndpointFile } = await import('../src/browser-server.js');
+    const { stopServer } = await import('../src/browser-server.js');
     await ConfigParser.getInstance().loadConfig({
       config: options.config,
       path: options.path,
     });
 
-    const endpoint = await getAliveEndpoint(options.instance);
-    if (!endpoint) {
+    if (!(await stopServer(options.instance))) {
       console.log('No running browser server found.');
       process.exit(0);
     }
 
-    try {
-      const { chromium } = await import('playwright-core');
-      const browser = await chromium.connect(endpoint, { timeout: 3000 });
-      await browser.close();
-    } catch {}
-
-    removeEndpointFile(options.instance);
     console.log('Browser server stopped.');
   });
 

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -763,7 +763,7 @@ browserCmd
       options.instance
     );
 
-    keepServerRunning(async () => {
+    await keepServerRunning(async () => {
       await server.close();
       removeEndpointFile(options.instance);
     });

--- a/boat/prima/bin/prima-cli.ts
+++ b/boat/prima/bin/prima-cli.ts
@@ -1,0 +1,5 @@
+#!/usr/bin/env bun
+import { createPrimaCommands } from '../src/cli.ts';
+
+const program = createPrimaCommands('prima');
+program.parse();

--- a/boat/prima/package.json
+++ b/boat/prima/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "prima",
+  "version": "1.0.0",
+  "description": "High-level browser driver CLI for orchestrating agents",
+  "type": "module",
+  "bin": { "prima": "./bin/prima-cli.ts" },
+  "scripts": {
+    "format": "biome format --write .",
+    "lint:fix": "biome lint --write .",
+    "check:fix": "biome check --write ."
+  },
+  "dependencies": {
+    "commander": "^14.0.1",
+    "dedent": "^1.6.0"
+  }
+}

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -83,6 +83,7 @@ function buildOptions(options: any): PrimaOptions {
     framework: options.framework,
     noVision: options.vision === false,
     url: options.url,
+    baseUrl: options.baseUrl,
     show: options.show,
     headless: options.headless,
     endpoint: options.endpoint,
@@ -176,7 +177,7 @@ export function createPrimaCommands(name = 'prima'): Command {
   });
 
   addCommonOptions(cmd.command('go <target>').description('Navigate to a url, a path, or a page described in plain words')).action(async (target, options) => {
-    if (!options.url && URL.canParse(target)) options.url = target;
+    if (URL.canParse(target)) options.baseUrl = target;
     await runPrima(options, `go ${target}`, (prima) => prima.go(target));
   });
 

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -61,6 +61,9 @@ const helpContract = dedent`
                                while attached, the attached session keeps its own
     Prima never launches a browser implicitly and never closes an attached one - it
     disconnects. browser list shows both kinds; ### Instance names the one you are on.
+    Every browser is reached over a Playwright browser-server endpoint, which needs the
+    Node build - run prima as "npx explorbot prima ..." or through the published prima
+    bin; from source under Bun the connection does not open.
     When no AI model is usable pw still works; for everything else drive
     playwright-cli directly.
     Parsed but not active yet: --framework, so reported code is CodeceptJS whatever
@@ -95,7 +98,7 @@ function addCommonOptions(cmd: Command): Command {
     .option('-i, --instance <name>', 'Browser instance to drive')
     .option('--session [file]', 'Persist cookies and storage to a session file')
     .option('--no-heal', 'Fail immediately instead of letting AI retry a failed action')
-    .option('--ephemeral', 'Keep no state between runs, output goes to a temp directory')
+    .option('--ephemeral', 'Keep no state between runs; applies to config-free runs, where output goes to a temp directory')
     .option('--framework <name>', 'Not active yet: framework the reported code targets, codeceptjs or playwright')
     .option('--url <url>', 'Page to open when the session has no page yet')
     .option('--endpoint <ep>', 'Websocket endpoint of a browser server to attach to, skipping discovery')

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -1,0 +1,184 @@
+import { Command } from 'commander';
+import dedent from 'dedent';
+import { keepServerRunning } from '../../../src/browser-server.ts';
+import { setPreserveConsoleLogs } from '../../../src/utils/logger.ts';
+import { type EnvelopeData, renderEnvelope } from './envelope.ts';
+import { Prima, type PrimaOptions } from './prima.ts';
+
+const helpContract = dedent`
+  Prima drives a browser that is already open. One command per process; every command
+  prints a plain-text envelope on stdout and exits 0 when ok, 1 when not.
+
+  TIERS - choose by what you hold, not by how hard the step looks
+    pw <fn>        Precise. A Playwright function expression built from a locator you
+                   already verified. No AI on the happy path.
+                     prima pw "({ page }) => page.click('[data-test=submit]')"
+    click / fill   One action described in words; AI resolves it on the current page.
+                     prima click "the primary action button in the header"
+                     prima fill "the search box" "a search term"
+    do <steps...>  Several described steps, run tester-style in one process.
+                     prima do "open the account menu" "choose the settings entry"
+    Never pass a locator or a function expression to click/fill/do - describe the target.
+    Never pass a description to pw - it takes executable code only.
+
+  LOOP
+    prima go <url|path|words>  reach the page you want to work on
+    prima research             once per new page; returns verified locators
+    prima pw "..."             drive the page with those locators
+    prima verify "..."         assert the outcome (prima ask "..." to inspect instead)
+    Fall back to click/fill/do whenever research left you no locator to hold.
+
+  ENVELOPE
+    ### Result     ok, command, healed, used
+    ### Page       url, title, state hash, visit count
+    ### Changes    what the accessibility tree gained or lost
+    ### Answer | ### Research | ### Verdict   output of ask, research, verify
+    ### Failure    error, reasoning, healing attempts, compact ARIA of the page
+    ### Instance   the browser you are on and the other instances running
+    ### Artifacts  paths to the full aria.yml, page.html and network.jsonl
+    used: is verified code that already executed - copy it into a test as is.
+    Set EXPLORBOT_NO_BANNER=1 so nothing but the envelope reaches stdout.
+
+  HEALING AND FAILURE
+    A failed action is retried by AI along a different route; healed: true means the
+    outcome was reached another way and used: holds the code that worked.
+    --no-heal skips that and fails fast.
+    Failures print compact ARIA inline, so retarget from the envelope itself and open
+    the artifact files only when the inline snapshot is not enough.
+
+  SESSIONS
+    --instance <name>  which browser process you talk to; parallel work needs one each
+    --session [file]   cookies and storage persisted across processes
+    --endpoint, --pw-session  attach to a browser opened by playwright-cli
+    Prima never launches a browser implicitly. Open one with playwright-cli (preferred)
+    or with prima browser start, and close it when finished - ### Instance lists what
+    you own. When no AI model is usable pw still works; for everything else drive
+    playwright-cli directly.
+`;
+
+function buildOptions(options: any): PrimaOptions {
+  return {
+    verbose: options.verbose || options.debug,
+    config: options.config,
+    path: options.path,
+    instance: options.instance,
+    session: options.session,
+    heal: options.heal,
+    ephemeral: options.ephemeral,
+    framework: options.framework,
+    noVision: options.vision === false,
+    url: options.url,
+    show: options.show,
+    headless: options.headless,
+    endpoint: options.endpoint,
+    pwSession: options.pwSession,
+  };
+}
+
+function addCommonOptions(cmd: Command): Command {
+  return cmd
+    .option('-v, --verbose', 'Enable verbose logging')
+    .option('--debug', 'Enable debug logging (same as --verbose)')
+    .option('-c, --config <path>', 'Path to explorbot configuration file')
+    .option('-p, --path <path>', 'Working directory path')
+    .option('-i, --instance <name>', 'Browser instance to drive')
+    .option('--session [file]', 'Persist cookies and storage to a session file')
+    .option('--no-heal', 'Fail immediately instead of letting AI retry a failed action')
+    .option('--ephemeral', 'Keep no state between runs, output goes to a temp directory')
+    .option('--framework <name>', 'Framework the reported code targets: codeceptjs or playwright')
+    .option('--url <url>', 'Page to open when the session has no page yet')
+    .option('--endpoint <ep>', 'Websocket endpoint of a playwright-cli browser to attach to')
+    .option('--pw-session <title>', 'Title of a playwright-cli session to attach to');
+}
+
+function primaFor(options: any): Prima {
+  setPreserveConsoleLogs(true);
+  if (options.ephemeral) process.env.EXPLORBOT_EPHEMERAL = '1';
+  return new Prima(buildOptions(options));
+}
+
+async function runPrima(options: any, command: string, run: (prima: Prima) => Promise<EnvelopeData>): Promise<void> {
+  const prima = primaFor(options);
+
+  let envelope: EnvelopeData;
+  try {
+    await prima.start();
+    envelope = await run(prima);
+  } catch (error) {
+    envelope = await prima.toolFailureEnvelope(command, error);
+  }
+
+  console.log(renderEnvelope(envelope));
+  await prima.stop().catch(() => {});
+  process.exit(envelope.ok ? 0 : 1);
+}
+
+export function createPrimaCommands(name = 'prima'): Command {
+  const cmd = new Command(name);
+  cmd.description('Drive an already-open browser one command at a time and report back in a plain-text envelope');
+  cmd.addHelpText('after', `\n${helpContract}`);
+
+  addCommonOptions(cmd.command('pw <fn>').description('Run a Playwright function expression against the open page')).action(async (fn, options) => {
+    await runPrima(options, `pw ${fn}`, (prima) => prima.pw(fn));
+  });
+
+  addCommonOptions(cmd.command('do <instructions...>').description('Run high-level instructions tester-style, one argument per instruction')).action(async (instructions, options) => {
+    await runPrima(options, `do ${instructions.join(' ')}`, (prima) => prima.do(instructions));
+  });
+
+  addCommonOptions(cmd.command('click <target>').description('Click an element described in plain words')).action(async (target, options) => {
+    await runPrima(options, `click ${target}`, (prima) => prima.click(target));
+  });
+
+  addCommonOptions(cmd.command('fill <field> <value>').description('Fill a field described in plain words')).action(async (field, value, options) => {
+    await runPrima(options, `fill ${field} ${value}`, (prima) => prima.fill(field, value));
+  });
+
+  addCommonOptions(cmd.command('ask <question>').description('Answer a question about the current page').option('--no-vision', 'Answer from page structure only, without a screenshot')).action(async (question, options) => {
+    await runPrima(options, `ask ${question}`, (prima) => prima.ask(question));
+  });
+
+  addCommonOptions(cmd.command('verify <assertion>').alias('assert').description('Assert a statement about the current page')).action(async (assertion, options) => {
+    await runPrima(options, `verify ${assertion}`, (prima) => prima.verify(assertion));
+  });
+
+  addCommonOptions(
+    cmd.command('research').description('Map the current page and return verified locators').option('--data', 'Include data extraction in the map').option('--deep', 'Expand hidden elements for a deeper map').option('--fresh', 'Ignore the cached map and research the page again')
+  ).action(async (options) => {
+    await runPrima(options, 'research', (prima) => prima.research({ data: options.data, deep: options.deep, fresh: options.fresh }));
+  });
+
+  addCommonOptions(cmd.command('go <target>').description('Navigate to a url, a path, or a page described in plain words')).action(async (target, options) => {
+    await runPrima(options, `go ${target}`, (prima) => prima.go(target));
+  });
+
+  const browser = cmd.command('browser').description('Manage the browsers prima drives');
+
+  addCommonOptions(browser.command('start').description('Start a prima-owned browser and hold it open until Ctrl+C'))
+    .option('-s, --show', 'Launch the browser in a visible window')
+    .option('--headless', 'Launch the browser without a window')
+    .action(async (options) => {
+      const prima = primaFor(options);
+      await prima.browserStart();
+      console.log(await prima.browserStatus());
+      keepServerRunning(() => prima.browserStop());
+    });
+
+  addCommonOptions(browser.command('stop').description('Stop the browser of this instance'))
+    .option('--all', 'Stop every running instance')
+    .action(async (options) => {
+      const prima = primaFor(options);
+      await prima.browserStop(options.all);
+      console.log(await prima.browserStatus());
+    });
+
+  addCommonOptions(browser.command('status').description('Report the browser of this instance')).action(async (options) => {
+    console.log(await primaFor(options).browserStatus());
+  });
+
+  addCommonOptions(browser.command('list').description('List every browser instance that is running')).action(async (options) => {
+    console.log(await primaFor(options).browserList());
+  });
+
+  return cmd;
+}

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -1,6 +1,7 @@
 import { Command } from 'commander';
 import dedent from 'dedent';
 import { keepServerRunning } from '../../../src/browser-server.ts';
+import { browserErrorMessage } from '../../../src/utils/browser-errors.ts';
 import { setPreserveConsoleLogs } from '../../../src/utils/logger.ts';
 import { type EnvelopeData, renderEnvelope } from './envelope.ts';
 import { Prima, type PrimaOptions } from './prima.ts';
@@ -37,7 +38,7 @@ const helpContract = dedent`
     ### Instance   the browser you are on and the other instances running
     ### Artifacts  paths to the full aria.yml, page.html and network.jsonl
     used: is verified code that already executed - copy it into a test as is.
-    Set EXPLORBOT_NO_BANNER=1 so nothing but the envelope reaches stdout.
+    Log lines can precede the envelope; start parsing at the first ### line.
 
   HEALING AND FAILURE
     A failed action is retried by AI along a different route; healed: true means the
@@ -49,11 +50,13 @@ const helpContract = dedent`
   SESSIONS
     --instance <name>  which browser process you talk to; parallel work needs one each
     --session [file]   cookies and storage persisted across processes
-    --endpoint, --pw-session  attach to a browser opened by playwright-cli
-    Prima never launches a browser implicitly. Open one with playwright-cli (preferred)
-    or with prima browser start, and close it when finished - ### Instance lists what
-    you own. When no AI model is usable pw still works; for everything else drive
+    Prima never launches a browser implicitly. The session it drives is the one from
+    prima browser start; close it when finished - ### Instance lists what you own.
+    When no AI model is usable pw still works; for everything else drive
     playwright-cli directly.
+    Parsed but not active yet: --endpoint and --pw-session, so a browser opened by
+    playwright-cli cannot be reached yet; and --framework, so reported code is
+    CodeceptJS whatever you pass.
 `;
 
 function buildOptions(options: any): PrimaOptions {
@@ -85,10 +88,10 @@ function addCommonOptions(cmd: Command): Command {
     .option('--session [file]', 'Persist cookies and storage to a session file')
     .option('--no-heal', 'Fail immediately instead of letting AI retry a failed action')
     .option('--ephemeral', 'Keep no state between runs, output goes to a temp directory')
-    .option('--framework <name>', 'Framework the reported code targets: codeceptjs or playwright')
+    .option('--framework <name>', 'Not active yet: framework the reported code targets, codeceptjs or playwright')
     .option('--url <url>', 'Page to open when the session has no page yet')
-    .option('--endpoint <ep>', 'Websocket endpoint of a playwright-cli browser to attach to')
-    .option('--pw-session <title>', 'Title of a playwright-cli session to attach to');
+    .option('--endpoint <ep>', 'Not active yet: websocket endpoint of a playwright-cli browser to attach to')
+    .option('--pw-session <title>', 'Not active yet: title of a playwright-cli session to attach to');
 }
 
 function primaFor(options: any): Prima {
@@ -111,6 +114,18 @@ async function runPrima(options: any, command: string, run: (prima: Prima) => Pr
   console.log(renderEnvelope(envelope));
   await prima.stop().catch(() => {});
   process.exit(envelope.ok ? 0 : 1);
+}
+
+async function runBrowser(options: any, run: (prima: Prima) => Promise<boolean>): Promise<void> {
+  let ok = false;
+  try {
+    ok = await run(primaFor(options));
+  } catch (error) {
+    console.error(browserErrorMessage(error));
+    process.exit(1);
+  }
+
+  process.exit(ok ? 0 : 1);
 }
 
 export function createPrimaCommands(name = 'prima'): Command {
@@ -158,26 +173,35 @@ export function createPrimaCommands(name = 'prima'): Command {
     .option('-s, --show', 'Launch the browser in a visible window')
     .option('--headless', 'Launch the browser without a window')
     .action(async (options) => {
-      const prima = primaFor(options);
-      await prima.browserStart();
-      console.log(await prima.browserStatus());
-      keepServerRunning(() => prima.browserStop());
+      await runBrowser(options, async (prima) => {
+        await prima.browserStart();
+        console.log(await prima.browserStatus());
+        return keepServerRunning(() => prima.browserStop());
+      });
     });
 
   addCommonOptions(browser.command('stop').description('Stop the browser of this instance'))
     .option('--all', 'Stop every running instance')
     .action(async (options) => {
-      const prima = primaFor(options);
-      await prima.browserStop(options.all);
-      console.log(await prima.browserStatus());
+      await runBrowser(options, async (prima) => {
+        const stopped = await prima.browserStop(options.all);
+        console.log(await prima.browserStatus());
+        return stopped;
+      });
     });
 
   addCommonOptions(browser.command('status').description('Report the browser of this instance')).action(async (options) => {
-    console.log(await primaFor(options).browserStatus());
+    await runBrowser(options, async (prima) => {
+      console.log(await prima.browserStatus());
+      return true;
+    });
   });
 
   addCommonOptions(browser.command('list').description('List every browser instance that is running')).action(async (options) => {
-    console.log(await primaFor(options).browserList());
+    await runBrowser(options, async (prima) => {
+      console.log(await prima.browserList());
+      return true;
+    });
   });
 
   return cmd;

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -37,7 +37,8 @@ const helpContract = dedent`
     ### Failure    error, reasoning, healing attempts, compact ARIA of the page
     ### Instance   the browser you are on and the other instances running
     ### Artifacts  paths to the full aria.yml, page.html and network.jsonl
-    used: is verified code that already executed - copy it into a test as is.
+    used: is code that already executed - CodeceptJS steps to copy as they are, except
+          for pw, whose Playwright expression a test needs inside I.usePlaywrightTo(...).
     Log lines can precede the envelope; start parsing at the first ### line.
 
   HEALING AND FAILURE
@@ -175,6 +176,7 @@ export function createPrimaCommands(name = 'prima'): Command {
   });
 
   addCommonOptions(cmd.command('go <target>').description('Navigate to a url, a path, or a page described in plain words')).action(async (target, options) => {
+    if (!options.url && URL.canParse(target)) options.url = target;
     await runPrima(options, `go ${target}`, (prima) => prima.go(target));
   });
 

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -48,15 +48,23 @@ const helpContract = dedent`
     the artifact files only when the inline snapshot is not enough.
 
   SESSIONS
-    --instance <name>  which browser process you talk to; parallel work needs one each
-    --session [file]   cookies and storage persisted across processes
-    Prima never launches a browser implicitly. The session it drives is the one from
-    prima browser start; close it when finished - ### Instance lists what you own.
+    By default prima attaches to the playwright-cli browser of this workspace and works
+    on the tabs it already has open; driving the same session from both tools is the
+    intended usage.
+    playwright-cli open <url>  the session prima attaches to
+    --pw-session <title>       which playwright-cli session, when several are open
+    --endpoint <ep>            attach to a browser server endpoint directly
+    prima browser start        a prima-owned browser instead, when no session is open
+    --instance <name>          which prima-owned browser you talk to; parallel work
+                               needs one each
+    --session [file]           cookies and storage persisted across processes; ignored
+                               while attached, the attached session keeps its own
+    Prima never launches a browser implicitly and never closes an attached one - it
+    disconnects. browser list shows both kinds; ### Instance names the one you are on.
     When no AI model is usable pw still works; for everything else drive
     playwright-cli directly.
-    Parsed but not active yet: --endpoint and --pw-session, so a browser opened by
-    playwright-cli cannot be reached yet; and --framework, so reported code is
-    CodeceptJS whatever you pass.
+    Parsed but not active yet: --framework, so reported code is CodeceptJS whatever
+    you pass.
 `;
 
 function buildOptions(options: any): PrimaOptions {
@@ -90,8 +98,8 @@ function addCommonOptions(cmd: Command): Command {
     .option('--ephemeral', 'Keep no state between runs, output goes to a temp directory')
     .option('--framework <name>', 'Not active yet: framework the reported code targets, codeceptjs or playwright')
     .option('--url <url>', 'Page to open when the session has no page yet')
-    .option('--endpoint <ep>', 'Not active yet: websocket endpoint of a playwright-cli browser to attach to')
-    .option('--pw-session <title>', 'Not active yet: title of a playwright-cli session to attach to');
+    .option('--endpoint <ep>', 'Websocket endpoint of a browser server to attach to, skipping discovery')
+    .option('--pw-session <title>', 'Title of the playwright-cli session to attach to');
 }
 
 function primaFor(options: any): Prima {

--- a/boat/prima/src/envelope.ts
+++ b/boat/prima/src/envelope.ts
@@ -116,7 +116,8 @@ function otherInstances(others: string[]): string {
 function browserLine(instance: InstanceInfo): string {
   if (instance.attached) return `browser: attached (${instance.attached})`;
   if (instance.startedAgo) return `browser: running, started ${instance.startedAgo} ago`;
-  return 'browser: running';
+  if (instance.tabs > 0) return 'browser: running';
+  return 'browser: not running';
 }
 
 function tabsLabel(tabs: number): string {

--- a/boat/prima/src/envelope.ts
+++ b/boat/prima/src/envelope.ts
@@ -1,0 +1,140 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+export interface InstanceInfo {
+  name: string;
+  tabs: number;
+  startedAgo?: string;
+  attached?: string;
+  others: Array<{ name: string; tabs: number }>;
+}
+
+export interface HealAttempt {
+  code: string;
+  outcome: string;
+}
+
+export interface EnvelopeData {
+  ok: boolean;
+  command: string;
+  healed?: boolean;
+  healNote?: string;
+  used?: string[];
+  page: { url: string; previousUrl?: string; title: string; state: string; visits: number };
+  changes?: string | null;
+  answer?: string;
+  research?: string;
+  verdict?: { passed: boolean; evidence: string; code: string };
+  failure?: { error: string; attempts: HealAttempt[]; reasoning?: string; compactAria?: string };
+  instance: InstanceInfo;
+  artifacts?: { aria: string; html: string; network: string };
+}
+
+export function renderEnvelope(data: EnvelopeData): string {
+  const sections = [renderResult(data), renderPage(data), renderOutcome(data), ...renderFailure(data), renderInstance(data.instance), renderArtifacts(data)];
+  return sections.filter((section) => section).join('\n\n');
+}
+
+export function writeArtifacts(dir: string, snapshot: { aria: string | null; html: string | null; requests: unknown[] }): { aria: string; html: string; network: string } {
+  mkdirSync(dir, { recursive: true });
+  const paths = {
+    aria: path.resolve(dir, 'aria.yml'),
+    html: path.resolve(dir, 'page.html'),
+    network: path.resolve(dir, 'network.jsonl'),
+  };
+  writeFileSync(paths.aria, snapshot.aria ?? '', 'utf-8');
+  writeFileSync(paths.html, snapshot.html ?? '', 'utf-8');
+  writeFileSync(paths.network, snapshot.requests.map((request) => `${JSON.stringify(request)}\n`).join(''), 'utf-8');
+  return paths;
+}
+
+function renderResult(data: EnvelopeData): string {
+  const lines = [`ok: ${data.ok}`, `command: ${data.command}`];
+  const healed = renderHealed(data);
+  if (healed) lines.push(healed);
+  if (data.used?.length) lines.push(`used: ${data.used.join('; ')}`);
+  return section('Result', lines.join('\n'));
+}
+
+function renderHealed(data: EnvelopeData): string | null {
+  if (data.healed === undefined) return null;
+  if (data.healNote) return `healed: ${data.healed} (${data.healNote})`;
+  return `healed: ${data.healed}`;
+}
+
+function renderPage(data: EnvelopeData): string {
+  const { url, previousUrl, title, state, visits } = data.page;
+  const urlLabel = `url: ${url}`;
+  const stateLabel = `state: ${state}`;
+  const width = Math.max(urlLabel.length, stateLabel.length) + 3;
+  let changedMarker = '';
+  if (previousUrl && previousUrl !== url) changedMarker = `(changed: ${previousUrl} → ${url})`;
+  const lines = [align(urlLabel, changedMarker, width), `title: ${title}`, align(stateLabel, `(visit #${visits})`, width)];
+  return section('Page', lines.join('\n'));
+}
+
+function renderOutcome(data: EnvelopeData): string | null {
+  if (data.changes) return section('Changes', data.changes);
+  if (data.answer) return section('Answer', data.answer);
+  if (data.research) return section('Research', data.research);
+  if (!data.verdict) return null;
+  const lines = [`passed: ${data.verdict.passed}`, `evidence: ${data.verdict.evidence}`, `code: ${data.verdict.code}`];
+  return section('Verdict', lines.join('\n'));
+}
+
+function renderFailure(data: EnvelopeData): Array<string | null> {
+  if (!data.failure) return [];
+  const lines = [`error: ${data.failure.error}`];
+  if (data.failure.reasoning) lines.push(`reasoning: ${data.failure.reasoning}`);
+  return [section('Failure', lines.join('\n')), renderAttempts(data.failure.attempts), renderCompactAria(data.failure.compactAria)];
+}
+
+function renderAttempts(attempts: HealAttempt[]): string | null {
+  if (!attempts?.length) return null;
+  const labels = attempts.map((attempt, index) => `${index + 1}. ${attempt.code}`);
+  const width = Math.max(...labels.map((label) => label.length)) + 3;
+  const lines = labels.map((label, index) => align(label, `→ ${attempts[index].outcome}`, width));
+  return section(`Healing attempts (${attempts.length})`, lines.join('\n'));
+}
+
+function renderCompactAria(compactAria?: string): string | null {
+  if (!compactAria) return null;
+  return section('Current page (compact ARIA)', compactAria);
+}
+
+function renderInstance(instance: InstanceInfo): string {
+  const others = instance.others.map((other) => `${other.name} (${tabsLabel(other.tabs)})`);
+  const lines = [`instance: ${instance.name} (${tabsLabel(instance.tabs)}) | other instances: ${otherInstances(others)}`, browserLine(instance)];
+  return section('Instance', lines.join('\n'));
+}
+
+function otherInstances(others: string[]): string {
+  if (!others.length) return 'none';
+  return others.join(', ');
+}
+
+function browserLine(instance: InstanceInfo): string {
+  if (instance.attached) return `browser: attached (${instance.attached})`;
+  if (instance.startedAgo) return `browser: running, started ${instance.startedAgo} ago`;
+  return 'browser: running';
+}
+
+function tabsLabel(tabs: number): string {
+  if (tabs === 1) return '1 tab';
+  return `${tabs} tabs`;
+}
+
+function renderArtifacts(data: EnvelopeData): string | null {
+  if (!data.artifacts) return null;
+  const lines = [`aria: ${data.artifacts.aria}`, `html: ${data.artifacts.html}`, `network: ${data.artifacts.network}`];
+  return section('Artifacts', lines.join('\n'));
+}
+
+function align(label: string, marker: string, width: number): string {
+  if (!marker) return label;
+  return `${label.padEnd(width)}${marker}`;
+}
+
+function section(title: string, body: string): string {
+  return `### ${title}\n${body}`;
+}

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -5,7 +5,7 @@ import type { Navigator } from '../../../src/ai/navigator.ts';
 import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
 import { createCodeceptJSTools } from '../../../src/ai/tools.ts';
 import { getAliveEndpoint, launchServer, listInstances, stopServer } from '../../../src/browser-server.ts';
-import { ConfigParser, outputPath } from '../../../src/config.ts';
+import { ConfigParser, type ExplorbotConfig, outputPath } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
 import type { WebPageState } from '../../../src/state-manager.ts';
 import { Task } from '../../../src/test-plan.ts';
@@ -39,6 +39,8 @@ export class Prima {
   }
 
   async start(): Promise<void> {
+    await this.loadConfig();
+
     if (!(await this.connectOwnInstance())) {
       throw new Error(dedent`
         No browser session found for instance "${this.instanceName()}".
@@ -217,11 +219,16 @@ export class Prima {
   }
 
   async browserStart(): Promise<void> {
-    const config = await ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path });
-    this.server = await this.launchOwnServer({ browser: config.playwright.browser, show: config.playwright.show }, this.instanceName());
+    const config = await this.loadConfig();
+    let show = config.playwright.show || false;
+    if (this.options.show) show = true;
+    if (this.options.headless) show = false;
+    this.server = await this.launchOwnServer({ browser: config.playwright.browser, show }, this.instanceName());
   }
 
   async browserStop(all = false): Promise<void> {
+    await this.loadConfig();
+
     if (!all) {
       await this.stopInstance(this.instanceName());
       return;
@@ -233,12 +240,27 @@ export class Prima {
   }
 
   async browserStatus(): Promise<string> {
+    await this.loadConfig();
     const info = await this.instanceInfo();
     const endpoint = await getAliveEndpoint(info.name);
     const others = info.others.map((other) => other.name).join(', ') || 'none';
     const lines = [`instance: ${info.name} (${info.tabs} ${pluralize(info.tabs, 'tab')}) | other instances: ${others}`];
     if (!endpoint) lines.push('browser: not running');
     if (endpoint) lines.push(`browser: running at ${endpoint}`);
+    return lines.join('\n');
+  }
+
+  async browserList(): Promise<string> {
+    await this.loadConfig();
+
+    const lines: string[] = [];
+    for (const instance of listInstances()) {
+      const endpoint = await getAliveEndpoint(instance.name);
+      if (!endpoint) continue;
+      lines.push(`${instance.name}  ${endpoint}`);
+    }
+
+    if (!lines.length) return 'no browser instances running';
     return lines.join('\n');
   }
 
@@ -249,6 +271,23 @@ export class Prima {
       .map((instance) => ({ name: instance.name, tabs: 0 }));
 
     return { name, tabs: this.tabCount(), others };
+  }
+
+  async toolFailureEnvelope(command: string, error: unknown): Promise<EnvelopeData> {
+    const state = this.bot.getCurrentState();
+    const instance = await this.instanceInfo().catch(() => ({ name: this.instanceName(), tabs: 0, others: [] }));
+
+    return {
+      ok: false,
+      command,
+      page: { url: state?.url || '', title: state?.title || '', state: state?.hash || '', visits: 0 },
+      failure: { error: `tool: ${browserErrorMessage(error)}`, attempts: [] },
+      instance,
+    };
+  }
+
+  private async loadConfig(): Promise<ExplorbotConfig> {
+    return ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path });
   }
 
   private async connectOwnInstance(): Promise<boolean> {
@@ -482,18 +521,6 @@ export class Prima {
     };
   }
 
-  private async toolFailureEnvelope(command: string, error: string): Promise<EnvelopeData> {
-    const state = this.bot.stateManager().getCurrentState();
-
-    return {
-      ok: false,
-      command,
-      page: { url: state?.url || '', title: state?.title || '', state: state?.hash || '', visits: 0 },
-      failure: { error: `tool: ${error}`, attempts: [] },
-      instance: await this.instanceInfo(),
-    };
-  }
-
   private async capturedResult(previousState: WebPageState | null, opts: { screenshot?: boolean } = {}): Promise<ActionResult> {
     const captured = await this.bot
       .getExplorer()
@@ -549,10 +576,14 @@ export interface PrimaOptions {
   config?: string;
   path?: string;
   instance?: string;
-  session?: string;
+  session?: string | boolean;
   heal?: boolean;
   ephemeral?: boolean;
   framework?: 'codeceptjs' | 'playwright';
   noVision?: boolean;
   url?: string;
+  show?: boolean;
+  headless?: boolean;
+  endpoint?: string;
+  pwSession?: string;
 }

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -45,9 +45,10 @@ export class Prima {
       throw new Error(dedent`
         No browser session found for instance "${this.instanceName()}".
         Create one first:
-          playwright-cli open <url>   preferred, prima drives that session
-          prima browser start        starts a prima-owned browser
+          prima browser start   starts a prima-owned browser
         Prima never launches a browser implicitly.
+        Attaching to a browser opened by playwright-cli is not wired yet, so --endpoint
+        and --pw-session cannot reach one.
       `);
     }
 
@@ -226,17 +227,16 @@ export class Prima {
     this.server = await this.launchOwnServer({ browser: config.playwright.browser, show }, this.instanceName());
   }
 
-  async browserStop(all = false): Promise<void> {
+  async browserStop(all = false): Promise<boolean> {
     await this.loadConfig();
 
-    if (!all) {
-      await this.stopInstance(this.instanceName());
-      return;
-    }
+    if (!all) return this.stopInstance(this.instanceName());
 
+    let stopped = false;
     for (const instance of listInstances()) {
-      await this.stopInstance(instance.name);
+      if (await this.stopInstance(instance.name)) stopped = true;
     }
+    return stopped;
   }
 
   async browserStatus(): Promise<string> {
@@ -276,12 +276,14 @@ export class Prima {
   async toolFailureEnvelope(command: string, error: unknown): Promise<EnvelopeData> {
     const state = this.bot.getCurrentState();
     const instance = await this.instanceInfo().catch(() => ({ name: this.instanceName(), tabs: 0, others: [] }));
+    const failure: EnvelopeData['failure'] = { error: `tool: ${browserErrorMessage(error)}`, attempts: [] };
+    if (state?.ariaSnapshot) failure.compactAria = compactAriaSnapshot(state.ariaSnapshot, true);
 
     return {
       ok: false,
       command,
       page: { url: state?.url || '', title: state?.title || '', state: state?.hash || '', visits: 0 },
-      failure: { error: `tool: ${browserErrorMessage(error)}`, attempts: [] },
+      failure,
       instance,
     };
   }
@@ -298,14 +300,14 @@ export class Prima {
     return launchServer(opts, instance);
   }
 
-  private async stopInstance(instance: string): Promise<void> {
+  private async stopInstance(instance: string): Promise<boolean> {
     if (instance === this.instanceName()) {
       const server = this.server;
       this.server = null;
       await server?.close();
     }
 
-    await stopServer(instance);
+    return stopServer(instance);
   }
 
   private isUrlTarget(target: string): boolean {
@@ -495,10 +497,8 @@ export class Prima {
   private async failureEnvelope(command: string, error: unknown, previousState: WebPageState | null, attempts: HealAttempt[] = []): Promise<EnvelopeData> {
     const result = await this.capturedResult(previousState);
     const failure: EnvelopeData['failure'] = { error: browserErrorMessage(error), attempts };
-    if (attempts.length) {
-      failure.reasoning = [...new Set(attempts.map((attempt) => attempt.outcome))].join('; ');
-      failure.compactAria = compactAriaSnapshot(result.ariaSnapshot, true);
-    }
+    if (result.ariaSnapshot) failure.compactAria = compactAriaSnapshot(result.ariaSnapshot, true);
+    if (attempts.length) failure.reasoning = [...new Set(attempts.map((attempt) => attempt.outcome))].join('; ');
 
     return {
       ok: false,

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -4,8 +4,8 @@ import { ActionResult } from '../../../src/action-result.ts';
 import type { Navigator } from '../../../src/ai/navigator.ts';
 import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
 import { createCodeceptJSTools } from '../../../src/ai/tools.ts';
-import { getAliveEndpoint, listInstances } from '../../../src/browser-server.ts';
-import { outputPath } from '../../../src/config.ts';
+import { getAliveEndpoint, launchServer, listInstances, stopServer } from '../../../src/browser-server.ts';
+import { ConfigParser, outputPath } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
 import type { WebPageState } from '../../../src/state-manager.ts';
 import { Task } from '../../../src/test-plan.ts';
@@ -23,6 +23,7 @@ export class Prima {
   private options: PrimaOptions;
   private bot: ExplorBot;
   private artifactsDir?: string;
+  private server: { close: () => Promise<void> } | null = null;
 
   constructor(options: PrimaOptions = {}) {
     this.options = options;
@@ -188,6 +189,59 @@ export class Prima {
     return this.reportEnvelope(command, result, previousState, { research: uiMap });
   }
 
+  async go(target: string): Promise<EnvelopeData> {
+    const command = `go ${target}`;
+    const code = `I.amOnPage('${target}')`;
+    const isUrl = this.isUrlTarget(target);
+
+    if (!isUrl) {
+      const guard = await this.aiGuard(command);
+      if (guard) return guard;
+    }
+
+    const previousState = this.bot.stateManager().getCurrentState();
+    let navigationError: unknown = null;
+
+    try {
+      await this.bot.agentNavigator().visit(target);
+    } catch (error) {
+      navigationError = error;
+    }
+
+    if (navigationError) return this.heal(command, code, navigationError, previousState);
+
+    const used: string[] = [];
+    if (isUrl) used.push(code);
+    const result = await this.capturedResult(this.bot.stateManager().getCurrentState());
+    return this.successEnvelope(command, used, result, previousState);
+  }
+
+  async browserStart(): Promise<void> {
+    const config = await ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path });
+    this.server = await this.launchOwnServer({ browser: config.playwright.browser, show: config.playwright.show }, this.instanceName());
+  }
+
+  async browserStop(all = false): Promise<void> {
+    if (!all) {
+      await this.stopInstance(this.instanceName());
+      return;
+    }
+
+    for (const instance of listInstances()) {
+      await this.stopInstance(instance.name);
+    }
+  }
+
+  async browserStatus(): Promise<string> {
+    const info = await this.instanceInfo();
+    const endpoint = await getAliveEndpoint(info.name);
+    const others = info.others.map((other) => other.name).join(', ') || 'none';
+    const lines = [`instance: ${info.name} (${info.tabs} ${pluralize(info.tabs, 'tab')}) | other instances: ${others}`];
+    if (!endpoint) lines.push('browser: not running');
+    if (endpoint) lines.push(`browser: running at ${endpoint}`);
+    return lines.join('\n');
+  }
+
   async instanceInfo(): Promise<InstanceInfo> {
     const name = this.instanceName();
     const others = listInstances()
@@ -199,6 +253,26 @@ export class Prima {
 
   private async connectOwnInstance(): Promise<boolean> {
     return !!(await getAliveEndpoint(this.instanceName()));
+  }
+
+  private async launchOwnServer(opts: { browser?: string; show?: boolean }, instance: string): Promise<{ close: () => Promise<void> }> {
+    return launchServer(opts, instance);
+  }
+
+  private async stopInstance(instance: string): Promise<void> {
+    if (instance === this.instanceName()) {
+      const server = this.server;
+      this.server = null;
+      await server?.close();
+    }
+
+    await stopServer(instance);
+  }
+
+  private isUrlTarget(target: string): boolean {
+    const value = target.trim();
+    if (value.startsWith('/')) return true;
+    return URL.canParse(value);
   }
 
   private async heal(command: string, expression: string, error: unknown, previousState: WebPageState | null): Promise<EnvelopeData> {

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -2,15 +2,22 @@ import path from 'node:path';
 import dedent from 'dedent';
 import { ActionResult } from '../../../src/action-result.ts';
 import type { Navigator } from '../../../src/ai/navigator.ts';
+import { locatorRule } from '../../../src/ai/rules.ts';
+import { createCodeceptJSTools } from '../../../src/ai/tools.ts';
 import { getAliveEndpoint, listInstances } from '../../../src/browser-server.ts';
 import { outputPath } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
 import type { WebPageState } from '../../../src/state-manager.ts';
+import { Task } from '../../../src/test-plan.ts';
 import { compactAriaSnapshot } from '../../../src/utils/aria.ts';
 import { browserErrorMessage } from '../../../src/utils/browser-errors.ts';
 import { pluralize } from '../../../src/utils/logger.ts';
 import { type EnvelopeData, type HealAttempt, type InstanceInfo, writeArtifacts } from './envelope.ts';
 import { isFunctionExpression, toCodeceptWrapper } from './pw-parser.ts';
+
+const MAX_INSTRUCTION_ITERATIONS = 6;
+const MAX_TOOL_ROUNDTRIPS = 5;
+const AI_AGENT_NAME = 'prima';
 
 export class Prima {
   private options: PrimaOptions;
@@ -26,6 +33,7 @@ export class Prima {
       session: options.session,
       instance: options.instance,
       headless: true,
+      optionalAi: true,
     });
   }
 
@@ -73,6 +81,106 @@ export class Prima {
     return this.successEnvelope(command, [expression], result, previousState);
   }
 
+  async do(instructions: string[]): Promise<EnvelopeData> {
+    const command = `do ${instructions.map((instruction) => `"${instruction}"`).join(' ')}`;
+    const guard = await this.aiGuard(command);
+    if (guard) return guard;
+
+    const provider = this.bot.getProvider();
+    const previousState = this.bot.stateManager().getCurrentState();
+    const conversation = provider.startConversation(this.instructionSystemPrompt(), AI_AGENT_NAME);
+    const task = new Task(instructions.join('; '), previousState?.url || '');
+    const tools = createCodeceptJSTools({ explorer: this.bot.getExplorer(), stateManager: this.bot.stateManager(), ai: provider }, task);
+    conversation.addUserText(this.instructionPrompt(instructions, await this.capturedResult(previousState)));
+
+    const used: string[] = [];
+    let failure: { code: string; message: string } | null = null;
+    let aiError: unknown = null;
+    let contextHash = previousState?.hash;
+
+    for (let iteration = 1; iteration <= Math.min(instructions.length + 2, MAX_INSTRUCTION_ITERATIONS); iteration++) {
+      const state = this.bot.stateManager().getCurrentState();
+      if (iteration > 1 && state && state.hash !== contextHash) {
+        contextHash = state.hash;
+        conversation.addUserText(this.pageContext(ActionResult.fromState(state)));
+      }
+
+      const invoked = await provider.invokeConversation(conversation, tools, { maxToolRoundtrips: MAX_TOOL_ROUNDTRIPS, agentName: AI_AGENT_NAME }).catch((error: unknown) => {
+        aiError = error;
+        return null;
+      });
+      if (!invoked) break;
+
+      const executions = invoked.toolExecutions || [];
+      if (!executions.length) break;
+
+      for (const execution of executions) {
+        if (!execution.wasSuccessful) {
+          failure = { code: execution.output?.code || '', message: execution.output?.message || 'action failed' };
+          continue;
+        }
+        used.push(...this.executedCodes(execution.output?.code));
+        failure = null;
+      }
+    }
+
+    if (aiError) return this.failureEnvelope(command, aiError, previousState);
+
+    if (failure) {
+      const envelope = await this.heal(command, failure.code || instructions.join('; '), failure.message, previousState);
+      envelope.used = [...used, ...(envelope.used || [])];
+      return envelope;
+    }
+
+    if (!used.length) return this.failureEnvelope(command, 'No action was performed for these instructions on the current page.', previousState);
+
+    const result = await this.capturedResult(this.bot.stateManager().getCurrentState());
+    return this.successEnvelope(command, used, result, previousState);
+  }
+
+  async click(target: string): Promise<EnvelopeData> {
+    return this.do([`click ${target}`]);
+  }
+
+  async fill(field: string, value: string): Promise<EnvelopeData> {
+    return this.do([`fill ${field} with value: ${value}`]);
+  }
+
+  async ask(question: string): Promise<EnvelopeData> {
+    const command = `ask ${question}`;
+    const guard = await this.aiGuard(command);
+    if (guard) return guard;
+
+    const previousState = this.bot.stateManager().getCurrentState();
+    const result = await this.capturedResult(previousState, { screenshot: this.visionEnabled() });
+    return this.reportEnvelope(command, result, previousState, { answer: await this.answer(question, result) });
+  }
+
+  async verify(assertion: string): Promise<EnvelopeData> {
+    const command = `verify ${assertion}`;
+    const guard = await this.aiGuard(command);
+    if (guard) return guard;
+
+    const previousState = this.bot.stateManager().getCurrentState();
+    const result = await this.capturedResult(previousState);
+    const verification = await this.bot.agentNavigator().verifyState(assertion, result);
+    const codes = verification.successfulCodes || [];
+    const verdict = { passed: verification.verified, evidence: this.verdictEvidence(verification.verified, codes), code: codes.join('\n') };
+    return this.reportEnvelope(command, result, previousState, { ok: verification.verified, verdict });
+  }
+
+  async research(opts: { data?: boolean; deep?: boolean; fresh?: boolean } = {}): Promise<EnvelopeData> {
+    const flags = [opts.data && '--data', opts.deep && '--deep', opts.fresh && '--fresh'].filter(Boolean);
+    const command = ['research', ...flags].join(' ');
+    const guard = await this.aiGuard(command);
+    if (guard) return guard;
+
+    const previousState = this.bot.stateManager().getCurrentState();
+    const result = await this.capturedResult(previousState);
+    const uiMap = await this.bot.agentResearcher().research(result, { screenshot: true, data: opts.data, deep: opts.deep, force: opts.fresh });
+    return this.reportEnvelope(command, result, previousState, { research: uiMap });
+  }
+
   async instanceInfo(): Promise<InstanceInfo> {
     const name = this.instanceName();
     const others = listInstances()
@@ -93,7 +201,7 @@ export class Prima {
     if (!navigator) {
       const envelope = await this.failureEnvelope(command, error, previousState);
       envelope.healed = false;
-      envelope.healNote = 'ai unavailable';
+      envelope.healNote = this.aiUnavailableNote();
       return envelope;
     }
 
@@ -121,12 +229,133 @@ export class Prima {
   }
 
   private healNavigator(): Navigator | null {
+    if (this.aiUnavailable()) return null;
     try {
-      if (!this.bot.getProvider?.()) return null;
       return this.bot.agentNavigator?.() ?? null;
     } catch {
       return null;
     }
+  }
+
+  private aiUnavailable(): string | null {
+    try {
+      if (this.bot.getProvider?.()) return null;
+    } catch (error) {
+      return browserErrorMessage(error);
+    }
+    return this.bot.aiFailureReason?.() || 'no AI model is configured';
+  }
+
+  private aiUnavailableNote(): string {
+    const reason = this.aiUnavailable();
+    if (!reason) return 'ai unavailable';
+    return `ai unavailable: ${reason}`;
+  }
+
+  private async aiGuard(command: string): Promise<EnvelopeData | null> {
+    const reason = this.aiUnavailable();
+    if (!reason) return null;
+    const message = `this command needs an AI model and none is usable: ${reason}. Drive the browser directly with playwright-cli or prima pw, or fix the AI config in ~/.explorbot/config.js or EXPLORBOT_AI_PROVIDER.`;
+    return this.toolFailureEnvelope(command, message);
+  }
+
+  private instructionSystemPrompt(): string {
+    return dedent`
+      <role>
+      You are a web automation engineer performing high-level instructions on the page that is already open in the browser.
+      </role>
+
+      <approach>
+      1. Read the page context and perform the instructions in the order they are listed.
+      2. Interact with the page only through the provided tools.
+      3. Pick the smallest interaction that fulfills an instruction, then move to the next one.
+      4. After the page changes, work from the updated context you are given, not from the earlier one.
+      5. Stop calling tools when every instruction is done, or when an instruction cannot be performed on this page — say what is missing instead.
+      </approach>
+
+      ${locatorRule}
+    `;
+  }
+
+  private instructionPrompt(instructions: string[], result: ActionResult): string {
+    const list = instructions.map((instruction, index) => `${index + 1}. ${instruction}`).join('\n');
+    return dedent`
+      <instructions>
+      ${list}
+      </instructions>
+
+      ${this.pageContext(result)}
+    `;
+  }
+
+  private pageContext(result: ActionResult): string {
+    const experience = this.bot.experienceTracker?.()?.renderExperienceTocFor?.(result) || '';
+    return dedent`
+      <page url="${result.url}" title="${result.title}">
+      ${compactAriaSnapshot(result.ariaSnapshot, true)}
+      </page>
+
+      ${experience}
+    `;
+  }
+
+  private executedCodes(code: unknown): string[] {
+    if (typeof code !== 'string') return [];
+    return code
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line);
+  }
+
+  private visionEnabled(): boolean {
+    if (this.options.noVision) return false;
+    return this.bot.getProvider().hasVision?.() === true;
+  }
+
+  private async answer(question: string, result: ActionResult): Promise<string> {
+    const seen = await this.visionAnswer(question, result);
+    if (seen) return seen;
+
+    const described = await this.textAnswer(question, result);
+    if (this.options.noVision) return described;
+    return `${described}\n\n(vision was unavailable, answered from page structure)`;
+  }
+
+  private async visionAnswer(question: string, result: ActionResult): Promise<string | null> {
+    if (!this.visionEnabled()) return null;
+    return this.bot.agentResearcher().answerQuestionAboutScreenshot(result, question);
+  }
+
+  private async textAnswer(question: string, result: ActionResult): Promise<string> {
+    const provider = this.bot.getProvider();
+    const summary = await this.bot.agentResearcher().summary(result);
+    const prompt = dedent`
+      Answer the question about the web page described below.
+      Rely only on the page summary and the accessibility tree given here.
+      When the answer is not present in them, say which part of the page would be needed instead of guessing.
+      Keep the answer under five sentences.
+
+      <question>
+      ${question}
+      </question>
+
+      <page_summary>
+      ${summary}
+      </page_summary>
+
+      <page_aria>
+      ${compactAriaSnapshot(result.ariaSnapshot, true)}
+      </page_aria>
+    `;
+
+    const response = await provider.chat([{ role: 'user', content: prompt }], provider.getModelForAgent?.(AI_AGENT_NAME), { agentName: AI_AGENT_NAME });
+    return response?.text || '';
+  }
+
+  private verdictEvidence(verified: boolean, codes: string[]): string {
+    if (!verified) return 'no assertion held on the current page';
+    if (!codes.length) return 'already verified on this page';
+    return `${codes[0]} passed`;
   }
 
   private async successEnvelope(command: string, used: string[], result: ActionResult, previousState: WebPageState | null): Promise<EnvelopeData> {
@@ -159,6 +388,17 @@ export class Prima {
     };
   }
 
+  private async reportEnvelope(command: string, result: ActionResult, previousState: WebPageState | null, outcome: Partial<EnvelopeData>): Promise<EnvelopeData> {
+    return {
+      ok: true,
+      command,
+      page: this.pageBlock(result, previousState),
+      ...outcome,
+      instance: await this.instanceInfo(),
+      artifacts: await this.writeSnapshot(result),
+    };
+  }
+
   private async toolFailureEnvelope(command: string, error: string): Promise<EnvelopeData> {
     const state = this.bot.stateManager().getCurrentState();
 
@@ -171,10 +411,10 @@ export class Prima {
     };
   }
 
-  private async capturedResult(previousState: WebPageState | null): Promise<ActionResult> {
+  private async capturedResult(previousState: WebPageState | null, opts: { screenshot?: boolean } = {}): Promise<ActionResult> {
     const captured = await this.bot
       .getExplorer()
-      ?.capture()
+      ?.capture(opts)
       .catch(() => null);
     if (captured) return captured;
     if (previousState) return ActionResult.fromState(previousState);

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -54,17 +54,16 @@ export class Prima {
     if (!validation.valid) return this.toolFailureEnvelope(command, validation.error!);
 
     const previousState = this.bot.stateManager().getCurrentState();
-    const action = this.bot.getExplorer().action();
     let result: ActionResult | null = null;
 
     try {
-      const executed = await action.execute(toCodeceptWrapper(expression));
+      const executed = await this.bot.getExplorer().action().execute(toCodeceptWrapper(expression));
       result = executed.actionResult;
     } catch (error) {
       return this.failureEnvelope(command, error, previousState);
     }
 
-    result ||= await this.bot.getExplorer().capture();
+    result ||= await this.capturedResult(previousState);
     return this.successEnvelope(command, [expression], result, previousState);
   }
 
@@ -94,7 +93,7 @@ export class Prima {
   }
 
   private async failureEnvelope(command: string, error: unknown, previousState: WebPageState | null): Promise<EnvelopeData> {
-    const result = await this.bot.getExplorer().capture();
+    const result = await this.capturedResult(previousState);
 
     return {
       ok: false,
@@ -116,6 +115,16 @@ export class Prima {
       failure: { error: `tool: ${error}`, attempts: [] },
       instance: await this.instanceInfo(),
     };
+  }
+
+  private async capturedResult(previousState: WebPageState | null): Promise<ActionResult> {
+    const captured = await this.bot
+      .getExplorer()
+      ?.capture()
+      .catch(() => null);
+    if (captured) return captured;
+    if (previousState) return ActionResult.fromState(previousState);
+    return new ActionResult({ url: '' });
   }
 
   private pageBlock(result: ActionResult, previousState: WebPageState | null): EnvelopeData['page'] {

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -1,5 +1,8 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import dedent from 'dedent';
+import type { Browser } from 'playwright';
+import * as playwright from 'playwright-core';
 import { ActionResult } from '../../../src/action-result.ts';
 import type { Navigator } from '../../../src/ai/navigator.ts';
 import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
@@ -14,16 +17,20 @@ import { browserErrorMessage } from '../../../src/utils/browser-errors.ts';
 import { pluralize } from '../../../src/utils/logger.ts';
 import { type EnvelopeData, type HealAttempt, type InstanceInfo, writeArtifacts } from './envelope.ts';
 import { isFunctionExpression, toCodeceptWrapper } from './pw-parser.ts';
+import { type PwServerDescriptor, readDescriptors, selectDescriptor } from './pw-registry.ts';
 
 const MAX_INSTRUCTION_ITERATIONS = 6;
 const MAX_TOOL_ROUNDTRIPS = 5;
 const AI_AGENT_NAME = 'prima';
+const CONNECT_TIMEOUT = 3000;
+const requireLib = createRequire(import.meta.url);
 
 export class Prima {
   private options: PrimaOptions;
   private bot: ExplorBot;
   private artifactsDir?: string;
   private server: { close: () => Promise<void> } | null = null;
+  private attached: string | null = null;
 
   constructor(options: PrimaOptions = {}) {
     this.options = options;
@@ -39,19 +46,8 @@ export class Prima {
   }
 
   async start(): Promise<void> {
-    await this.loadConfig();
-
-    if (!(await this.connectOwnInstance())) {
-      throw new Error(dedent`
-        No browser session found for instance "${this.instanceName()}".
-        Create one first:
-          prima browser start   starts a prima-owned browser
-        Prima never launches a browser implicitly.
-        Attaching to a browser opened by playwright-cli is not wired yet, so --endpoint
-        and --pw-session cannot reach one.
-      `);
-    }
-
+    const config = await this.loadConfig();
+    await this.attachBrowser(config);
     await this.bot.start();
 
     if (!this.options.url) return;
@@ -229,6 +225,7 @@ export class Prima {
 
   async browserStop(all = false): Promise<boolean> {
     await this.loadConfig();
+    if (this.attached) return false;
 
     if (!all) return this.stopInstance(this.instanceName());
 
@@ -257,7 +254,11 @@ export class Prima {
     for (const instance of listInstances()) {
       const endpoint = await getAliveEndpoint(instance.name);
       if (!endpoint) continue;
-      lines.push(`${instance.name}  ${endpoint}`);
+      lines.push(`prima --instance ${instance.name}  ${endpoint}`);
+    }
+
+    for (const descriptor of this.discover().candidates) {
+      lines.push(`playwright-cli --pw-session ${descriptor.title}  ${descriptor.endpoint}`);
     }
 
     if (!lines.length) return 'no browser instances running';
@@ -270,7 +271,9 @@ export class Prima {
       .filter((instance) => instance.name !== name)
       .map((instance) => ({ name: instance.name, tabs: 0 }));
 
-    return { name, tabs: this.tabCount(), others };
+    const info: InstanceInfo = { name, tabs: this.tabCount(), others };
+    if (this.attached) info.attached = this.attached;
+    return info;
   }
 
   async toolFailureEnvelope(command: string, error: unknown): Promise<EnvelopeData> {
@@ -290,6 +293,84 @@ export class Prima {
 
   private async loadConfig(): Promise<ExplorbotConfig> {
     return ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path });
+  }
+
+  private async attachBrowser(config: ExplorbotConfig): Promise<void> {
+    if (this.options.endpoint) {
+      const endpoint = this.options.endpoint;
+      const browserName = config.playwright.browser || 'chromium';
+      if (await this.attachToEndpoint({ file: '', title: '', endpoint, workspaceDir: '', browserName, playwrightLib: '' })) return;
+      throw new Error(dedent`
+        No browser answered at ${endpoint}.
+        Check the endpoint of the running session, or drop --endpoint to attach to the
+        playwright-cli browser of this workspace.
+      `);
+    }
+
+    const { match, candidates } = this.discover();
+    if (match && (await this.attachToEndpoint(match))) return;
+
+    if (!match && candidates.length) {
+      const titles = candidates.map((candidate) => candidate.title).join(', ');
+      throw new Error(dedent`
+        Several playwright-cli sessions are open for this workspace: ${titles}
+        Pick one with --pw-session <title>.
+      `);
+    }
+
+    if (await this.connectOwnInstance()) return;
+
+    throw new Error(dedent`
+      No browser to drive for instance "${this.instanceName()}".
+      Open one first:
+        playwright-cli open <url>   prima attaches to this workspace session by default
+        prima browser start         starts a prima-owned browser instead
+      Prima never launches a browser implicitly.
+    `);
+  }
+
+  private discover(): { match?: PwServerDescriptor; candidates: PwServerDescriptor[] } {
+    const title = this.options.pwSession ?? process.env.PLAYWRIGHT_CLI_SESSION;
+    return selectDescriptor(readDescriptors(), { workspaceDir: this.workspaceDir(), title });
+  }
+
+  private async attachToEndpoint(descriptor: PwServerDescriptor): Promise<boolean> {
+    const browser = await this.connectDescriptor(descriptor);
+    if (!browser) return false;
+
+    this.bot.attachBrowser(browser);
+    this.attached = this.attachmentLabel(descriptor);
+    return true;
+  }
+
+  private async connectDescriptor(descriptor: PwServerDescriptor): Promise<Browser | null> {
+    const connected = await this.connectWith(playwright, descriptor);
+    if (connected) return connected;
+    return this.connectWith(this.descriptorLib(descriptor), descriptor);
+  }
+
+  private async connectWith(lib: any, descriptor: PwServerDescriptor): Promise<Browser | null> {
+    const launcher = lib?.[descriptor.browserName];
+    if (!launcher?.connect) return null;
+    return launcher.connect(descriptor.endpoint, { timeout: CONNECT_TIMEOUT }).catch(() => null);
+  }
+
+  private descriptorLib(descriptor: PwServerDescriptor): any {
+    if (!descriptor.playwrightLib) return null;
+    try {
+      return requireLib(descriptor.playwrightLib);
+    } catch {
+      return null;
+    }
+  }
+
+  private attachmentLabel(descriptor: PwServerDescriptor): string {
+    if (!descriptor.title) return `endpoint ${descriptor.endpoint}`;
+    return `playwright-cli session "${descriptor.title}", workspace ${descriptor.workspaceDir}`;
+  }
+
+  private workspaceDir(): string {
+    return path.resolve(this.options.path || process.cwd());
   }
 
   private async connectOwnInstance(): Promise<boolean> {

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -37,6 +37,7 @@ export class Prima {
     this.bot = new ExplorBot({
       config: options.config,
       path: options.path,
+      baseUrl: this.configBaseUrl(),
       verbose: options.verbose,
       session: options.session,
       instance: options.instance,
@@ -294,7 +295,14 @@ export class Prima {
   }
 
   private async loadConfig(): Promise<ExplorbotConfig> {
-    return ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path });
+    return ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path, baseUrl: this.configBaseUrl() });
+  }
+
+  private configBaseUrl(): string | undefined {
+    const url = this.options.url;
+    if (!url) return undefined;
+    if (!URL.canParse(url)) return undefined;
+    return url;
   }
 
   private async resolveBrowser(config: ExplorbotConfig): Promise<void> {

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -1,0 +1,172 @@
+import path from 'node:path';
+import dedent from 'dedent';
+import { ActionResult } from '../../../src/action-result.ts';
+import { getAliveEndpoint, listInstances } from '../../../src/browser-server.ts';
+import { outputPath } from '../../../src/config.ts';
+import { ExplorBot } from '../../../src/explorbot.ts';
+import type { WebPageState } from '../../../src/state-manager.ts';
+import { browserErrorMessage } from '../../../src/utils/browser-errors.ts';
+import { type EnvelopeData, type InstanceInfo, writeArtifacts } from './envelope.ts';
+import { isFunctionExpression, toCodeceptWrapper } from './pw-parser.ts';
+
+export class Prima {
+  private options: PrimaOptions;
+  private bot: ExplorBot;
+  private artifactsDir?: string;
+
+  constructor(options: PrimaOptions = {}) {
+    this.options = options;
+    this.bot = new ExplorBot({
+      config: options.config,
+      path: options.path,
+      verbose: options.verbose,
+      session: options.session,
+      instance: options.instance,
+      headless: true,
+    });
+  }
+
+  async start(): Promise<void> {
+    if (!(await this.connectOwnInstance())) {
+      throw new Error(dedent`
+        No browser session found for instance "${this.instanceName()}".
+        Create one first:
+          playwright-cli open <url>   preferred, prima drives that session
+          prima browser start        starts a prima-owned browser
+        Prima never launches a browser implicitly.
+      `);
+    }
+
+    await this.bot.start();
+
+    if (!this.options.url) return;
+    if (this.bot.getCurrentState()) return;
+    await this.bot.visit(this.options.url);
+  }
+
+  async stop(): Promise<void> {
+    await this.bot.stop();
+  }
+
+  async pw(expression: string): Promise<EnvelopeData> {
+    const command = `pw ${expression}`;
+    const validation = isFunctionExpression(expression);
+    if (!validation.valid) return this.toolFailureEnvelope(command, validation.error!);
+
+    const previousState = this.bot.stateManager().getCurrentState();
+    const action = this.bot.getExplorer().action();
+    let result: ActionResult | null = null;
+
+    try {
+      const executed = await action.execute(toCodeceptWrapper(expression));
+      result = executed.actionResult;
+    } catch (error) {
+      return this.failureEnvelope(command, error, previousState);
+    }
+
+    result ||= await this.bot.getExplorer().capture();
+    return this.successEnvelope(command, [expression], result, previousState);
+  }
+
+  async instanceInfo(): Promise<InstanceInfo> {
+    const name = this.instanceName();
+    const others = listInstances()
+      .filter((instance) => instance.name !== name)
+      .map((instance) => ({ name: instance.name, tabs: 0 }));
+
+    return { name, tabs: this.tabCount(), others };
+  }
+
+  private async connectOwnInstance(): Promise<boolean> {
+    return !!(await getAliveEndpoint(this.instanceName()));
+  }
+
+  private async successEnvelope(command: string, used: string[], result: ActionResult, previousState: WebPageState | null): Promise<EnvelopeData> {
+    return {
+      ok: true,
+      command,
+      used,
+      page: this.pageBlock(result, previousState),
+      changes: await this.pageChanges(result, previousState, used[0]),
+      instance: await this.instanceInfo(),
+      artifacts: await this.writeSnapshot(result),
+    };
+  }
+
+  private async failureEnvelope(command: string, error: unknown, previousState: WebPageState | null): Promise<EnvelopeData> {
+    const result = await this.bot.getExplorer().capture();
+
+    return {
+      ok: false,
+      command,
+      page: this.pageBlock(result, previousState),
+      failure: { error: browserErrorMessage(error), attempts: [] },
+      instance: await this.instanceInfo(),
+      artifacts: await this.writeSnapshot(result),
+    };
+  }
+
+  private async toolFailureEnvelope(command: string, error: string): Promise<EnvelopeData> {
+    const state = this.bot.stateManager().getCurrentState();
+
+    return {
+      ok: false,
+      command,
+      page: { url: state?.url || '', title: state?.title || '', state: state?.hash || '', visits: 0 },
+      failure: { error: `tool: ${error}`, attempts: [] },
+      instance: await this.instanceInfo(),
+    };
+  }
+
+  private pageBlock(result: ActionResult, previousState: WebPageState | null): EnvelopeData['page'] {
+    return {
+      url: result.url,
+      previousUrl: previousState?.url,
+      title: result.title,
+      state: result.getStateHash(),
+      visits: this.bot.stateManager().getVisitCount(result.url),
+    };
+  }
+
+  private async pageChanges(result: ActionResult, previousState: WebPageState | null, code: string): Promise<string | null> {
+    if (!previousState) return null;
+    const toolResult = await result.toToolResult(ActionResult.fromState(previousState), code);
+    return toolResult.pageDiff?.ariaChanges ?? null;
+  }
+
+  private async writeSnapshot(result: ActionResult): Promise<EnvelopeData['artifacts']> {
+    return writeArtifacts(this.nextArtifactDir(), {
+      aria: result.ariaSnapshot,
+      html: await result.combinedHtml(),
+      requests: this.bot.requestStore().getRequests(),
+    });
+  }
+
+  private nextArtifactDir(): string {
+    this.artifactsDir ||= outputPath('prima');
+    return path.join(this.artifactsDir, new Date().toISOString().replace(/[:.]/g, '-'));
+  }
+
+  private tabCount(): number {
+    const page = this.bot.getExplorer()?.page;
+    if (!page) return 0;
+    return page.context().pages().length;
+  }
+
+  private instanceName(): string {
+    return this.options.instance || 'default';
+  }
+}
+
+export interface PrimaOptions {
+  verbose?: boolean;
+  config?: string;
+  path?: string;
+  instance?: string;
+  session?: string;
+  heal?: boolean;
+  ephemeral?: boolean;
+  framework?: 'codeceptjs' | 'playwright';
+  noVision?: boolean;
+  url?: string;
+}

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -69,7 +69,7 @@ export class Prima {
     let executionError: unknown = null;
 
     try {
-      const executed = await this.bot.getExplorer().action().execute(toCodeceptWrapper(expression));
+      const executed = await this.bot.getExplorer().action().execute(toCodeceptWrapper(expression), { verbatim: true });
       result = executed.actionResult;
     } catch (error) {
       executionError = error;

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -1,8 +1,8 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import dedent from 'dedent';
+import * as playwright from 'playwright';
 import type { Browser } from 'playwright';
-import * as playwright from 'playwright-core';
 import { ActionResult } from '../../../src/action-result.ts';
 import type { Navigator } from '../../../src/ai/navigator.ts';
 import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
@@ -47,7 +47,7 @@ export class Prima {
 
   async start(): Promise<void> {
     const config = await this.loadConfig();
-    await this.attachBrowser(config);
+    await this.resolveBrowser(config);
     await this.bot.start();
 
     if (!this.options.url) return;
@@ -257,7 +257,9 @@ export class Prima {
       lines.push(`prima --instance ${instance.name}  ${endpoint}`);
     }
 
-    for (const descriptor of this.discover().candidates) {
+    const discovery = await this.discover();
+    await discovery.browser?.close().catch(() => {});
+    for (const descriptor of discovery.candidates) {
       lines.push(`playwright-cli --pw-session ${descriptor.title}  ${descriptor.endpoint}`);
     }
 
@@ -295,7 +297,7 @@ export class Prima {
     return ConfigParser.getInstance().loadConfig({ config: this.options.config, path: this.options.path });
   }
 
-  private async attachBrowser(config: ExplorbotConfig): Promise<void> {
+  private async resolveBrowser(config: ExplorbotConfig): Promise<void> {
     if (this.options.endpoint) {
       const endpoint = this.options.endpoint;
       const browserName = config.playwright.browser || 'chromium';
@@ -307,8 +309,8 @@ export class Prima {
       `);
     }
 
-    const { match, candidates } = this.discover();
-    if (match && (await this.attachToEndpoint(match))) return;
+    const { match, candidates, browser } = await this.discover();
+    if (match && (await this.attachToEndpoint(match, browser))) return;
 
     if (!match && candidates.length) {
       const titles = candidates.map((candidate) => candidate.title).join(', ');
@@ -329,13 +331,30 @@ export class Prima {
     `);
   }
 
-  private discover(): { match?: PwServerDescriptor; candidates: PwServerDescriptor[] } {
+  private async discover(descriptors = readDescriptors()): Promise<Discovery> {
     const title = this.options.pwSession ?? process.env.PLAYWRIGHT_CLI_SESSION;
-    return selectDescriptor(readDescriptors(), { workspaceDir: this.workspaceDir(), title });
+    const opts = { workspaceDir: this.workspaceDir(), title };
+
+    const alive = new Map<PwServerDescriptor, Browser>();
+    for (const candidate of selectDescriptor(descriptors, opts).candidates) {
+      const browser = await this.connectDescriptor(candidate);
+      if (browser) alive.set(candidate, browser);
+    }
+
+    const selected = selectDescriptor([...alive.keys()], opts);
+    const discovery: Discovery = { match: selected.match, candidates: selected.candidates };
+    if (selected.match) discovery.browser = alive.get(selected.match);
+
+    for (const [descriptor, browser] of alive) {
+      if (descriptor === selected.match) continue;
+      await browser.close().catch(() => {});
+    }
+
+    return discovery;
   }
 
-  private async attachToEndpoint(descriptor: PwServerDescriptor): Promise<boolean> {
-    const browser = await this.connectDescriptor(descriptor);
+  private async attachToEndpoint(descriptor: PwServerDescriptor, probed?: Browser): Promise<boolean> {
+    const browser = probed || (await this.connectDescriptor(descriptor));
     if (!browser) return false;
 
     this.bot.attachBrowser(browser);
@@ -650,6 +669,12 @@ export class Prima {
   private instanceName(): string {
     return this.options.instance || 'default';
   }
+}
+
+interface Discovery {
+  match?: PwServerDescriptor;
+  candidates: PwServerDescriptor[];
+  browser?: Browser;
 }
 
 export interface PrimaOptions {

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import dedent from 'dedent';
 import { ActionResult } from '../../../src/action-result.ts';
 import type { Navigator } from '../../../src/ai/navigator.ts';
-import { locatorRule } from '../../../src/ai/rules.ts';
+import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
 import { createCodeceptJSTools } from '../../../src/ai/tools.ts';
 import { getAliveEndpoint, listInstances } from '../../../src/browser-server.ts';
 import { outputPath } from '../../../src/config.ts';
@@ -96,7 +96,8 @@ export class Prima {
     const used: string[] = [];
     let failure: { code: string; message: string } | null = null;
     let aiError: unknown = null;
-    let contextHash = previousState?.hash;
+    let narration = '';
+    let contextHash = this.bot.stateManager().getCurrentState()?.hash;
 
     for (let iteration = 1; iteration <= Math.min(instructions.length + 2, MAX_INSTRUCTION_ITERATIONS); iteration++) {
       const state = this.bot.stateManager().getCurrentState();
@@ -112,7 +113,10 @@ export class Prima {
       if (!invoked) break;
 
       const executions = invoked.toolExecutions || [];
-      if (!executions.length) break;
+      if (!executions.length) {
+        narration = invoked.response?.text?.trim() || '';
+        break;
+      }
 
       for (const execution of executions) {
         if (!execution.wasSuccessful) {
@@ -132,7 +136,10 @@ export class Prima {
       return envelope;
     }
 
-    if (!used.length) return this.failureEnvelope(command, 'No action was performed for these instructions on the current page.', previousState);
+    if (!used.length) {
+      const reason = ['No action was performed for these instructions on the current page.', narration].filter(Boolean).join(' ');
+      return this.failureEnvelope(command, reason, previousState);
+    }
 
     const result = await this.capturedResult(this.bot.stateManager().getCurrentState());
     return this.successEnvelope(command, used, result, previousState);
@@ -274,6 +281,8 @@ export class Prima {
       </approach>
 
       ${locatorRule}
+
+      ${actionRule}
     `;
   }
 

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -1,12 +1,15 @@
 import path from 'node:path';
 import dedent from 'dedent';
 import { ActionResult } from '../../../src/action-result.ts';
+import type { Navigator } from '../../../src/ai/navigator.ts';
 import { getAliveEndpoint, listInstances } from '../../../src/browser-server.ts';
 import { outputPath } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
 import type { WebPageState } from '../../../src/state-manager.ts';
+import { compactAriaSnapshot } from '../../../src/utils/aria.ts';
 import { browserErrorMessage } from '../../../src/utils/browser-errors.ts';
-import { type EnvelopeData, type InstanceInfo, writeArtifacts } from './envelope.ts';
+import { pluralize } from '../../../src/utils/logger.ts';
+import { type EnvelopeData, type HealAttempt, type InstanceInfo, writeArtifacts } from './envelope.ts';
 import { isFunctionExpression, toCodeceptWrapper } from './pw-parser.ts';
 
 export class Prima {
@@ -55,13 +58,16 @@ export class Prima {
 
     const previousState = this.bot.stateManager().getCurrentState();
     let result: ActionResult | null = null;
+    let executionError: unknown = null;
 
     try {
       const executed = await this.bot.getExplorer().action().execute(toCodeceptWrapper(expression));
       result = executed.actionResult;
     } catch (error) {
-      return this.failureEnvelope(command, error, previousState);
+      executionError = error;
     }
+
+    if (executionError) return this.heal(command, expression, executionError, previousState);
 
     result ||= await this.capturedResult(previousState);
     return this.successEnvelope(command, [expression], result, previousState);
@@ -80,6 +86,49 @@ export class Prima {
     return !!(await getAliveEndpoint(this.instanceName()));
   }
 
+  private async heal(command: string, expression: string, error: unknown, previousState: WebPageState | null): Promise<EnvelopeData> {
+    if (this.options.heal === false) return this.failureEnvelope(command, error, previousState);
+
+    const navigator = this.healNavigator();
+    if (!navigator) {
+      const envelope = await this.failureEnvelope(command, error, previousState);
+      envelope.healed = false;
+      envelope.healNote = 'ai unavailable';
+      return envelope;
+    }
+
+    const message = dedent`
+      I tried to run this command on the page: ${expression}
+      But it failed with: ${browserErrorMessage(error)}
+      Reach the same outcome on the current page in a different way.
+    `;
+
+    const attempts: Array<{ code: string; error?: string }> = [];
+    const failedResult = await this.capturedResult(previousState);
+    const resolved = await navigator.resolveState(message, failedResult, { onAttempt: (attempt) => attempts.push(attempt) }).catch(() => false);
+
+    if (!resolved) {
+      const healAttempts = attempts.map((attempt) => ({ code: attempt.code, outcome: attempt.error || 'ok' }));
+      return this.failureEnvelope(command, error, previousState, healAttempts);
+    }
+
+    const used = attempts.filter((attempt) => !attempt.error).map((attempt) => attempt.code);
+    const result = await this.capturedResult(this.bot.stateManager().getCurrentState());
+    const envelope = await this.successEnvelope(command, used, result, previousState);
+    envelope.healed = true;
+    envelope.healNote = `recovered after ${attempts.length} ${pluralize(attempts.length, 'attempt')}`;
+    return envelope;
+  }
+
+  private healNavigator(): Navigator | null {
+    try {
+      if (!this.bot.getProvider?.()) return null;
+      return this.bot.agentNavigator?.() ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private async successEnvelope(command: string, used: string[], result: ActionResult, previousState: WebPageState | null): Promise<EnvelopeData> {
     return {
       ok: true,
@@ -92,14 +141,19 @@ export class Prima {
     };
   }
 
-  private async failureEnvelope(command: string, error: unknown, previousState: WebPageState | null): Promise<EnvelopeData> {
+  private async failureEnvelope(command: string, error: unknown, previousState: WebPageState | null, attempts: HealAttempt[] = []): Promise<EnvelopeData> {
     const result = await this.capturedResult(previousState);
+    const failure: EnvelopeData['failure'] = { error: browserErrorMessage(error), attempts };
+    if (attempts.length) {
+      failure.reasoning = [...new Set(attempts.map((attempt) => attempt.outcome))].join('; ');
+      failure.compactAria = compactAriaSnapshot(result.ariaSnapshot, true);
+    }
 
     return {
       ok: false,
       command,
       page: this.pageBlock(result, previousState),
-      failure: { error: browserErrorMessage(error), attempts: [] },
+      failure,
       instance: await this.instanceInfo(),
       artifacts: await this.writeSnapshot(result),
     };

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -299,7 +299,7 @@ export class Prima {
   }
 
   private configBaseUrl(): string | undefined {
-    const url = this.options.url;
+    const url = this.options.baseUrl || this.options.url;
     if (!url) return undefined;
     if (!URL.canParse(url)) return undefined;
     return url;
@@ -696,6 +696,7 @@ export interface PrimaOptions {
   framework?: 'codeceptjs' | 'playwright';
   noVision?: boolean;
   url?: string;
+  baseUrl?: string;
   show?: boolean;
   headless?: boolean;
   endpoint?: string;

--- a/boat/prima/src/pw-parser.ts
+++ b/boat/prima/src/pw-parser.ts
@@ -1,0 +1,17 @@
+const FUNCTION_SHAPE = /^(async\s+)?(function\b|\()/;
+
+export function isFunctionExpression(expr: string): { valid: boolean; error?: string } {
+  const trimmed = expr.trim();
+  if (!trimmed) return { valid: false, error: 'empty expression; pass a function like ({ page }) => ...' };
+  if (!FUNCTION_SHAPE.test(trimmed)) return { valid: false, error: 'expression must be a function like ({ page }) => ... destructuring the playwright objects it needs' };
+  try {
+    new Function(`return (${trimmed})`);
+  } catch (e) {
+    return { valid: false, error: `not a valid function expression: ${(e as Error).message}` };
+  }
+  return { valid: true };
+}
+
+export function toCodeceptWrapper(expr: string): string {
+  return `I.usePlaywrightTo('pw', ${expr.trim()})`;
+}

--- a/boat/prima/src/pw-parser.ts
+++ b/boat/prima/src/pw-parser.ts
@@ -13,5 +13,5 @@ export function isFunctionExpression(expr: string): { valid: boolean; error?: st
 }
 
 export function toCodeceptWrapper(expr: string): string {
-  return `I.usePlaywrightTo('pw', ${expr.trim()})`;
+  return `I.usePlaywrightTo('pw', async (playwright) => (${expr.trim()})(playwright))`;
 }

--- a/boat/prima/src/pw-registry.ts
+++ b/boat/prima/src/pw-registry.ts
@@ -1,0 +1,75 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const DEFAULT_TITLE = 'default';
+const DEFAULT_BROWSER = 'chromium';
+
+export function registryDir(): string {
+  if (process.platform === 'darwin') return path.join(os.homedir(), 'Library', 'Caches', 'ms-playwright', 'b');
+  if (process.platform === 'win32') return path.join(process.env.LOCALAPPDATA || path.join(os.homedir(), 'AppData', 'Local'), 'ms-playwright', 'b');
+  return path.join(process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache'), 'ms-playwright', 'b');
+}
+
+export function readDescriptors(dir = registryDir()): PwServerDescriptor[] {
+  const descriptors: PwServerDescriptor[] = [];
+  for (const fileName of listFiles(dir)) {
+    const descriptor = parseDescriptor(path.join(dir, fileName));
+    if (descriptor) descriptors.push(descriptor);
+  }
+  return descriptors;
+}
+
+export function selectDescriptor(descriptors: PwServerDescriptor[], opts: { workspaceDir: string; title?: string }): { match?: PwServerDescriptor; candidates: PwServerDescriptor[] } {
+  const workspaceDir = path.resolve(opts.workspaceDir);
+  const candidates = descriptors.filter((descriptor) => path.resolve(descriptor.workspaceDir) === workspaceDir);
+  if (!candidates.length) return { candidates };
+
+  if (opts.title) {
+    const titled = candidates.find((descriptor) => descriptor.title === opts.title);
+    if (titled) return { match: titled, candidates };
+    return { candidates };
+  }
+
+  const preferred = candidates.find((descriptor) => descriptor.title === DEFAULT_TITLE);
+  if (preferred) return { match: preferred, candidates };
+  if (candidates.length === 1) return { match: candidates[0], candidates };
+  return { candidates };
+}
+
+function listFiles(dir: string): string[] {
+  try {
+    return readdirSync(dir);
+  } catch {
+    return [];
+  }
+}
+
+function parseDescriptor(file: string): PwServerDescriptor | null {
+  let data: any;
+  try {
+    data = JSON.parse(readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+
+  if (!data?.endpoint || !data?.title || !data?.workspaceDir) return null;
+
+  return {
+    file,
+    title: data.title,
+    endpoint: data.endpoint,
+    workspaceDir: data.workspaceDir,
+    browserName: data.browser?.browserName || DEFAULT_BROWSER,
+    playwrightLib: data.playwrightLib || '',
+  };
+}
+
+export interface PwServerDescriptor {
+  file: string;
+  title: string;
+  endpoint: string;
+  workspaceDir: string;
+  browserName: string;
+  playwrightLib: string;
+}

--- a/boat/prima/tests/envelope.test.ts
+++ b/boat/prima/tests/envelope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdtempSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
@@ -107,5 +107,6 @@ describe('writeArtifacts', () => {
     expect(readFileSync(result.html, 'utf-8')).toContain('<html>');
     expect(readFileSync(result.network, 'utf-8')).toContain('/api/user');
     expect(path.isAbsolute(result.aria)).toBe(true);
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/boat/prima/tests/envelope.test.ts
+++ b/boat/prima/tests/envelope.test.ts
@@ -86,6 +86,17 @@ describe('renderEnvelope', () => {
     expect(out).toContain('browser: attached (playwright-cli session "default"');
     expect(out).not.toContain('started 12m ago');
   });
+
+  test('instance without evidence of a live browser reports it as not running', () => {
+    const out = renderEnvelope({ ...base, instance: { name: 'default', tabs: 0, others: [] } });
+    expect(out).toContain('browser: not running');
+  });
+
+  test('open tabs alone are evidence enough for a running browser', () => {
+    const out = renderEnvelope({ ...base, instance: { name: 'default', tabs: 2, others: [] } });
+    expect(out).toContain('browser: running');
+    expect(out).not.toContain('browser: not running');
+  });
 });
 
 describe('writeArtifacts', () => {

--- a/boat/prima/tests/envelope.test.ts
+++ b/boat/prima/tests/envelope.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { type EnvelopeData, renderEnvelope, writeArtifacts } from '../src/envelope.ts';
+
+const base: EnvelopeData = {
+  ok: true,
+  command: "pw ({ page }) => page.click('text=Login')",
+  used: ["I.click('Login')"],
+  page: { url: 'https://app.example.com/dashboard', previousUrl: 'https://app.example.com/login', title: 'Dashboard', state: 'dashboard_h1_dashboard', visits: 1 },
+  changes: 'ariaDiff:\n  added:\n    - heading "Dashboard"',
+  instance: { name: 'default', tabs: 3, startedAgo: '12m', others: [{ name: 'auth-test', tabs: 1 }] },
+  artifacts: { aria: '/tmp/x/aria.yml', html: '/tmp/x/page.html', network: '/tmp/x/network.jsonl' },
+};
+
+describe('renderEnvelope', () => {
+  test('success envelope contains all sections in order', () => {
+    const out = renderEnvelope(base);
+    const sections = ['### Result', '### Page', '### Changes', '### Instance', '### Artifacts'];
+    const positions = sections.map((s) => out.indexOf(s));
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+    expect(out).toContain('ok: true');
+    expect(out).toContain("used: I.click('Login')");
+    expect(out).toContain('(changed: https://app.example.com/login → https://app.example.com/dashboard)');
+    expect(out).toContain('instance: default (3 tabs) | other instances: auth-test (1 tab)');
+  });
+
+  test('unchanged url renders without changed marker', () => {
+    const out = renderEnvelope({ ...base, page: { ...base.page, previousUrl: base.page.url } });
+    expect(out).not.toContain('(changed:');
+  });
+
+  test('failure envelope renders attempts, reasoning and compact aria', () => {
+    const out = renderEnvelope({
+      ...base,
+      ok: false,
+      failure: {
+        error: "locator 'text=Login' not found",
+        attempts: [
+          { code: "I.click('Login')", outcome: 'not visible' },
+          { code: 'scroll + retry', outcome: 'covered by cookie banner' },
+        ],
+        reasoning: 'element hidden behind consent overlay',
+        compactAria: '- button "Accept all"',
+      },
+    });
+    expect(out).toContain('### Failure');
+    expect(out).toContain('### Healing attempts (2)');
+    expect(out).toContain("1. I.click('Login')");
+    expect(out).toContain('→ not visible');
+    expect(out).toContain('### Current page (compact ARIA)');
+    expect(out).toContain('- button "Accept all"');
+  });
+
+  test('answer replaces changes for ask', () => {
+    const out = renderEnvelope({ ...base, changes: undefined, answer: 'A login form with email and password fields' });
+    expect(out).toContain('### Answer');
+    expect(out).not.toContain('### Changes');
+  });
+
+  test('research replaces changes for research', () => {
+    const out = renderEnvelope({ ...base, changes: undefined, research: '## Login form\n- email field\n- password field' });
+    expect(out).toContain('### Research');
+    expect(out).toContain('- password field');
+    expect(out).not.toContain('### Changes');
+    expect(out).not.toContain('### Answer');
+  });
+
+  test('verdict replaces changes for verify', () => {
+    const out = renderEnvelope({ ...base, changes: undefined, verdict: { passed: true, evidence: 'heading "Dashboard" present', code: "I.see('Dashboard')" } });
+    expect(out).toContain('### Verdict');
+    expect(out).toContain('passed: true');
+    expect(out).toContain("I.see('Dashboard')");
+  });
+
+  test('healed success carries note', () => {
+    const out = renderEnvelope({ ...base, healed: true, healNote: 'dismissed overlay first' });
+    expect(out).toContain('healed: true (dismissed overlay first)');
+  });
+
+  test('attached instance renders attached browser line', () => {
+    const out = renderEnvelope({ ...base, instance: { ...base.instance, attached: 'playwright-cli session "default", workspace /w' } });
+    expect(out).toContain('browser: attached (playwright-cli session "default"');
+    expect(out).not.toContain('started 12m ago');
+  });
+});
+
+describe('writeArtifacts', () => {
+  test('writes aria, html and network files and returns absolute paths', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'prima-'));
+    const result = writeArtifacts(dir, { aria: '- button "Login"', html: '<html></html>', requests: [{ url: '/api/user', status: 200 }] });
+    expect(readFileSync(result.aria, 'utf-8')).toContain('button "Login"');
+    expect(readFileSync(result.html, 'utf-8')).toContain('<html>');
+    expect(readFileSync(result.network, 'utf-8')).toContain('/api/user');
+    expect(path.isAbsolute(result.aria)).toBe(true);
+  });
+});

--- a/boat/prima/tests/envelope.test.ts
+++ b/boat/prima/tests/envelope.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { readFileSync } from 'node:fs';
 import { type EnvelopeData, renderEnvelope, writeArtifacts } from '../src/envelope.ts';
 
 const base: EnvelopeData = {

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -58,6 +58,7 @@ function fakeProvider(invokeConversation: (...args: any[]) => Promise<any>, prom
 function fakePrima(options: Record<string, unknown> = {}) {
   const prima = new Prima({ instance: 'default', ...options });
   const executed: string[] = [];
+  const executeOptions: unknown[] = [];
   const after = fakeState({
     url: 'https://app.example.com/dashboard',
     title: 'Dashboard',
@@ -68,8 +69,9 @@ function fakePrima(options: Record<string, unknown> = {}) {
   (prima as any).bot = {
     getExplorer: () => ({
       action: () => ({
-        execute: async (code: string) => {
+        execute: async (code: string, opts?: unknown) => {
           executed.push(code);
+          executeOptions.push(opts);
           return { actionResult: after, lastError: null };
         },
       }),
@@ -84,7 +86,7 @@ function fakePrima(options: Record<string, unknown> = {}) {
     getProvider: () => ({ chat: async () => '' }),
   };
   (prima as any).artifactsDir = artifactsRoot;
-  return { prima, executed };
+  return { prima, executed, executeOptions };
 }
 
 describe('Prima.pw', () => {
@@ -99,9 +101,10 @@ describe('Prima.pw', () => {
   });
 
   test('executes wrapped function and returns success envelope data', async () => {
-    const { prima, executed } = fakePrima();
+    const { prima, executed, executeOptions } = fakePrima();
     const envelope = await prima.pw("({ page }) => page.click('text=Login')");
     expect(executed[0]).toContain('I.usePlaywrightTo');
+    expect(executeOptions[0]).toEqual({ verbatim: true });
     expect(envelope.ok).toBe(true);
     expect(envelope.command).toBe("pw ({ page }) => page.click('text=Login')");
     expect(envelope.used).toEqual(["({ page }) => page.click('text=Login')"]);

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -246,8 +246,155 @@ describe('Prima.start', () => {
         started = true;
       },
     };
-    await expect(prima.start()).rejects.toThrow(/not wired yet/);
+    (prima as any).discover = () => ({ candidates: [] });
+    await expect(prima.start()).rejects.toThrow(/playwright-cli open/);
     expect(started).toBe(false);
+  });
+});
+
+describe('Prima attach ladder', () => {
+  const descriptor = { file: 'a', title: 'default', endpoint: '/tmp/pw/a.sock', workspaceDir: process.cwd(), browserName: 'chromium', playwrightLib: '/lib/pw' };
+
+  function ladderPrima(options: Record<string, unknown> = {}) {
+    const prima = new Prima({ instance: 'default', ...options });
+    const calls: string[] = [];
+    (prima as any).bot = { start: async () => calls.push('bot.start'), getCurrentState: () => null };
+    return { prima, calls };
+  }
+
+  test('start attaches to workspace playwright-cli browser before own daemon', async () => {
+    const { prima, calls } = ladderPrima();
+    (prima as any).discover = () => ({ match: descriptor, candidates: [] });
+    (prima as any).attachToEndpoint = async () => {
+      calls.push('attach');
+      return true;
+    };
+    (prima as any).connectOwnInstance = async () => {
+      calls.push('own');
+      return true;
+    };
+
+    await prima.start();
+    expect(calls).toEqual(['attach', 'bot.start']);
+  });
+
+  test('dead playwright-cli descriptor falls through to the own instance', async () => {
+    const { prima, calls } = ladderPrima();
+    (prima as any).discover = () => ({ match: descriptor, candidates: [descriptor] });
+    (prima as any).attachToEndpoint = async () => {
+      calls.push('attach');
+      return false;
+    };
+    (prima as any).connectOwnInstance = async () => {
+      calls.push('own');
+      return true;
+    };
+
+    await prima.start();
+    expect(calls).toEqual(['attach', 'own', 'bot.start']);
+  });
+
+  test('start uses explicitly started own instance when nothing attachable', async () => {
+    const { prima, calls } = ladderPrima();
+    (prima as any).discover = () => ({ candidates: [] });
+    (prima as any).attachToEndpoint = async () => {
+      calls.push('attach');
+      return true;
+    };
+    (prima as any).connectOwnInstance = async () => {
+      calls.push('own');
+      return true;
+    };
+
+    await prima.start();
+    expect(calls).toEqual(['own', 'bot.start']);
+  });
+
+  test('explicit endpoint attaches without discovery', async () => {
+    const { prima } = ladderPrima({ endpoint: 'ws://127.0.0.1:4321/session' });
+    const attached: any[] = [];
+    (prima as any).discover = () => {
+      throw new Error('discovery must be skipped for an explicit endpoint');
+    };
+    (prima as any).attachToEndpoint = async (target: unknown) => {
+      attached.push(target);
+      return true;
+    };
+
+    await prima.start();
+    expect(attached.length).toBe(1);
+    expect(attached[0].endpoint).toBe('ws://127.0.0.1:4321/session');
+  });
+
+  test('unreachable explicit endpoint fails naming the endpoint', async () => {
+    const { prima } = ladderPrima({ endpoint: 'ws://127.0.0.1:4321/session' });
+    (prima as any).attachToEndpoint = async () => false;
+
+    await expect(prima.start()).rejects.toThrow(/ws:\/\/127.0.0.1:4321\/session/);
+  });
+
+  test('start fails with playwright-cli guidance when no session exists anywhere', async () => {
+    const { prima } = ladderPrima();
+    (prima as any).discover = () => ({ candidates: [] });
+    (prima as any).connectOwnInstance = async () => false;
+
+    await expect(prima.start()).rejects.toThrow(/playwright-cli open/);
+    await expect(prima.start()).rejects.toThrow(/prima browser start/);
+  });
+
+  test('ambiguous sessions surface as tool error listing candidates', async () => {
+    const { prima } = ladderPrima();
+    (prima as any).discover = () => ({ candidates: [{ title: 'auth' }, { title: 'smoke' }] });
+
+    await expect(prima.start()).rejects.toThrow(/auth.*smoke|smoke.*auth/);
+  });
+
+  test('attached session is injected into the browser and reported in the instance block', async () => {
+    const { prima } = fakePrima();
+    const injected: any[] = [];
+    (prima as any).bot.attachBrowser = (browser: unknown) => injected.push(browser);
+    (prima as any).connectDescriptor = async () => ({ contexts: () => [] });
+
+    const attached = await (prima as any).attachToEndpoint({ ...descriptor, title: 'auth', workspaceDir: '/work/app' });
+    expect(attached).toBe(true);
+    expect(injected.length).toBe(1);
+
+    const info = await prima.instanceInfo();
+    expect(info.attached).toContain('auth');
+    expect(info.attached).toContain('/work/app');
+  });
+
+  test('endpoint attachment is reported by its endpoint', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.attachBrowser = () => {};
+    (prima as any).connectDescriptor = async () => ({ contexts: () => [] });
+
+    await (prima as any).attachToEndpoint({ ...descriptor, title: '', workspaceDir: '', endpoint: 'ws://127.0.0.1:4321/session' });
+    const info = await prima.instanceInfo();
+    expect(info.attached).toContain('ws://127.0.0.1:4321/session');
+  });
+
+  test('descriptor that cannot be connected reports no attachment', async () => {
+    const { prima } = fakePrima();
+    (prima as any).connectDescriptor = async () => null;
+
+    expect(await (prima as any).attachToEndpoint(descriptor)).toBe(false);
+    expect((await prima.instanceInfo()).attached).toBeUndefined();
+  });
+
+  test('stop in attached mode never reaches the browser server kill path', async () => {
+    const { prima } = fakePrima();
+    const calls: string[] = [];
+    (prima as any).attached = 'playwright-cli session "default", workspace /work/app';
+    (prima as any).bot.stop = async () => calls.push('bot.stop');
+    (prima as any).stopInstance = async (instance: string) => {
+      calls.push(`stopInstance:${instance}`);
+      return true;
+    };
+
+    await prima.stop();
+    expect(await prima.browserStop()).toBe(false);
+    expect(calls).toEqual(['bot.stop']);
   });
 });
 
@@ -485,6 +632,7 @@ describe('Prima AI availability', () => {
   test('start survives a failing ai provider bootstrap and do reports the fallback', async () => {
     const { prima } = fakePrima();
     const bot = new ExplorBot({ optionalAi: true });
+    (prima as any).discover = () => ({ candidates: [] });
     (prima as any).connectOwnInstance = async () => true;
     (prima as any).bot.start = () => bot.startProviderOnly();
     (prima as any).bot.getProvider = () => bot.getProvider();
@@ -616,6 +764,7 @@ describe('Prima.go', () => {
         started = true;
       },
     };
+    (prima as any).discover = () => ({ candidates: [] });
 
     await expect(prima.start()).rejects.toThrow(/prima browser start/);
     expect(started).toBe(false);

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -1,7 +1,8 @@
-import { beforeAll, describe, expect, test } from 'bun:test';
-import { existsSync, mkdtempSync } from 'node:fs';
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { getEndpointFilePath, listInstances } from '../../../src/browser-server.ts';
 import { ConfigParser } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
 import { Prima } from '../src/prima.ts';
@@ -9,6 +10,10 @@ import { Prima } from '../src/prima.ts';
 beforeAll(() => {
   ConfigParser.resetForTesting();
   ConfigParser.setupTestConfig();
+});
+
+afterAll(() => {
+  ConfigParser.cleanupAllTestDirectories();
 });
 
 function fakeState(over: Record<string, unknown> = {}) {
@@ -498,5 +503,178 @@ describe('Prima.instanceInfo', () => {
     expect(info.name).toBe('default');
     expect(info.tabs).toBe(0);
     expect(info.others).toEqual([]);
+  });
+});
+
+describe('Prima.go', () => {
+  test('delegates to navigator.visit and returns envelope', async () => {
+    const { prima } = fakePrima();
+    const visited: string[] = [];
+    (prima as any).bot.agentNavigator = () => ({
+      visit: async (destination: string) => {
+        visited.push(destination);
+      },
+    });
+
+    const envelope = await prima.go('billing settings');
+    expect(visited).toEqual(['billing settings']);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.command).toBe('go billing settings');
+    expect(envelope.page.url).toBeTruthy();
+    expect(envelope.used).toEqual([]);
+  });
+
+  test('url target reports the executed navigation code as used', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.agentNavigator = () => ({ visit: async () => {} });
+
+    const envelope = await prima.go('/dashboard');
+    expect(envelope.ok).toBe(true);
+    expect(envelope.used).toEqual(["I.amOnPage('/dashboard')"]);
+    expect(envelope.page.url).toBe('https://app.example.com/dashboard');
+  });
+
+  test('url target navigates without an ai model', async () => {
+    const { prima } = fakePrima();
+    const visited: string[] = [];
+    (prima as any).bot.getProvider = () => {
+      throw new Error('AI connection failed: no credentials');
+    };
+    (prima as any).bot.agentNavigator = () => ({
+      visit: async (destination: string) => {
+        visited.push(destination);
+      },
+    });
+
+    const envelope = await prima.go('https://app.example.com/billing');
+    expect(visited).toEqual(['https://app.example.com/billing']);
+    expect(envelope.ok).toBe(true);
+  });
+
+  test('intent target without an ai model returns the playwright-cli fallback', async () => {
+    const { prima } = fakePrima();
+    let navigated = false;
+    (prima as any).bot.getProvider = () => {
+      throw new Error('AI connection failed: no credentials');
+    };
+    (prima as any).bot.agentNavigator = () => {
+      navigated = true;
+      return { visit: async () => {} };
+    };
+
+    const envelope = await prima.go('billing settings');
+    expect(navigated).toBe(false);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain('playwright-cli');
+    expect(envelope.failure?.error).toContain('AI connection failed: no credentials');
+  });
+
+  test('failed url navigation without ai degrades to a failure envelope', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getProvider = () => {
+      throw new Error('AI provider is not configured');
+    };
+    (prima as any).bot.agentNavigator = () => ({
+      visit: async () => {
+        throw new Error('Navigation to /billing failed: redirected to /login and could not resolve');
+      },
+    });
+
+    const envelope = await prima.go('/billing');
+    expect(envelope.ok).toBe(false);
+    expect(envelope.healed).toBe(false);
+    expect(envelope.healNote).toContain('ai unavailable');
+    expect(envelope.failure?.error).toContain('redirected to /login');
+  });
+
+  test('navigation error is routed through heal', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.agentNavigator = () => ({
+      visit: async () => {
+        throw new Error('Navigation to /billing failed');
+      },
+      resolveState: async (_message: string, _result: unknown, opts: any) => {
+        opts?.onAttempt?.({ code: "I.click('Billing')" });
+        return true;
+      },
+    });
+
+    const envelope = await prima.go('/billing');
+    expect(envelope.ok).toBe(true);
+    expect(envelope.healed).toBe(true);
+    expect(envelope.used).toEqual(["I.click('Billing')"]);
+  });
+
+  test('go cannot run before a session exists and never launches a browser', async () => {
+    const prima = new Prima({ instance: 'default' });
+    let started = false;
+    (prima as any).bot = {
+      start: async () => {
+        started = true;
+      },
+    };
+
+    await expect(prima.start()).rejects.toThrow(/prima browser start/);
+    expect(started).toBe(false);
+    expect(existsSync(getEndpointFilePath('default'))).toBe(false);
+  });
+});
+
+describe('Prima browser instances', () => {
+  afterEach(() => {
+    for (const instance of ['default', 'staging']) {
+      rmSync(getEndpointFilePath(instance), { force: true });
+    }
+  });
+
+  function writeDeadEndpoint(instance: string) {
+    const file = getEndpointFilePath(instance);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, `ws://127.0.0.1:1/${instance}`, 'utf8');
+  }
+
+  test('browserStart launches the configured browser for the instance and keeps the server', async () => {
+    const { prima } = fakePrima({ instance: 'staging' });
+    const launches: any[] = [];
+    let closed = false;
+    (prima as any).launchOwnServer = async (opts: any, instance: string) => {
+      launches.push({ opts, instance });
+      return {
+        close: async () => {
+          closed = true;
+        },
+      };
+    };
+
+    await prima.browserStart();
+    expect(launches).toEqual([{ opts: { browser: 'chromium', show: false }, instance: 'staging' }]);
+
+    await prima.browserStop();
+    expect(closed).toBe(true);
+  });
+
+  test('browserStop with all clears every registered instance', async () => {
+    const { prima } = fakePrima();
+    writeDeadEndpoint('default');
+    writeDeadEndpoint('staging');
+    expect(listInstances().length).toBe(2);
+
+    await prima.browserStop(true);
+    expect(listInstances()).toEqual([]);
+  });
+
+  test('browserStatus reports the instance, tabs and other instances', async () => {
+    const { prima } = fakePrima();
+    writeDeadEndpoint('staging');
+
+    const status = await prima.browserStatus();
+    expect(status).toContain('instance: default (0 tabs)');
+    expect(status).toContain('staging');
+    expect(status).toContain('browser: not running');
+  });
+
+  test('session file is wired into the browser context options', () => {
+    const prima = new Prima({ session: 'output/session.json' });
+    expect((prima as any).bot.options.session).toBe('output/session.json');
   });
 });

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -102,6 +102,34 @@ describe('Prima.pw', () => {
     expect(envelope.page.url).toBe('https://app.example.com/login');
     expect(envelope.artifacts).toBeTruthy();
   });
+
+  test('unrecoverable browser still returns a failure envelope when capture fails too', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getExplorer = () => ({
+      action: () => ({
+        execute: async () => {
+          throw new Error('Browser page is unavailable before action');
+        },
+      }),
+      capture: async () => {
+        throw new Error('Target page, context or browser has been closed');
+      },
+    });
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain('Browser page is unavailable');
+    expect(envelope.page.url).toContain('/login');
+    expect(envelope.artifacts).toBeTruthy();
+  });
+
+  test('missing explorer returns a failure envelope instead of rejecting', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getExplorer = () => undefined;
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toBeTruthy();
+    expect(envelope.page.url).toContain('/login');
+  });
 });
 
 describe('Prima.start', () => {

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -349,6 +349,52 @@ describe('Prima attach ladder', () => {
     await expect(prima.start()).rejects.toThrow(/auth.*smoke|smoke.*auth/);
   });
 
+  test('a stale descriptor is skipped so a live session beside it still wins', async () => {
+    const { prima } = fakePrima();
+    const stale = { ...descriptor, title: 'default', endpoint: '/tmp/pw/stale.sock' };
+    const live = { ...descriptor, title: 'auth', endpoint: '/tmp/pw/auth.sock' };
+    const disconnected: string[] = [];
+    (prima as any).connectDescriptor = async (candidate: any) => {
+      if (candidate.endpoint === stale.endpoint) return null;
+      return { endpoint: candidate.endpoint, close: async () => disconnected.push(candidate.endpoint) };
+    };
+
+    const discovery = await (prima as any).discover([stale, live]);
+    expect(discovery.match?.title).toBe('auth');
+    expect(discovery.candidates.map((candidate: any) => candidate.title)).toEqual(['auth']);
+    expect(discovery.browser?.endpoint).toBe(live.endpoint);
+    expect(disconnected).toEqual([]);
+  });
+
+  test('probe connections that are not attached to are disconnected', async () => {
+    const { prima } = fakePrima();
+    const first = { ...descriptor, title: 'auth' };
+    const second = { ...descriptor, title: 'smoke', endpoint: '/tmp/pw/smoke.sock' };
+    const disconnected: string[] = [];
+    (prima as any).connectDescriptor = async (candidate: any) => ({ close: async () => disconnected.push(candidate.title) });
+
+    const discovery = await (prima as any).discover([first, second]);
+    expect(discovery.match).toBeUndefined();
+    expect(discovery.candidates.length).toBe(2);
+    expect(disconnected.sort()).toEqual(['auth', 'smoke']);
+  });
+
+  test('the probed connection is reused instead of connecting twice', async () => {
+    const { prima } = fakePrima();
+    let connects = 0;
+    const injected: any[] = [];
+    (prima as any).bot.attachBrowser = (browser: unknown) => injected.push(browser);
+    (prima as any).connectDescriptor = async () => {
+      connects++;
+      return { contexts: () => [] };
+    };
+
+    const discovery = await (prima as any).discover([descriptor]);
+    expect(await (prima as any).attachToEndpoint(discovery.match, discovery.browser)).toBe(true);
+    expect(connects).toBe(1);
+    expect(injected[0]).toBe(discovery.browser);
+  });
+
   test('attached session is injected into the browser and reported in the instance block', async () => {
     const { prima } = fakePrima();
     const injected: any[] = [];

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -1,0 +1,129 @@
+import { existsSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { ConfigParser } from '../../../src/config.ts';
+import { Prima } from '../src/prima.ts';
+
+beforeAll(() => {
+  ConfigParser.resetForTesting();
+  ConfigParser.setupTestConfig();
+});
+
+function fakeState(over: Record<string, unknown> = {}) {
+  return {
+    url: 'https://app.example.com/login',
+    title: 'Login',
+    hash: 'login_h1_login',
+    getStateHash: () => 'login_h1_login',
+    ariaSnapshot: '- textbox "Email"\n- button "Sign in"',
+    combinedHtml: () => '<form></form>',
+    ...over,
+  };
+}
+
+function fakePrima() {
+  const prima = new Prima({ instance: 'default' });
+  const executed: string[] = [];
+  const after = fakeState({
+    url: 'https://app.example.com/dashboard',
+    title: 'Dashboard',
+    hash: 'dashboard_h1_dashboard',
+    getStateHash: () => 'dashboard_h1_dashboard',
+    toToolResult: async () => ({ pageDiff: { urlChanged: true, ariaChanges: 'added:\n  - heading "Dashboard"' } }),
+  });
+  (prima as any).bot = {
+    getExplorer: () => ({
+      action: () => ({
+        execute: async (code: string) => {
+          executed.push(code);
+          return { actionResult: after, lastError: null };
+        },
+      }),
+      capture: async () => after,
+    }),
+    stateManager: () => ({
+      getCurrentState: () => fakeState(),
+      getVisitCount: () => 1,
+    }),
+    requestStore: () => ({ getRequests: () => [] }),
+  };
+  (prima as any).artifactsDir = mkdtempSync(path.join(tmpdir(), 'prima-'));
+  return { prima, executed };
+}
+
+describe('Prima.pw', () => {
+  test('rejects non-function argument as tool error without executing', async () => {
+    const { prima, executed } = fakePrima();
+    const envelope = await prima.pw("page.click('text=Login')");
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain('tool:');
+    expect(envelope.failure?.error).toContain('function');
+    expect(executed.length).toBe(0);
+  });
+
+  test('executes wrapped function and returns success envelope data', async () => {
+    const { prima, executed } = fakePrima();
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(executed[0]).toContain('I.usePlaywrightTo');
+    expect(envelope.ok).toBe(true);
+    expect(envelope.command).toBe("pw ({ page }) => page.click('text=Login')");
+    expect(envelope.used).toEqual(["({ page }) => page.click('text=Login')"]);
+    expect(envelope.page.url).toBe('https://app.example.com/dashboard');
+    expect(envelope.page.previousUrl).toBe('https://app.example.com/login');
+    expect(envelope.page.state).toBe('dashboard_h1_dashboard');
+    expect(envelope.page.visits).toBe(1);
+  });
+
+  test('reports page changes from the action pipeline diff and writes artifacts', async () => {
+    const { prima } = fakePrima();
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(envelope.changes).toContain('heading "Dashboard"');
+    expect(existsSync(envelope.artifacts!.aria)).toBe(true);
+    expect(existsSync(envelope.artifacts!.html)).toBe(true);
+    expect(existsSync(envelope.artifacts!.network)).toBe(true);
+    expect(envelope.instance.name).toBe('default');
+  });
+
+  test('execution error returns failure envelope with captured page', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getExplorer = () => ({
+      action: () => ({
+        execute: async () => {
+          throw new Error("locator 'text=Login' not found");
+        },
+      }),
+      capture: async () => fakeState({ url: 'https://app.example.com/login' }),
+    });
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain("locator 'text=Login' not found");
+    expect(envelope.failure?.attempts).toEqual([]);
+    expect(envelope.page.url).toBe('https://app.example.com/login');
+    expect(envelope.artifacts).toBeTruthy();
+  });
+});
+
+describe('Prima.start', () => {
+  test('never launches a browser and points at session creation when nothing is alive', async () => {
+    const prima = new Prima({ instance: 'default' });
+    let started = false;
+    (prima as any).bot = {
+      start: async () => {
+        started = true;
+      },
+    };
+    await expect(prima.start()).rejects.toThrow(/playwright-cli open/);
+    expect(started).toBe(false);
+  });
+});
+
+describe('Prima.instanceInfo', () => {
+  test('reports instance name, tab count and other instances', async () => {
+    const { prima } = fakePrima();
+    const info = await prima.instanceInfo();
+    expect(info.name).toBe('default');
+    expect(info.tabs).toBe(0);
+    expect(info.others).toEqual([]);
+  });
+});

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -298,13 +298,51 @@ describe('Prima.do', () => {
     expect(envelope.used).toEqual(["I.click('#login-btn')"]);
   });
 
-  test('reports a failure when the model performs no action', async () => {
+  test('reports a failure when the model performs no action and keeps its explanation', async () => {
     const { prima } = fakePrima();
-    (prima as any).bot.getProvider = () => fakeProvider(async () => ({ toolExecutions: [] }));
+    (prima as any).bot.getProvider = () => fakeProvider(async () => ({ toolExecutions: [], response: { text: 'This page has no invoice list to open.' } }));
 
-    const envelope = await prima.do(['click the login link']);
+    const envelope = await prima.do(['open the first invoice']);
     expect(envelope.ok).toBe(false);
-    expect(envelope.failure?.error).toBeTruthy();
+    expect(envelope.failure?.error).toContain('No action was performed');
+    expect(envelope.failure?.error).toContain('This page has no invoice list to open.');
+  });
+
+  test('re-injects fresh page context when the state changed between iterations', async () => {
+    const { prima } = fakePrima();
+    const prompts: string[] = [];
+    const states = [fakeState(), fakeState({ hash: 'dashboard_h1_dashboard', ariaSnapshot: '- heading "Dashboard"\n- link "Invoices"' })];
+    let index = 0;
+    let calls = 0;
+    (prima as any).bot.stateManager = () => ({ getCurrentState: () => states[index], getVisitCount: () => 1 });
+    (prima as any).bot.getProvider = () =>
+      fakeProvider(async () => {
+        calls++;
+        if (calls > 2) return { toolExecutions: [] };
+        index = 1;
+        return { toolExecutions: [toolExecution("I.click('Invoices')")] };
+      }, prompts);
+
+    await prima.do(['open the invoices page', 'read the first invoice']);
+
+    expect(prompts.length).toBe(2);
+    expect(prompts[0]).toContain('button "Sign in"');
+    expect(prompts[1]).toContain('heading "Dashboard"');
+  });
+
+  test('keeps the context when the state did not change between iterations', async () => {
+    const { prima } = fakePrima();
+    const prompts: string[] = [];
+    let calls = 0;
+    (prima as any).bot.getProvider = () =>
+      fakeProvider(async () => {
+        calls++;
+        if (calls > 2) return { toolExecutions: [] };
+        return { toolExecutions: [toolExecution("I.click('Invoices')")] };
+      }, prompts);
+
+    await prima.do(['open the invoices page', 'read the first invoice']);
+    expect(prompts.length).toBe(1);
   });
 
   test('click is a single-instruction alias over do', async () => {

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -1,8 +1,9 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { beforeAll, describe, expect, test } from 'bun:test';
 import { ConfigParser } from '../../../src/config.ts';
+import { ExplorBot } from '../../../src/explorbot.ts';
 import { Prima } from '../src/prima.ts';
 
 beforeAll(() => {
@@ -31,6 +32,17 @@ function failingExplorer() {
       },
     }),
     capture: async () => fakeState(),
+  };
+}
+
+function toolExecution(code: string, success = true, message?: string) {
+  return { toolName: 'click', input: { commands: [code] }, output: { success, code, message }, wasSuccessful: success };
+}
+
+function fakeProvider(invokeConversation: (...args: any[]) => Promise<any>, prompts: string[] = []) {
+  return {
+    startConversation: () => ({ addUserText: (text: string) => prompts.push(text) }),
+    invokeConversation,
   };
 }
 
@@ -211,7 +223,8 @@ describe('Prima heal', () => {
     expect(called).toBe(false);
     expect(envelope.ok).toBe(false);
     expect(envelope.healed).toBe(false);
-    expect(envelope.healNote).toBe('ai unavailable');
+    expect(envelope.healNote).toContain('ai unavailable');
+    expect(envelope.healNote).toContain('AI provider is not configured');
     expect(envelope.failure?.error).toContain("locator 'text=Login' not found");
   });
 });
@@ -227,6 +240,216 @@ describe('Prima.start', () => {
     };
     await expect(prima.start()).rejects.toThrow(/playwright-cli open/);
     expect(started).toBe(false);
+  });
+});
+
+describe('Prima.do', () => {
+  test('runs a bounded AI loop over the instruction set', async () => {
+    const { prima } = fakePrima();
+    const prompts: string[] = [];
+    let calls = 0;
+    (prima as any).bot.getProvider = () =>
+      fakeProvider(async () => {
+        calls++;
+        if (calls > 1) return { toolExecutions: [] };
+        return { toolExecutions: [toolExecution("I.click('Login')")] };
+      }, prompts);
+
+    const envelope = await prima.do(['open the first invoice', 'download its PDF']);
+
+    expect(prompts.join('\n')).toContain('open the first invoice');
+    expect(prompts.join('\n')).toContain('download its PDF');
+    expect(prompts.join('\n')).toContain('button "Sign in"');
+    expect(envelope.used).toEqual(["I.click('Login')"]);
+    expect(envelope.ok).toBe(true);
+    expect(calls).toBe(2);
+  });
+
+  test('caps iterations at the instruction budget', async () => {
+    const { prima } = fakePrima();
+    let calls = 0;
+    (prima as any).bot.getProvider = () =>
+      fakeProvider(async () => {
+        calls++;
+        return { toolExecutions: [toolExecution("I.click('Next')")] };
+      });
+
+    await prima.do(['first step', 'second step']);
+    expect(calls).toBe(4);
+
+    calls = 0;
+    await prima.do(['a', 'b', 'c', 'd', 'e', 'f', 'g']);
+    expect(calls).toBe(6);
+  });
+
+  test('routes a failed tool execution through heal', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getProvider = () => fakeProvider(async () => ({ toolExecutions: [toolExecution("I.click('Login')", false, 'element not found')] }));
+    (prima as any).bot.agentNavigator = () => ({
+      resolveState: async (_msg: string, _result: unknown, opts: any) => {
+        opts?.onAttempt?.({ code: "I.click('#login-btn')" });
+        return true;
+      },
+    });
+
+    const envelope = await prima.do(['click the login link']);
+    expect(envelope.ok).toBe(true);
+    expect(envelope.healed).toBe(true);
+    expect(envelope.used).toEqual(["I.click('#login-btn')"]);
+  });
+
+  test('reports a failure when the model performs no action', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getProvider = () => fakeProvider(async () => ({ toolExecutions: [] }));
+
+    const envelope = await prima.do(['click the login link']);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toBeTruthy();
+  });
+
+  test('click is a single-instruction alias over do', async () => {
+    const { prima } = fakePrima();
+    const received: string[][] = [];
+    (prima as any).do = async (instructions: string[]) => {
+      received.push(instructions);
+      return { ok: true };
+    };
+
+    await prima.click('the login link');
+    expect(received[0].length).toBe(1);
+    expect(received[0][0]).toContain('the login link');
+  });
+
+  test('fill is a single-instruction alias carrying field and value', async () => {
+    const { prima } = fakePrima();
+    const received: string[][] = [];
+    (prima as any).do = async (instructions: string[]) => {
+      received.push(instructions);
+      return { ok: true };
+    };
+
+    await prima.fill('the email field', 'user@example.com');
+    expect(received[0].length).toBe(1);
+    expect(received[0][0]).toContain('the email field');
+    expect(received[0][0]).toContain('user@example.com');
+  });
+});
+
+describe('Prima.ask, verify, research', () => {
+  test('ask defaults to vision via screenshot analysis', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getProvider = () => ({ hasVision: () => true });
+    (prima as any).bot.agentResearcher = () => ({ answerQuestionAboutScreenshot: async () => 'A login page with an email form' });
+
+    const envelope = await prima.ask('what do I see?');
+    expect(envelope.answer).toContain('login');
+    expect(envelope.changes).toBeUndefined();
+    expect(envelope.artifacts).toBeTruthy();
+  });
+
+  test('ask with noVision answers from researcher summary', async () => {
+    const { prima } = fakePrima({ noVision: true });
+    (prima as any).bot.agentResearcher = () => ({ summary: async () => 'Login form with email and password' });
+    const prompts: string[] = [];
+    (prima as any).bot.getProvider = () => ({
+      chat: async (messages: any[]) => {
+        prompts.push(messages[0].content);
+        return { text: 'A login page with an email form' };
+      },
+    });
+
+    const envelope = await prima.ask('what do I see?');
+    expect(envelope.answer).toContain('login');
+    expect(envelope.answer).not.toContain('vision');
+    expect(prompts.join('\n')).toContain('Login form with email and password');
+    expect(prompts.join('\n')).toContain('what do I see?');
+  });
+
+  test('ask notes the degradation when no vision model is configured', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.agentResearcher = () => ({ summary: async () => 'Login form' });
+    (prima as any).bot.getProvider = () => ({
+      hasVision: () => false,
+      chat: async () => ({ text: 'A login page' }),
+    });
+
+    const envelope = await prima.ask('what do I see?');
+    expect(envelope.answer).toContain('A login page');
+    expect(envelope.answer).toContain('vision');
+  });
+
+  test('verify returns verdict with assertion code', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.agentNavigator = () => ({
+      verifyState: async () => ({ verified: true, successfulCodes: ["I.see('Dashboard')"], assertionSteps: [], totalAttempted: 1 }),
+    });
+
+    const envelope = await prima.verify('user sees the dashboard');
+    expect(envelope.verdict?.passed).toBe(true);
+    expect(envelope.verdict?.code).toBe("I.see('Dashboard')");
+    expect(envelope.ok).toBe(true);
+  });
+
+  test('failed verification is reported as a failed verdict', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.agentNavigator = () => ({
+      verifyState: async () => ({ verified: false, successfulCodes: [], assertionSteps: [], totalAttempted: 3 }),
+    });
+
+    const envelope = await prima.verify('user sees the dashboard');
+    expect(envelope.verdict?.passed).toBe(false);
+    expect(envelope.verdict?.evidence).toBeTruthy();
+    expect(envelope.ok).toBe(false);
+  });
+
+  test('research returns UI map in envelope', async () => {
+    const { prima } = fakePrima();
+    const options: any[] = [];
+    (prima as any).bot.agentResearcher = () => ({
+      research: async (_state: unknown, opts: any) => {
+        options.push(opts);
+        return '## Section: Login Form\n| Element | ARIA | CSS |';
+      },
+    });
+
+    const envelope = await prima.research({ data: true });
+    expect(envelope.research).toContain('Login Form');
+    expect(envelope.ok).toBe(true);
+    expect(envelope.changes).toBeUndefined();
+    expect(options[0]).toMatchObject({ screenshot: true, data: true });
+  });
+});
+
+describe('Prima AI availability', () => {
+  test('model commands fail with the playwright-cli fallback when ai is unusable', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getProvider = () => {
+      throw new Error('AI connection failed: no credentials');
+    };
+
+    const envelopes = [await prima.do(['click the login link']), await prima.ask('what do I see?'), await prima.verify('user is logged in'), await prima.research()];
+
+    for (const envelope of envelopes) {
+      expect(envelope.ok).toBe(false);
+      expect(envelope.failure?.error).toContain('playwright-cli');
+      expect(envelope.failure?.error).toContain('AI connection failed: no credentials');
+    }
+  });
+
+  test('start survives a failing ai provider bootstrap and do reports the fallback', async () => {
+    const { prima } = fakePrima();
+    const bot = new ExplorBot({ optionalAi: true });
+    (prima as any).connectOwnInstance = async () => true;
+    (prima as any).bot.start = () => bot.startProviderOnly();
+    (prima as any).bot.getProvider = () => bot.getProvider();
+    (prima as any).bot.aiFailureReason = () => bot.aiFailureReason();
+
+    await prima.start();
+    expect(bot.getProvider()).toBeUndefined();
+
+    const envelope = await prima.do(['click the login link']);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain('playwright-cli');
   });
 });
 

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -75,6 +75,7 @@ function fakePrima(options: Record<string, unknown> = {}) {
       getCurrentState: () => fakeState(),
       getVisitCount: () => 1,
     }),
+    getCurrentState: () => fakeState(),
     requestStore: () => ({ getRequests: () => [] }),
     getProvider: () => ({ chat: async () => '' }),
   };

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -1,7 +1,8 @@
-import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, describe, expect, spyOn, test } from 'bun:test';
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { Navigator } from '../../../src/ai/navigator.ts';
 import { getEndpointFilePath, listInstances } from '../../../src/browser-server.ts';
 import { ConfigParser } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
@@ -775,20 +776,28 @@ describe('Prima.go', () => {
 
   test('failed url navigation without ai degrades to a failure envelope', async () => {
     const { prima } = fakePrima();
+    const navigator = Object.create(Navigator.prototype) as any;
+    navigator.provider = undefined;
+    navigator.config = { playwright: { url: 'https://app.example.com' } };
+    navigator.hooksRunner = { runBeforeHook: async () => {}, runAfterHook: async () => {} };
+    navigator.explorer = {
+      action: () => ({
+        execute: async () => {},
+        lastError: null,
+        actionResult: fakeState(),
+        stateManager: { getCurrentState: () => ({ url: '/login', fullUrl: 'https://app.example.com/login' }) },
+      }),
+    };
     (prima as any).bot.getProvider = () => {
       throw new Error('AI provider is not configured');
     };
-    (prima as any).bot.agentNavigator = () => ({
-      visit: async () => {
-        throw new Error('Navigation to /billing failed: redirected to /login and could not resolve');
-      },
-    });
+    (prima as any).bot.agentNavigator = () => navigator;
 
     const envelope = await prima.go('/billing');
     expect(envelope.ok).toBe(false);
     expect(envelope.healed).toBe(false);
     expect(envelope.healNote).toContain('ai unavailable');
-    expect(envelope.failure?.error).toContain('redirected to /login');
+    expect(envelope.failure?.error).toContain('AI-assisted recovery is unavailable');
   });
 
   test('navigation error is routed through heal', async () => {
@@ -881,5 +890,35 @@ describe('Prima browser instances', () => {
   test('session file is wired into the browser context options', () => {
     const prima = new Prima({ session: 'output/session.json' });
     expect((prima as any).bot.options.session).toBe('output/session.json');
+  });
+});
+
+describe('Prima base url', () => {
+  function recordConfigLoad() {
+    const loadConfig = spyOn(ConfigParser.getInstance(), 'loadConfig').mockImplementation(async () => ({}) as any);
+    loadConfig.mockClear();
+    return loadConfig;
+  }
+
+  test('a url is seeded into every config load, so a config-free run has one', async () => {
+    const prima = new Prima({ url: 'https://app.example.com/login' });
+    const loadConfig = recordConfigLoad();
+
+    await (prima as any).loadConfig();
+
+    expect((prima as any).bot.options.baseUrl).toBe('https://app.example.com/login');
+    expect(loadConfig.mock.calls.at(-1)?.[0].baseUrl).toBe('https://app.example.com/login');
+    loadConfig.mockRestore();
+  });
+
+  test('a path is left out, so the configured base url stays in charge', async () => {
+    const prima = new Prima({ url: '/dashboard' });
+    const loadConfig = recordConfigLoad();
+
+    await (prima as any).loadConfig();
+
+    expect((prima as any).bot.options.baseUrl).toBeUndefined();
+    expect(loadConfig.mock.calls.at(-1)?.[0].baseUrl).toBeUndefined();
+    loadConfig.mockRestore();
   });
 });

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -7,13 +7,17 @@ import { ConfigParser } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
 import { Prima } from '../src/prima.ts';
 
+let artifactsRoot: string;
+
 beforeAll(() => {
   ConfigParser.resetForTesting();
   ConfigParser.setupTestConfig();
+  artifactsRoot = mkdtempSync(path.join(tmpdir(), 'prima-'));
 });
 
 afterAll(() => {
   ConfigParser.cleanupAllTestDirectories();
+  rmSync(artifactsRoot, { recursive: true, force: true });
 });
 
 function fakeState(over: Record<string, unknown> = {}) {
@@ -79,7 +83,7 @@ function fakePrima(options: Record<string, unknown> = {}) {
     requestStore: () => ({ getRequests: () => [] }),
     getProvider: () => ({ chat: async () => '' }),
   };
-  (prima as any).artifactsDir = mkdtempSync(path.join(tmpdir(), 'prima-'));
+  (prima as any).artifactsDir = artifactsRoot;
   return { prima, executed };
 }
 

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -18,12 +18,24 @@ function fakeState(over: Record<string, unknown> = {}) {
     getStateHash: () => 'login_h1_login',
     ariaSnapshot: '- textbox "Email"\n- button "Sign in"',
     combinedHtml: () => '<form></form>',
+    toToolResult: async () => ({ pageDiff: { urlChanged: false, ariaChanges: null } }),
     ...over,
   };
 }
 
-function fakePrima() {
-  const prima = new Prima({ instance: 'default' });
+function failingExplorer() {
+  return {
+    action: () => ({
+      execute: async () => {
+        throw new Error("locator 'text=Login' not found");
+      },
+    }),
+    capture: async () => fakeState(),
+  };
+}
+
+function fakePrima(options: Record<string, unknown> = {}) {
+  const prima = new Prima({ instance: 'default', ...options });
   const executed: string[] = [];
   const after = fakeState({
     url: 'https://app.example.com/dashboard',
@@ -47,6 +59,7 @@ function fakePrima() {
       getVisitCount: () => 1,
     }),
     requestStore: () => ({ getRequests: () => [] }),
+    getProvider: () => ({ chat: async () => '' }),
   };
   (prima as any).artifactsDir = mkdtempSync(path.join(tmpdir(), 'prima-'));
   return { prima, executed };
@@ -129,6 +142,77 @@ describe('Prima.pw', () => {
     expect(envelope.ok).toBe(false);
     expect(envelope.failure?.error).toBeTruthy();
     expect(envelope.page.url).toContain('/login');
+  });
+});
+
+describe('Prima heal', () => {
+  test('failed pw heals via navigator and reports healed envelope', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getExplorer = failingExplorer;
+    (prima as any).bot.agentNavigator = () => ({
+      resolveState: async (_msg: string, _result: unknown, opts: any) => {
+        opts?.onAttempt?.({ code: "I.click('Login')", error: 'not visible' });
+        opts?.onAttempt?.({ code: "I.click('#login-btn')" });
+        return true;
+      },
+    });
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(envelope.ok).toBe(true);
+    expect(envelope.healed).toBe(true);
+    expect(envelope.healNote).toBeTruthy();
+    expect(envelope.used).toEqual(["I.click('#login-btn')"]);
+  });
+
+  test('exhausted heal returns failure envelope with attempts and compact aria', async () => {
+    const { prima } = fakePrima();
+    (prima as any).bot.getExplorer = failingExplorer;
+    (prima as any).bot.agentNavigator = () => ({
+      resolveState: async (_msg: string, _result: unknown, opts: any) => {
+        opts?.onAttempt?.({ code: "I.click('Login')", error: 'not visible' });
+        return false;
+      },
+    });
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain("locator 'text=Login' not found");
+    expect(envelope.failure?.attempts).toEqual([{ code: "I.click('Login')", outcome: 'not visible' }]);
+    expect(envelope.failure?.reasoning).toBe('not visible');
+    expect(envelope.failure?.compactAria).toContain('button');
+    expect(envelope.artifacts).toBeTruthy();
+  });
+
+  test('heal disabled skips navigator entirely', async () => {
+    const { prima } = fakePrima({ heal: false });
+    let called = false;
+    (prima as any).bot.getExplorer = failingExplorer;
+    (prima as any).bot.agentNavigator = () => {
+      called = true;
+      return { resolveState: async () => true };
+    };
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(called).toBe(false);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.healed).toBeUndefined();
+    expect(envelope.failure?.attempts).toEqual([]);
+  });
+
+  test('unusable ai provider skips healing and notes it in the envelope', async () => {
+    const { prima } = fakePrima();
+    let called = false;
+    (prima as any).bot.getExplorer = failingExplorer;
+    (prima as any).bot.getProvider = () => {
+      throw new Error('AI provider is not configured');
+    };
+    (prima as any).bot.agentNavigator = () => {
+      called = true;
+      return { resolveState: async () => true };
+    };
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
+    expect(called).toBe(false);
+    expect(envelope.ok).toBe(false);
+    expect(envelope.healed).toBe(false);
+    expect(envelope.healNote).toBe('ai unavailable');
+    expect(envelope.failure?.error).toContain("locator 'text=Login' not found");
   });
 });
 

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -90,6 +90,7 @@ describe('Prima.pw', () => {
     expect(envelope.ok).toBe(false);
     expect(envelope.failure?.error).toContain('tool:');
     expect(envelope.failure?.error).toContain('function');
+    expect(envelope.failure?.compactAria).toContain('button');
     expect(executed.length).toBe(0);
   });
 
@@ -212,6 +213,7 @@ describe('Prima heal', () => {
     expect(envelope.ok).toBe(false);
     expect(envelope.healed).toBeUndefined();
     expect(envelope.failure?.attempts).toEqual([]);
+    expect(envelope.failure?.compactAria).toContain('button');
   });
 
   test('unusable ai provider skips healing and notes it in the envelope', async () => {
@@ -244,7 +246,7 @@ describe('Prima.start', () => {
         started = true;
       },
     };
-    await expect(prima.start()).rejects.toThrow(/playwright-cli open/);
+    await expect(prima.start()).rejects.toThrow(/not wired yet/);
     expect(started).toBe(false);
   });
 });

--- a/boat/prima/tests/prima.test.ts
+++ b/boat/prima/tests/prima.test.ts
@@ -921,4 +921,39 @@ describe('Prima base url', () => {
     expect(loadConfig.mock.calls.at(-1)?.[0].baseUrl).toBeUndefined();
     loadConfig.mockRestore();
   });
+
+  test('a base url only reaches the configuration, never the browser', async () => {
+    const { prima } = fakePrima({ baseUrl: 'https://app.example.com/billing' });
+    const loadConfig = recordConfigLoad();
+    const visited: string[] = [];
+    (prima as any).bot.start = async () => {};
+    (prima as any).bot.getCurrentState = () => null;
+    (prima as any).bot.visit = async (url: string) => visited.push(`start:${url}`);
+    (prima as any).bot.agentNavigator = () => ({ visit: async (url: string) => visited.push(`go:${url}`) });
+    (prima as any).discover = () => ({ candidates: [] });
+    (prima as any).connectOwnInstance = async () => true;
+
+    await prima.start();
+    await prima.go('https://app.example.com/billing');
+
+    expect(loadConfig.mock.calls.at(-1)?.[0].baseUrl).toBe('https://app.example.com/billing');
+    expect(visited).toEqual(['go:https://app.example.com/billing']);
+    loadConfig.mockRestore();
+  });
+
+  test('an explicit url is still opened when the session has no page', async () => {
+    const { prima } = fakePrima({ url: 'https://app.example.com/billing' });
+    const loadConfig = recordConfigLoad();
+    const visited: string[] = [];
+    (prima as any).bot.start = async () => {};
+    (prima as any).bot.getCurrentState = () => null;
+    (prima as any).bot.visit = async (url: string) => visited.push(`start:${url}`);
+    (prima as any).discover = () => ({ candidates: [] });
+    (prima as any).connectOwnInstance = async () => true;
+
+    await prima.start();
+
+    expect(visited).toEqual(['start:https://app.example.com/billing']);
+    loadConfig.mockRestore();
+  });
 });

--- a/boat/prima/tests/pw-parser.test.ts
+++ b/boat/prima/tests/pw-parser.test.ts
@@ -20,8 +20,14 @@ describe('isFunctionExpression', () => {
 });
 
 describe('toCodeceptWrapper', () => {
-  test('interpolates the function verbatim into usePlaywrightTo', () => {
+  test('calls the function from an async wrapper the native helper API accepts', () => {
     const code = toCodeceptWrapper("({ page }) => page.click('text=Login')");
-    expect(code).toBe("I.usePlaywrightTo('pw', ({ page }) => page.click('text=Login'))");
+    expect(code).toBe("I.usePlaywrightTo('pw', async (playwright) => (({ page }) => page.click('text=Login'))(playwright))");
+  });
+
+  test('keeps an already async function callable', () => {
+    const code = toCodeceptWrapper("async ({ page }) => { await page.click('text=Login') }");
+    expect(code).toContain("async ({ page }) => { await page.click('text=Login') }");
+    expect(code).toStartWith("I.usePlaywrightTo('pw', async (playwright) =>");
   });
 });

--- a/boat/prima/tests/pw-parser.test.ts
+++ b/boat/prima/tests/pw-parser.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test';
+import { isFunctionExpression, toCodeceptWrapper } from '../src/pw-parser.ts';
+
+describe('isFunctionExpression', () => {
+  test.each([
+    "({ page }) => page.click('text=Login')",
+    "async ({ page }) => { await page.fill('#email', 'user@example.com'); await page.keyboard.press('Enter'); }",
+    '({ browserContext }) => browserContext.clearCookies()',
+    '({ page, browser }) => browser.version()',
+    'function ({ page }) { return page.title() }',
+  ])('accepts %s', (expr) => {
+    expect(isFunctionExpression(expr).valid).toBe(true);
+  });
+
+  test.each(["page.click('text=Login')", "({ page }) => page.click('a'", 'just some text', ''])('rejects %s', (expr) => {
+    const result = isFunctionExpression(expr);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe('toCodeceptWrapper', () => {
+  test('interpolates the function verbatim into usePlaywrightTo', () => {
+    const code = toCodeceptWrapper("({ page }) => page.click('text=Login')");
+    expect(code).toBe("I.usePlaywrightTo('pw', ({ page }) => page.click('text=Login'))");
+  });
+});

--- a/boat/prima/tests/pw-registry.test.ts
+++ b/boat/prima/tests/pw-registry.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readDescriptors, registryDir, selectDescriptor } from '../src/pw-registry.ts';
+
+function writeDescriptor(dir: string, name: string, data: Record<string, unknown>) {
+  writeFileSync(path.join(dir, name), JSON.stringify({ playwrightVersion: '1.62.0', playwrightLib: '/lib/pw', endpoint: `/tmp/pw/${name}.sock`, browser: { browserName: 'chromium' }, ...data }));
+}
+
+describe('registryDir', () => {
+  test('points at the ms-playwright browser-server cache', () => {
+    expect(registryDir()).toContain(path.join('ms-playwright', 'b'));
+  });
+});
+
+describe('readDescriptors', () => {
+  test('parses descriptor files and skips malformed ones', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'pwb-'));
+    writeDescriptor(dir, 'a', { title: 'default', workspaceDir: '/work/app' });
+    writeFileSync(path.join(dir, 'broken'), 'not json');
+    const list = readDescriptors(dir);
+    expect(list.length).toBe(1);
+    expect(list[0].title).toBe('default');
+    expect(list[0].browserName).toBe('chromium');
+    expect(list[0].playwrightLib).toBe('/lib/pw');
+  });
+
+  test('skips descriptors without an endpoint, a title or a workspace', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'pwb-'));
+    writeDescriptor(dir, 'a', { title: 'default' });
+    writeDescriptor(dir, 'b', { workspaceDir: '/work/app' });
+    writeDescriptor(dir, 'c', { title: 'default', workspaceDir: '/work/app', endpoint: undefined });
+    expect(readDescriptors(dir)).toEqual([]);
+  });
+
+  test('returns nothing when the registry directory is missing', () => {
+    expect(readDescriptors(path.join(tmpdir(), 'pwb-missing-registry'))).toEqual([]);
+  });
+});
+
+describe('selectDescriptor', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'pwb-'));
+  writeDescriptor(dir, 'a', { title: 'default', workspaceDir: '/work/app' });
+  writeDescriptor(dir, 'b', { title: 'auth', workspaceDir: '/work/app' });
+  writeDescriptor(dir, 'c', { title: 'default', workspaceDir: '/work/other' });
+  const all = readDescriptors(dir);
+
+  test('explicit title wins within workspace', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/app', title: 'auth' });
+    expect(match?.title).toBe('auth');
+  });
+
+  test('default title picked for workspace when present', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/app' });
+    expect(match?.title).toBe('default');
+  });
+
+  test('single survivor for workspace picked without title', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/other' });
+    expect(match?.workspaceDir).toBe('/work/other');
+  });
+
+  test('no workspace match returns candidates empty', () => {
+    const { match, candidates } = selectDescriptor(all, { workspaceDir: '/elsewhere' });
+    expect(match).toBeUndefined();
+    expect(candidates.length).toBe(0);
+  });
+
+  test('ambiguity returns no match with candidates listed', () => {
+    const noDefault = all.filter((d) => d.title !== 'default');
+    const extra = [...noDefault, { ...noDefault[0], title: 'second' }];
+    const { match, candidates } = selectDescriptor(extra, { workspaceDir: '/work/app' });
+    expect(match).toBeUndefined();
+    expect(candidates.length).toBe(2);
+  });
+
+  test('unknown title in a populated workspace returns the workspace candidates', () => {
+    const { match, candidates } = selectDescriptor(all, { workspaceDir: '/work/app', title: 'missing' });
+    expect(match).toBeUndefined();
+    expect(candidates.map((candidate) => candidate.title).sort()).toEqual(['auth', 'default']);
+  });
+
+  test('workspace paths are compared resolved', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/app/../app' });
+    expect(match?.title).toBe('default');
+  });
+});

--- a/docs/contributing/npm-package.md
+++ b/docs/contributing/npm-package.md
@@ -18,7 +18,7 @@ The build runs the TypeScript compiler (`tsc`) with a dedicated `tsconfig.build.
 2. **Import rewriting** - `rewriteRelativeImportExtensions` rewrites `.ts` imports to `.js` in the output (a TypeScript 5.7+ feature).
 3. **Type declarations** - `scripts/build-types.ts` emits `.d.ts` files for the library API (see [Type Declarations](#type-declarations)).
 4. **Asset copying** - Copies `rules/` and `assets/sample-files/` into `dist/` so runtime path resolution works.
-5. **Shebang replacement** - Replaces `#!/usr/bin/env bun` with `#!/usr/bin/env node` in the CLI entry point.
+5. **Shebang replacement** - Replaces `#!/usr/bin/env bun` with `#!/usr/bin/env node` in every CLI entry point declared in `bin`: `dist/bin/explorbot-cli.js` and `dist/boat/prima/bin/prima-cli.js`.
 
 ### Build Configuration
 
@@ -65,7 +65,10 @@ Key `package.json` fields:
 
 ```json
 {
-  "bin": { "explorbot": "./dist/bin/explorbot-cli.js" },
+  "bin": {
+    "explorbot": "./dist/bin/explorbot-cli.js",
+    "prima": "./dist/boat/prima/bin/prima-cli.js"
+  },
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",
   "exports": {
@@ -84,12 +87,17 @@ Key `package.json` fields:
     "boat/doc-collector/src/**/*.ts",
     "boat/doc-collector/bin/**/*.ts",
     "boat/doc-collector/package.json",
+    "boat/prima/src/**/*.ts",
+    "boat/prima/bin/**/*.ts",
+    "boat/prima/package.json",
     "rules/",
     "assets/sample-files/"
   ],
   "engines": { "node": ">=24.0.0" }
 }
 ```
+
+The package ships two commands: `explorbot`, and `prima` for the [prima boat](../reference/commands.md#prima-boat), so `npx -p explorbot prima <command>` works without a separate install.
 
 Explorbot is both a CLI (`bin`) and a library (`exports`). The `.` entry point is `src/index.ts`, a side-effect-free barrel that re-exports the public API (`ExplorBot`, `Plan`, `Test`, and their types). The `exports` conditions are ordered so each consumer gets the right entry: `types` (the emitted `.d.ts`) for type-checking, `bun` (the TypeScript source) under Bun, and `import` (the compiled JS) under Node.js. This is why the source `src/**` files ship alongside `dist/`.
 
@@ -99,8 +107,9 @@ Explorbot is both a CLI (`bin`) and a library (`exports`). The `.` entry point i
 # Build the npm package
 bun run build:npm
 
-# Verify the CLI works on Node.js
+# Verify the CLIs work on Node.js
 node dist/bin/explorbot-cli.js --help
+node dist/boat/prima/bin/prima-cli.js --help
 
 # Check what would be published
 npm pack --dry-run

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -45,6 +45,7 @@ Inside the TUI, use the matching slash command: `/explore`, `/research`, `/plan`
 | Execute CodeceptJS command | `npx explorbot shell <url> <command>` | `I.click(...)` etc. inline | One-shot vs interactive |
 | Load saved plan | `npx explorbot plan:load <file> [index]` | `/plan:load <file>` | Preview a plan |
 | Collect documentation | `npx explorbot docs collect <path-or-url>` | — | See [doc-collector](../doc-collection/basics.md) |
+| Drive an already-open browser | `npx explorbot prima <command>` | — | One command per process, see [Prima boat](#prima-boat) |
 | Extract built-in rules | `npx explorbot extract-rules <agent>` | — | Customizable rules to `rules/` |
 | Create a rule file | `npx explorbot add-rule [agent] [name]` | `/add-rule [agent] [name]` | Writes `rules/<agent>/<name>.md` |
 | Manage persistent browser | `npx explorbot browser {start\|stop\|status}` | — | Share browser across runs |
@@ -77,7 +78,7 @@ npx explorbot navigate /login --session             # probe + capture auth in on
 npx explorbot research /dashboard --session auth.json   # reuse captured auth
 ```
 
-Without a file path, the flag defaults to `session.json` inside the resolved configuration's output directory. In config-free mode that is the temporary or explicitly configured `EXPLORBOT_OUTPUT` directory.
+Without a file path, the flag defaults to `session.json` inside the resolved configuration's output directory. In config-free mode that is the per-host state directory `~/.explorbot/state/<host>/`, or whatever `EXPLORBOT_OUTPUT` points at.
 
 ## Environment Variables
 
@@ -97,16 +98,17 @@ EXPLORBOT_AI_PROVIDER=openrouter \
 | `EXPLORBOT_URL` | Base URL to test; the API boat reads it as the base endpoint |
 | `EXPLORBOT_VISION_MODEL` | Screenshot analysis; overrides the provider recommendation |
 | `EXPLORBOT_AGENTIC_MODEL` | Captain and Pilot decisions; overrides the provider recommendation |
-| `EXPLORBOT_OUTPUT` | Output root for states, plans, research, and reports. Defaults to a fresh temp directory |
+| `EXPLORBOT_OUTPUT` | Output root for states, plans, research, and reports. Defaults to the per-host state dir under ~/.explorbot/state |
+| `EXPLORBOT_EPHEMERAL` | Keep no state between runs — output goes to a fresh temp directory instead of the per-host state dir |
 | `EXPLORBOT_KNOWLEDGE` | Inline knowledge text, applied to every page |
 | `EXPLORBOT_KNOWLEDGE_FILE` | Path to a knowledge markdown file |
 | `EXPLORBOT_API_SPEC` | OpenAPI spec path for the API boat |
 | `EXPLORBOT_NO_BANNER` | Suppress the startup banner, for machine-readable output |
 <!-- END env -->
 
-A config file always wins when present. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `openrouter`, `sambanova`.
+A config file always wins when present. Explorbot looks for one in this order: the path given to `--config`, then `explorbot.config.*` in the working directory, then `~/.explorbot/config.*`, and only then builds a configuration from the environment. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `openrouter`, `sambanova`.
 
-In this mode experience is not written and the Historian is off, so no generated test files appear. See [Agentic Usage](../workflow/agentic-usage.md) for the full picture.
+In this mode output goes to `~/.explorbot/state/<host>/` (or `EXPLORBOT_OUTPUT`, or a temp directory with `EXPLORBOT_EPHEMERAL=1`), experience is not written, and the Historian is off, so no generated test files appear. See [Agentic Usage](../workflow/agentic-usage.md) for the full picture.
 
 ## Persistent Browser
 
@@ -602,6 +604,104 @@ Create a starter `docbot.config.ts` file.
 npx explorbot docs init
 npx explorbot docs init --path explorbot-testing
 ```
+
+## Prima boat
+
+Prima drives a browser that is already open, one command per process. Every page command prints a plain-text envelope on stdout and exits `0` when the envelope says `ok: true`, `1` when it does not — so a coding agent can act on the result without parsing JSON. The `browser` commands print a status line instead.
+
+Run it as `npx explorbot prima <command>` or through the standalone `prima` bin.
+
+| Command | Purpose |
+|---|---|
+| `prima pw <fn>` | Run a Playwright function expression against the open page |
+| `prima do <steps...>` | Run several described steps tester-style, one argument per step |
+| `prima click <target>` | Click an element described in plain words |
+| `prima fill <field> <value>` | Fill a field described in plain words |
+| `prima ask <question>` | Answer a question about the current page |
+| `prima verify <assertion>` | Assert a statement about the current page (alias: `assert`) |
+| `prima research` | Map the current page and return verified locators |
+| `prima go <target>` | Navigate to a url, a path, or a page described in plain words |
+| `prima browser {start\|stop\|status\|list}` | Manage the browsers prima drives |
+
+### Choosing a command
+
+Pick by what you hold, not by how hard the step looks.
+
+- **`pw`** is precise: a function expression built from a locator you already verified. No AI on the happy path, so it also works when no model is configured.
+- **`click` and `fill`** take one action described in words and let AI resolve it against the current page.
+- **`do`** takes several described steps and runs them tester-style in one process.
+
+Never pass a locator or a function expression to `click`, `fill`, or `do` — describe the target. Never pass a description to `pw` — it takes executable code only.
+
+The loop that works: `go` to the page, `research` it once for verified locators, drive it with `pw`, then `verify` the outcome. Fall back to `click`, `fill`, or `do` whenever research left you no locator to hold.
+
+### The envelope
+
+```
+### Result
+ok: true
+command: pw ({ page }) => page.click('[data-test=submit]')
+used: ({ page }) => page.click('[data-test=submit]')
+
+### Page
+url: /orders/4821                     (changed: /orders/new → /orders/4821)
+title: Order 4821 - Widget Depot
+state: orders_4821_h1_order_placed    (visit #1)
+
+### Changes
+ariaDiff:
+  added:
+    - heading "Order placed" [level=1]
+  removed:
+    - button "Submit"
+
+### Instance
+instance: default (1 tab) | other instances: none
+browser: attached (playwright-cli session "default", workspace /home/you/projects/shop)
+
+### Artifacts
+aria: /home/you/.explorbot/state/app.example.com/prima/2026-08-04T10-04-22-285Z/aria.yml
+html: /home/you/.explorbot/state/app.example.com/prima/2026-08-04T10-04-22-285Z/page.html
+network: /home/you/.explorbot/state/app.example.com/prima/2026-08-04T10-04-22-285Z/network.jsonl
+```
+
+`used:` is code that already executed — copy it into a test as is. Log lines can precede the envelope, so start parsing at the first `###` line.
+
+`ask`, `research`, and `verify` replace the `### Changes` block with `### Answer`, `### Research`, or `### Verdict`. A failure adds `### Failure` with the error and the compact ARIA of the page, so you can retarget from the envelope itself instead of opening the artifact files.
+
+When an action fails, AI retries it along a different route; `healed: true` means the outcome was reached another way and `used:` holds the code that worked. `--no-heal` skips that and fails fast.
+
+### Browsers and sessions
+
+Prima never launches a browser implicitly. Open one first:
+
+```bash
+playwright-cli open https://app.example.com   # the session prima attaches to by default
+npx explorbot prima browser start             # a prima-owned browser instead
+```
+
+By default prima attaches to the playwright-cli browser of the current workspace and works on the tabs it already has open — driving the same session from both tools is the intended usage. Stopping prima disconnects from an attached browser; it never closes it. `prima browser list` shows both kinds of browser, and the `### Instance` block names the one you are on.
+
+| Option | Description |
+|---|---|
+| `--pw-session <title>` | Which playwright-cli session, when several are open for the workspace |
+| `--endpoint <ep>` | Attach to a browser server endpoint directly, skipping discovery |
+| `--instance <name>` | Which prima-owned browser to talk to; parallel work needs one each |
+| `--session [file]` | Cookies and storage persisted across processes; ignored while attached, since the attached session keeps its own |
+| `--no-heal` | Fail immediately instead of letting AI retry a failed action |
+| `--ephemeral` | Keep no state between runs; output goes to a temp directory |
+
+`--instance` and `--session` answer different questions: `--instance` picks *which browser process* prima drives, `--session` decides *whose cookies* it starts from.
+
+### Without a config file
+
+Prima follows the same [configuration ladder](#environment-variables) as every other command, so a provider name in the environment is enough:
+
+```bash
+EXPLORBOT_AI_PROVIDER=groq npx explorbot prima go https://app.example.com
+```
+
+`pw` still works when no model is usable at all; commands that need one say so and point at the fallback.
 
 ## Plan Management
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -108,7 +108,7 @@ EXPLORBOT_AI_PROVIDER=openrouter \
 
 A config file always wins when present. Explorbot looks for one in this order: the path given to `--config`, then `explorbot.config.*` in the working directory, then `~/.explorbot/config.*`, and only then builds a configuration from the environment. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `openrouter`, `sambanova`.
 
-In this mode output goes to `~/.explorbot/state/<host>/` (or `EXPLORBOT_OUTPUT`, or a temp directory with `EXPLORBOT_EPHEMERAL=1`), experience is not written, and the Historian is off, so no generated test files appear. See [Agentic Usage](../workflow/agentic-usage.md) for the full picture.
+In this mode output goes to `~/.explorbot/state/<host>/` (or `EXPLORBOT_OUTPUT`, or a temp directory with `EXPLORBOT_EPHEMERAL=1`), experience is kept beside it unless the run is ephemeral, and the Historian is off, so no generated test files appear. See [Agentic Usage](../workflow/agentic-usage.md) for the full picture.
 
 ## Persistent Browser
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -665,7 +665,7 @@ html: /home/you/.explorbot/state/app.example.com/prima/2026-08-04T10-04-22-285Z/
 network: /home/you/.explorbot/state/app.example.com/prima/2026-08-04T10-04-22-285Z/network.jsonl
 ```
 
-`used:` is code that already executed — copy it into a test as is. Log lines can precede the envelope, so start parsing at the first `###` line.
+`used:` is code that already executed. For `click`, `fill`, `do`, and `go` those are CodeceptJS steps you can copy into a test as they are; for `pw` it is the Playwright expression you passed, which a CodeceptJS test needs wrapped in `I.usePlaywrightTo(...)`. Log lines can precede the envelope, so start parsing at the first `###` line.
 
 `ask`, `research`, and `verify` replace the `### Changes` block with `### Answer`, `### Research`, or `### Verdict`. A failure adds `### Failure` with the error and the compact ARIA of the page, so you can retarget from the envelope itself instead of opening the artifact files.
 
@@ -682,16 +682,34 @@ npx explorbot prima browser start             # a prima-owned browser instead
 
 By default prima attaches to the playwright-cli browser of the current workspace and works on the tabs it already has open — driving the same session from both tools is the intended usage. Stopping prima disconnects from an attached browser; it never closes it. `prima browser list` shows both kinds of browser, and the `### Instance` block names the one you are on.
 
+Prima reaches every browser over a Playwright browser-server endpoint — a playwright-cli session, an `--endpoint`, or a `prima browser start` instance — and that client needs the Node build, which is what `npx explorbot prima` and the published `prima` bin run on. Driving a browser by running the CLI from source under Bun does not connect.
+
+Every command takes these:
+
 | Option | Description |
 |---|---|
 | `--pw-session <title>` | Which playwright-cli session, when several are open for the workspace |
 | `--endpoint <ep>` | Attach to a browser server endpoint directly, skipping discovery |
-| `--instance <name>` | Which prima-owned browser to talk to; parallel work needs one each |
+| `-i, --instance <name>` | Which prima-owned browser to talk to; parallel work needs one each |
 | `--session [file]` | Cookies and storage persisted across processes; ignored while attached, since the attached session keeps its own |
+| `--url <url>` | Page to open when the session has no page yet |
 | `--no-heal` | Fail immediately instead of letting AI retry a failed action |
-| `--ephemeral` | Keep no state between runs; output goes to a temp directory |
+| `--ephemeral` | Keep no state between runs. Applies to config-free runs only — with a config file the output directory comes from the config |
+| `--framework <name>` | Parsed but not active yet; reported code is CodeceptJS whatever you pass |
+| `-v, --verbose`, `--debug`, `-c, --config <path>`, `-p, --path <path>` | As on every other Explorbot command |
 
 `--instance` and `--session` answer different questions: `--instance` picks *which browser process* prima drives, `--session` decides *whose cookies* it starts from.
+
+A few commands add their own:
+
+| Command | Option | Description |
+|---|---|---|
+| `ask` | `--no-vision` | Answer from page structure only, without a screenshot |
+| `research` | `--data` | Include data extraction in the map |
+| `research` | `--deep` | Expand hidden elements for a deeper map |
+| `research` | `--fresh` | Ignore the cached map and research the page again |
+| `browser start` | `-s, --show` / `--headless` | Launch the browser with or without a window |
+| `browser stop` | `--all` | Stop every running instance |
 
 ### Without a config file
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -391,7 +391,7 @@ npx explorbot explore /dashboard --config ./custom/path/config.js
 
 ### Running without a config file
 
-When no config file is found — neither in the working directory nor at `~/.explorbot/config.*` — and `EXPLORBOT_AI_PROVIDER` is set, Explorbot synthesizes a configuration from `EXPLORBOT_*` environment variables. Output goes to the per-host state directory `~/.explorbot/state/<host>/` (`EXPLORBOT_OUTPUT` overrides it, `EXPLORBOT_EPHEMERAL=1` sends it to a temp directory instead), experience is not written, and the Historian is off. This is meant for one-liner CI jobs, demos, and coding agents — see [Agentic Usage](../workflow/agentic-usage.md) for the variable list and the trade-offs.
+When no config file is found — neither in the working directory nor at `~/.explorbot/config.*` — and `EXPLORBOT_AI_PROVIDER` is set, Explorbot synthesizes a configuration from `EXPLORBOT_*` environment variables. Output goes to the per-host state directory `~/.explorbot/state/<host>/` (`EXPLORBOT_OUTPUT` overrides it, `EXPLORBOT_EPHEMERAL=1` sends it to a temp directory instead), experience is written there and reused by later runs against the same host unless the run is ephemeral, and the Historian is off. This is meant for one-liner CI jobs, demos, and coding agents — see [Agentic Usage](../workflow/agentic-usage.md) for the variable list and the trade-offs.
 
 ## Full configuration reference
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -391,7 +391,7 @@ npx explorbot explore /dashboard --config ./custom/path/config.js
 
 ### Running without a config file
 
-When no config file is found and `EXPLORBOT_AI_PROVIDER` is set, Explorbot synthesizes a configuration from `EXPLORBOT_*` environment variables. Output goes to a temp directory, experience is not written, and the Historian is off. This is meant for one-liner CI jobs, demos, and coding agents — see [Agentic Usage](../workflow/agentic-usage.md) for the variable list and the trade-offs.
+When no config file is found — neither in the working directory nor at `~/.explorbot/config.*` — and `EXPLORBOT_AI_PROVIDER` is set, Explorbot synthesizes a configuration from `EXPLORBOT_*` environment variables. Output goes to the per-host state directory `~/.explorbot/state/<host>/` (`EXPLORBOT_OUTPUT` overrides it, `EXPLORBOT_EPHEMERAL=1` sends it to a temp directory instead), experience is not written, and the Historian is off. This is meant for one-liner CI jobs, demos, and coding agents — see [Agentic Usage](../workflow/agentic-usage.md) for the variable list and the trade-offs.
 
 ## Full configuration reference
 

--- a/docs/superpowers/plans/2026-08-01-actor-boat.md
+++ b/docs/superpowers/plans/2026-08-01-actor-boat.md
@@ -1,0 +1,904 @@
+# Actor Boat Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `boat/actor` — an intent-level browser driver CLI (`explorbot act ...`) that lets an orchestrating agent act on pages via Playwright calls or natural language while explorbot's cheap models handle perception, healing, and evidence.
+
+**Architecture:** A boat following the `boat/doc-collector` pattern: `Actor` class wraps `ExplorBot`, reuses Navigator/Researcher/Explorer/StateManager, adds a pure envelope renderer and a pw-expression validator. Core changes are minimal: named browser-server instances, a Navigator heal-attempt hook, and a global-config/per-host-state ladder in config loading.
+
+**Tech Stack:** Bun (never Node), TypeScript, commander, CodeceptJS/Playwright via Explorer, `bun:test`, Biome.
+
+**Spec:** `docs/superpowers/specs/2026-08-01-actor-boat-design.md` — read it first.
+
+**Execution model:** Run implementation subagents on Opus (user directive).
+
+## Global Constraints
+
+- Bun only; never Node.js APIs where Bun equivalents exist; tests via `bun:test`.
+- No code comments unless explicitly specified; premature exit over if/else; no ternary operators; no `...(cond ? {} : {})` spreads; `?.` over `&&` chains; private methods after public; types at end of file; `dedent` for prompts.
+- Prompts and tool descriptions must be GENERAL — never encode a specific failing example.
+- Business logic lives in the `Actor` class / agents; CLI handlers only parse options and delegate (repo rule).
+- Run `bun run format` after each code change; `bun run lint:fix` after big ones.
+- Clean stdout: respect `EXPLORBOT_NO_BANNER`; envelope output goes to `console.log`, logs go through `tag()` logger.
+- DO NOT duplicate existing code — reuse `src/utils/aria.ts`, `src/action-result.ts`, `src/browser-server.ts`, Historian converters.
+
+## File Structure
+
+```
+boat/actor/
+├── package.json               # name "actbot", bin actbot
+├── bin/actbot-cli.ts          # standalone CLI entry
+├── src/
+│   ├── cli.ts                 # createActCommands(name = 'act')
+│   ├── actor.ts               # Actor class (all business logic)
+│   ├── envelope.ts            # EnvelopeData type, renderEnvelope(), writeArtifacts()
+│   └── pw-parser.ts           # validatePwExpression(), toCodeceptWrapper()
+└── tests/
+    ├── envelope.test.ts
+    ├── pw-parser.test.ts
+    └── actor.test.ts          # duck-typed ExplorBot mocks
+Core modifications:
+├── src/browser-server.ts      # named instances (endpoint file per instance)
+├── src/ai/navigator.ts        # resolveState onAttempt hook (small)
+├── src/config.ts              # global config + global .env + per-host state dir
+└── bin/explorbot-cli.ts       # program.addCommand(createActCommands('act'))
+```
+
+---
+
+### Task 1: Envelope module
+
+**Files:**
+- Create: `boat/actor/package.json`, `boat/actor/src/envelope.ts`
+- Test: `boat/actor/tests/envelope.test.ts`
+
+**Interfaces:**
+- Produces (used by Tasks 3–7 and 9):
+
+```typescript
+export interface InstanceInfo {
+  name: string;
+  tabs: number;
+  startedAgo?: string;
+  others: Array<{ name: string; tabs: number }>;
+}
+export interface HealAttempt {
+  code: string;
+  outcome: string;
+}
+export interface EnvelopeData {
+  ok: boolean;
+  command: string;
+  healed?: boolean;
+  healNote?: string;
+  used?: string[];
+  page: { url: string; previousUrl?: string; title: string; state: string; visits: number };
+  changes?: string | null;
+  answer?: string;
+  verdict?: { passed: boolean; evidence: string; code: string };
+  failure?: { error: string; attempts: HealAttempt[]; reasoning?: string; compactAria?: string };
+  instance: InstanceInfo;
+  artifacts?: { aria: string; html: string; network: string };
+}
+export function renderEnvelope(data: EnvelopeData): string;
+export function writeArtifacts(dir: string, snapshot: { aria: string | null; html: string | null; requests: unknown[] }): { aria: string; html: string; network: string };
+```
+
+- [ ] **Step 1: Scaffold the boat package**
+
+`boat/actor/package.json` (mirror `boat/api-tester/package.json` shape):
+
+```json
+{
+  "name": "actbot",
+  "version": "1.0.0",
+  "description": "High-level browser driver CLI for orchestrating agents",
+  "type": "module",
+  "bin": { "actbot": "./bin/actbot-cli.ts" },
+  "scripts": {
+    "format": "biome format --write .",
+    "lint:fix": "biome lint --write .",
+    "check:fix": "biome check --write ."
+  },
+  "dependencies": {
+    "commander": "^14.0.1",
+    "dedent": "^1.6.0"
+  }
+}
+```
+
+- [ ] **Step 2: Write failing envelope tests**
+
+`boat/actor/tests/envelope.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readFileSync } from 'node:fs';
+import { type EnvelopeData, renderEnvelope, writeArtifacts } from '../src/envelope.ts';
+
+const base: EnvelopeData = {
+  ok: true,
+  command: "pw page.click('text=Login')",
+  used: ["I.click('Login')"],
+  page: { url: 'https://app.example.com/dashboard', previousUrl: 'https://app.example.com/login', title: 'Dashboard', state: 'dashboard_h1_dashboard', visits: 1 },
+  changes: 'ariaDiff:\n  added:\n    - heading "Dashboard"',
+  instance: { name: 'default', tabs: 3, startedAgo: '12m', others: [{ name: 'auth-test', tabs: 1 }] },
+  artifacts: { aria: '/tmp/x/aria.yml', html: '/tmp/x/page.html', network: '/tmp/x/network.jsonl' },
+};
+
+describe('renderEnvelope', () => {
+  test('success envelope contains all sections in order', () => {
+    const out = renderEnvelope(base);
+    const sections = ['### Result', '### Page', '### Changes', '### Instance', '### Artifacts'];
+    const positions = sections.map((s) => out.indexOf(s));
+    expect(positions.every((p) => p >= 0)).toBe(true);
+    expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+    expect(out).toContain('ok: true');
+    expect(out).toContain("used: I.click('Login')");
+    expect(out).toContain('(changed: https://app.example.com/login → https://app.example.com/dashboard)');
+    expect(out).toContain('instance: default (3 tabs) | other instances: auth-test (1 tab)');
+  });
+
+  test('unchanged url renders without changed marker', () => {
+    const out = renderEnvelope({ ...base, page: { ...base.page, previousUrl: base.page.url } });
+    expect(out).not.toContain('(changed:');
+  });
+
+  test('failure envelope renders attempts, reasoning and compact aria', () => {
+    const out = renderEnvelope({
+      ...base,
+      ok: false,
+      failure: {
+        error: "locator 'text=Login' not found",
+        attempts: [{ code: "I.click('Login')", outcome: 'not visible' }, { code: 'scroll + retry', outcome: 'covered by cookie banner' }],
+        reasoning: 'element hidden behind consent overlay',
+        compactAria: '- button "Accept all"',
+      },
+    });
+    expect(out).toContain('### Failure');
+    expect(out).toContain('### Healing attempts (2)');
+    expect(out).toContain("1. I.click('Login')");
+    expect(out).toContain('→ not visible');
+    expect(out).toContain('### Current page (compact ARIA)');
+    expect(out).toContain('- button "Accept all"');
+  });
+
+  test('answer replaces changes for ask', () => {
+    const out = renderEnvelope({ ...base, changes: undefined, answer: 'A login form with email and password fields' });
+    expect(out).toContain('### Answer');
+    expect(out).not.toContain('### Changes');
+  });
+
+  test('verdict replaces changes for verify', () => {
+    const out = renderEnvelope({ ...base, changes: undefined, verdict: { passed: true, evidence: 'heading "Dashboard" present', code: "I.see('Dashboard')" } });
+    expect(out).toContain('### Verdict');
+    expect(out).toContain('passed: true');
+    expect(out).toContain("I.see('Dashboard')");
+  });
+
+  test('healed success carries note', () => {
+    const out = renderEnvelope({ ...base, healed: true, healNote: 'dismissed overlay first' });
+    expect(out).toContain('healed: true (dismissed overlay first)');
+  });
+});
+
+describe('writeArtifacts', () => {
+  test('writes aria, html and network files and returns absolute paths', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'act-'));
+    const result = writeArtifacts(dir, { aria: '- button "Login"', html: '<html></html>', requests: [{ url: '/api/user', status: 200 }] });
+    expect(readFileSync(result.aria, 'utf-8')).toContain('button "Login"');
+    expect(readFileSync(result.html, 'utf-8')).toContain('<html>');
+    expect(readFileSync(result.network, 'utf-8')).toContain('/api/user');
+    expect(path.isAbsolute(result.aria)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests, verify they fail**
+
+Run: `bun test boat/actor/tests/envelope.test.ts`
+Expected: FAIL — cannot resolve `../src/envelope.ts`.
+
+- [ ] **Step 4: Implement `boat/actor/src/envelope.ts`**
+
+Pure string building. Rules:
+- Sections always in order: Result, Page, then exactly one of Changes/Answer/Verdict (Changes only when `changes` is a non-empty string), Failure + Healing attempts + Current page (only when `failure` set), Instance, Artifacts (only when set).
+- `healed: true (note)` on one line when healNote present, plain `healed: false` otherwise; omit line when `healed` is undefined.
+- `used:` joins multiple codes with `; `.
+- Page line: `url: <url>   (changed: <prev> → <url>)` only when previousUrl differs.
+- State line: `state: <state>            (visit #<visits>)`.
+- Instance line exactly as tested; `others` empty → `| other instances: none`.
+- Network artifact written as JSONL (one `JSON.stringify` per request).
+- Every attempt line: `<n>. <code>` padded, then `→ <outcome>`.
+
+Keep it one exported function plus small private helpers below it; no classes.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `bun test boat/actor/tests/envelope.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+bun run format
+git add boat/actor
+git commit -m "feat(actor): boat scaffold and result envelope"
+```
+
+---
+
+### Task 2: pw expression validator
+
+**Files:**
+- Create: `boat/actor/src/pw-parser.ts`
+- Test: `boat/actor/tests/pw-parser.test.ts`
+
+**Interfaces:**
+- Produces (used by Task 3):
+
+```typescript
+export function validatePwExpression(expr: string): { valid: boolean; error?: string };
+export function toCodeceptWrapper(expr: string): string;
+```
+
+- [ ] **Step 1: Write failing tests**
+
+`boat/actor/tests/pw-parser.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test';
+import { toCodeceptWrapper, validatePwExpression } from '../src/pw-parser.ts';
+
+describe('validatePwExpression', () => {
+  test.each([
+    "page.click('text=Login')",
+    "page.getByRole('button', { name: 'Submit' }).click()",
+    "page.fill('#email', 'user@example.com')",
+    "page.keyboard.press('Enter')",
+    "page.selectOption('select#tier', 'pro')",
+    "page.getByText('3 items').isVisible()",
+  ])('accepts %s', (expr) => {
+    expect(validatePwExpression(expr).valid).toBe(true);
+  });
+
+  test.each([
+    ["fetch('https://evil.example')", 'must start with page.'],
+    ["process.exit(1)", 'must start with page.'],
+    ["page.click('a'); process.exit(1)", 'single expression'],
+    ["page.evaluate(() => require('fs'))", 'forbidden token'],
+    ["page.click('a'", 'unbalanced'],
+  ])('rejects %s', (expr) => {
+    const result = validatePwExpression(expr);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+});
+
+describe('toCodeceptWrapper', () => {
+  test('wraps expression in usePlaywrightTo', () => {
+    const code = toCodeceptWrapper("page.click('text=Login')");
+    expect(code).toContain("I.usePlaywrightTo");
+    expect(code).toContain("await page.click('text=Login')");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, verify fail**
+
+Run: `bun test boat/actor/tests/pw-parser.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `boat/actor/src/pw-parser.ts`**
+
+Validation rules (general, not example-driven):
+- Trimmed expression must start with `page.`.
+- Balanced `()`, `[]`, `{}` and closed string literals (single scan with a quote/bracket stack).
+- No statement separators outside strings: `;` splitting into a second non-empty statement fails with 'single expression only'.
+- Forbidden identifiers outside strings: `require`, `import`, `process`, `child_process`, `Bun`, `globalThis`, `eval`.
+- Return `{ valid: true }` or `{ valid: false, error: <specific reason> }`.
+
+```typescript
+export function toCodeceptWrapper(expr: string): string {
+  return `I.usePlaywrightTo('pw', async ({ page }) => { await ${expr} })`;
+}
+```
+
+- [ ] **Step 4: Run tests, verify pass**
+
+Run: `bun test boat/actor/tests/pw-parser.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run format
+git add boat/actor/src/pw-parser.ts boat/actor/tests/pw-parser.test.ts
+git commit -m "feat(actor): pw expression validator and codecept wrapper"
+```
+
+---
+
+### Task 3: Named browser instances in browser-server
+
+**Files:**
+- Modify: `src/browser-server.ts` (exports at line 88: `readEndpoint, removeEndpointFile, isServerRunning, launchServer, getEndpointFilePath, getAliveEndpoint`)
+- Modify: `bin/explorbot-cli.ts` browser start/stop/status handlers (lines ~736-821) to pass instance through
+- Test: `tests/unit/browser-server-instances.test.ts`
+
+**Interfaces:**
+- Produces (used by Tasks 4 and 7): every exported function gains an optional trailing `instance = 'default'` parameter; endpoint file becomes `.browser-endpoint` for `default` and `.browser-endpoint-<name>` otherwise. New export:
+
+```typescript
+export function listInstances(): Array<{ name: string; endpoint: string }>;
+```
+
+- [ ] **Step 1: Read `src/browser-server.ts` fully** — understand `getEndpointFilePath`, `writeEndpoint`, `getAliveEndpoint` before touching anything.
+
+- [ ] **Step 2: Write failing test**
+
+`tests/unit/browser-server-instances.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+import { getEndpointFilePath } from '../../src/browser-server.ts';
+
+describe('named instances', () => {
+  test('default instance keeps legacy filename', () => {
+    expect(path.basename(getEndpointFilePath())).toBe('.browser-endpoint');
+    expect(path.basename(getEndpointFilePath('default'))).toBe('.browser-endpoint');
+  });
+
+  test('named instance gets suffixed filename', () => {
+    expect(path.basename(getEndpointFilePath('staging'))).toBe('.browser-endpoint-staging');
+  });
+});
+```
+
+Add a test for `listInstances()` writing two endpoint files into a temp output dir if `getEndpointFilePath` resolves from a configurable root; if the output root comes from config at import time, keep `listInstances` scanning `path.dirname(getEndpointFilePath())` for files matching `.browser-endpoint*` and test via that dir.
+
+- [ ] **Step 3: Run test, verify fail**
+
+Run: `bun test tests/unit/browser-server-instances.test.ts`
+Expected: FAIL — `getEndpointFilePath` does not accept an argument (or wrong filename).
+
+- [ ] **Step 4: Implement**
+
+Thread `instance = 'default'` through `getEndpointFilePath`, `readEndpoint`, `writeEndpoint`, `removeEndpointFile`, `isServerRunning`, `getAliveEndpoint`, `launchServer`. Filename: `default` → `.browser-endpoint` (backward compatible), else `.browser-endpoint-${instance}`. Sanitize instance to `[a-z0-9-]` and reject others with a thrown Error. `listInstances()` scans the endpoint dir with `readdirSync`, maps filenames back to names.
+
+- [ ] **Step 5: Run full unit suite**
+
+Run: `bun test tests/unit/`
+Expected: PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run format
+git add src/browser-server.ts tests/unit/browser-server-instances.test.ts bin/explorbot-cli.ts
+git commit -m "feat: named browser server instances"
+```
+
+---
+
+### Task 4: Actor class core — lifecycle and pw command
+
+**Files:**
+- Create: `boat/actor/src/actor.ts`
+- Test: `boat/actor/tests/actor.test.ts`
+
+**Interfaces:**
+- Consumes: `renderEnvelope`/`writeArtifacts`/`EnvelopeData`/`InstanceInfo` (Task 1), `validatePwExpression`/`toCodeceptWrapper` (Task 2), `getAliveEndpoint(instance)`/`launchServer` (Task 3), `ExplorBot` API (`src/explorbot.ts`: `start()`, `stop()`, `visit(url)`, `getExplorer()`, `stateManager()`, `getCurrentState()`, `agentNavigator()`, `agentResearcher()`, `agentHistorian()`, `requestStore()`), `Explorer.action(): Action` (`src/explorer.ts:151`), `Action.execute(code)` / `Action.capturePageState()` (`src/action.ts:64-68`), `ActionResult` (`getStateHash()`, `ariaSnapshot`, `combinedHtml()`, `url`, `title`), `compactAriaSnapshot` (`src/utils/aria.ts`), `Diff`/`PageDiff` via `ActionResult` (`src/action-result.ts`).
+- Produces (used by Tasks 5–7, 9):
+
+```typescript
+export interface ActorOptions {
+  verbose?: boolean;
+  config?: string;
+  path?: string;
+  instance?: string;
+  session?: string;
+  heal?: boolean;
+  ephemeral?: boolean;
+  framework?: 'codeceptjs' | 'playwright';
+  vision?: boolean;
+  url?: string;
+}
+export class Actor {
+  constructor(options?: ActorOptions);
+  async start(): Promise<void>;
+  async stop(): Promise<void>;
+  async pw(expression: string): Promise<EnvelopeData>;
+  async instanceInfo(): Promise<InstanceInfo>;
+}
+```
+
+- [ ] **Step 1: Study `boat/doc-collector/src/docbot.ts`** — the Actor mirrors how DocBot wraps ExplorBot (constructor builds `new ExplorBot({...})`, `start()` boots it, agents accessed lazily).
+
+- [ ] **Step 2: Write failing tests with duck-typed mocks**
+
+`boat/actor/tests/actor.test.ts` — follow the duck-type-mock style of `tests/integration/` (mock Explorer/StateManager, no real browser):
+
+```typescript
+import { describe, expect, test } from 'bun:test';
+import { Actor } from '../src/actor.ts';
+
+function fakeState(over: Record<string, unknown> = {}) {
+  return {
+    url: 'https://app.example.com/login',
+    title: 'Login',
+    getStateHash: () => 'login_h1_login',
+    ariaSnapshot: '- textbox "Email"\n- button "Sign in"',
+    combinedHtml: () => '<form></form>',
+    ...over,
+  };
+}
+
+function fakeActor() {
+  const actor = new Actor({ instance: 'default' });
+  const executed: string[] = [];
+  const after = fakeState({ url: 'https://app.example.com/dashboard', title: 'Dashboard', getStateHash: () => 'dashboard_h1_dashboard' });
+  (actor as any).bot = {
+    getExplorer: () => ({
+      action: () => ({
+        execute: async (code: string) => {
+          executed.push(code);
+          return { actionResult: after, lastError: null };
+        },
+      }),
+      capture: async () => after,
+    }),
+    stateManager: () => ({
+      getCurrentState: () => fakeState(),
+      getVisitCount: () => 1,
+    }),
+    requestStore: () => ({ getRequests: () => [] }),
+  };
+  (actor as any).artifactsDir = '/tmp/act-test';
+  return { actor, executed };
+}
+
+describe('Actor.pw', () => {
+  test('rejects invalid expression as tool error without executing', async () => {
+    const { actor, executed } = fakeActor();
+    const envelope = await actor.pw("process.exit(1)");
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain('page.');
+    expect(executed.length).toBe(0);
+  });
+
+  test('executes wrapped expression and returns success envelope data', async () => {
+    const { actor, executed } = fakeActor();
+    const envelope = await actor.pw("page.click('text=Login')");
+    expect(executed[0]).toContain("I.usePlaywrightTo");
+    expect(envelope.ok).toBe(true);
+    expect(envelope.used).toEqual(["page.click('text=Login')"]);
+    expect(envelope.page.url).toBe('https://app.example.com/dashboard');
+    expect(envelope.page.previousUrl).toBe('https://app.example.com/login');
+  });
+});
+```
+
+- [ ] **Step 3: Run tests, verify fail**
+
+Run: `bun test boat/actor/tests/actor.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 4: Implement Actor core**
+
+`boat/actor/src/actor.ts` responsibilities in this task:
+- Constructor stores options, builds `ExplorBot` options (`config`, `path`, `verbose`, `session`, `headless: true`) — but do NOT boot in constructor (DocBot pattern).
+- `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, launch via `launchServer` equivalent used by `explorbot browser start` (reuse, do not reimplement); then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`.
+- `pw(expression)`:
+  1. `validatePwExpression` — invalid → return tool-error envelope (`ok: false`, `failure.error` prefixed `tool:`), never execute.
+  2. Capture `before = stateManager.getCurrentState()`.
+  3. `const action = explorer.action(); await action.execute(toCodeceptWrapper(expression))`.
+  4. On success build `EnvelopeData` with `used: [expression]`, page block from resulting `ActionResult` (`previousUrl` from `before`), `changes` from the pageDiff ariaChanges the Action pipeline computed (see `ActionResult.toToolResult` usage in `src/ai/tools.ts:1122` for how diffs are obtained — reuse the same path, do not recompute).
+  5. Write artifacts via `writeArtifacts(this.nextArtifactDir(), { aria: result.ariaSnapshot, html: result.combinedHtml(), requests: this.bot.requestStore().getRequests() })`.
+  6. On execution error: this task returns a plain failure envelope (heal comes in Task 5).
+- `instanceInfo()`: name from options; tabs from `explorer` playwright context pages count (add a small public accessor if none exists — check `src/explorer.ts:79` `playwrightHelper?.page`); others from `listInstances()` (Task 3) excluding self; tabs for others may be reported as 0 when unreachable — do not connect to other instances.
+- `nextArtifactDir()`: `<output>/act/<ISO-timestamp>/`, one per command invocation.
+
+Mockability rule: everything the tests stub lives behind `this.bot` — keep all ExplorBot access via that single field.
+
+- [ ] **Step 5: Run tests, verify pass**
+
+Run: `bun test boat/actor/tests/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run format
+git add boat/actor
+git commit -m "feat(actor): Actor core with pw execution and instance info"
+```
+
+---
+
+### Task 5: Heal loop
+
+**Files:**
+- Modify: `src/ai/navigator.ts:192` (`resolveState` signature), `boat/actor/src/actor.ts`
+- Test: `boat/actor/tests/actor.test.ts` (extend), `tests/integration/` untouched
+
+**Interfaces:**
+- Consumes: `navigator.resolveState(message, actionResult, opts)` (`src/ai/navigator.ts:192`).
+- Produces: `resolveState` opts gains `onAttempt?: (attempt: { code: string; error?: string }) => void`, invoked once per executed recovery attempt with the exact code string and the error message when it failed. Actor gains private `heal(...)` used by pw (and Task 6 commands).
+
+- [ ] **Step 1: Extend `resolveState` with the attempt hook**
+
+Read `src/ai/navigator.ts` `resolveState` implementation; find where recovery code executes (each `action.execute`/attempt site). Add `opts.onAttempt` invocation at each attempt completion with `{ code, error: lastError?.message }`. Smallest change possible; no behavior change when the callback is absent.
+
+- [ ] **Step 2: Write failing Actor heal test**
+
+Extend `boat/actor/tests/actor.test.ts`; stub `agentNavigator` on the fake bot:
+
+```typescript
+test('failed pw heals via navigator and reports healed envelope', async () => {
+  const { actor } = fakeActor();
+  (actor as any).bot.getExplorer = () => ({
+    action: () => ({
+      execute: async () => {
+        throw new Error("locator 'text=Login' not found");
+      },
+    }),
+    capture: async () => fakeState(),
+  });
+  (actor as any).bot.agentNavigator = () => ({
+    resolveState: async (_msg: string, _result: unknown, opts: any) => {
+      opts?.onAttempt?.({ code: "I.click('Login')", error: 'not visible' });
+      opts?.onAttempt?.({ code: "I.click('#login-btn')" });
+      return true;
+    },
+  });
+  const envelope = await actor.pw("page.click('text=Login')");
+  expect(envelope.ok).toBe(true);
+  expect(envelope.healed).toBe(true);
+  expect(envelope.used).toEqual(["I.click('#login-btn')"]);
+});
+
+test('exhausted heal returns failure envelope with attempts and compact aria', async () => {
+  const { actor } = fakeActor();
+  (actor as any).bot.getExplorer = () => ({
+    action: () => ({
+      execute: async () => {
+        throw new Error("locator 'text=Login' not found");
+      },
+    }),
+    capture: async () => fakeState(),
+  });
+  (actor as any).bot.agentNavigator = () => ({
+    resolveState: async (_msg: string, _result: unknown, opts: any) => {
+      opts?.onAttempt?.({ code: "I.click('Login')", error: 'not visible' });
+      return false;
+    },
+  });
+  const envelope = await actor.pw("page.click('text=Login')");
+  expect(envelope.ok).toBe(false);
+  expect(envelope.failure?.attempts.length).toBe(1);
+  expect(envelope.failure?.compactAria).toContain('button');
+});
+```
+
+- [ ] **Step 3: Run tests, verify fail**
+
+Run: `bun test boat/actor/tests/actor.test.ts`
+Expected: new tests FAIL (heal not implemented).
+
+- [ ] **Step 4: Implement heal in Actor**
+
+Private `heal(errorMessage, actionResult, originalCode)`:
+- Skip entirely when `options.heal === false` — go straight to failure envelope.
+- Collect attempts array via `onAttempt`; call `navigator.resolveState(errorMessage, actionResult, { onAttempt })`.
+- `true` → success envelope: `healed: true`, `healNote` = last attempt outcome summary, `used` = codes of successful attempts (last attempt without error), current state re-read from `stateManager.getCurrentState()`.
+- `false` → failure envelope: `error`, `attempts` (map error→outcome, success→'ok'), `compactAria` from `compactAriaSnapshot(state.ariaSnapshot, true)` (`src/utils/aria.ts`), reasoning left to Task 8's compaction if trivial — set `reasoning` to a one-line join of distinct outcomes for now (general, not model-generated).
+- Failure envelopes still include artifacts and instance blocks.
+
+- [ ] **Step 5: Run boat tests and repo unit tests**
+
+Run: `bun test boat/actor/tests/ tests/unit/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run format
+git add src/ai/navigator.ts boat/actor
+git commit -m "feat(actor): heal loop over navigator recovery with attempt trace"
+```
+
+---
+
+### Task 6: do, click, fill, ask, verify commands
+
+**Files:**
+- Modify: `boat/actor/src/actor.ts`
+- Test: `boat/actor/tests/actor.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `collectInteractiveNodes(snapshot)` (`src/utils/aria.ts`), `createCodeceptJSTools` (`src/ai/tools.ts:30`) — tool objects expose `.execute(input)`; `provider.invokeConversation` with `maxToolRoundtrips` (Driller pattern, `src/ai/driller.ts:325-329`); `researcher.answerQuestionAboutScreenshot(state, question)` and `researcher.summary(state)` (`src/ai/researcher.ts:544, 659`); `navigator.verifyState(message, actionResult)` (`src/ai/navigator.ts:618`) returning `{ verified, successfulCodes, assertionSteps, totalAttempted }`.
+- Produces:
+
+```typescript
+async do(instruction: string): Promise<EnvelopeData>;
+async click(target: string): Promise<EnvelopeData>;
+async fill(field: string, value: string): Promise<EnvelopeData>;
+async ask(question: string): Promise<EnvelopeData>;
+async verify(assertion: string): Promise<EnvelopeData>;
+```
+
+- [ ] **Step 1: Write failing tests for the deterministic fast path**
+
+```typescript
+test('do with unambiguous role+name executes without AI', async () => {
+  const { actor, executed } = fakeActor();
+  let aiCalled = false;
+  (actor as any).bot.getProvider = () => ({ invokeConversation: async () => { aiCalled = true; } });
+  const envelope = await actor.do('click the "Sign in" button');
+  expect(aiCalled).toBe(false);
+  expect(executed.some((code) => code.includes("I.click"))).toBe(true);
+  expect(envelope.ok).toBe(true);
+});
+
+test('verify returns verdict with assertion code', async () => {
+  const { actor } = fakeActor();
+  (actor as any).bot.agentNavigator = () => ({
+    verifyState: async () => ({ verified: true, successfulCodes: ["I.see('Dashboard')"], assertionSteps: [], totalAttempted: 1 }),
+  });
+  const envelope = await actor.verify('user sees the dashboard');
+  expect(envelope.verdict?.passed).toBe(true);
+  expect(envelope.verdict?.code).toBe("I.see('Dashboard')");
+});
+
+test('ask without vision answers from researcher summary', async () => {
+  const { actor } = fakeActor();
+  (actor as any).bot.agentResearcher = () => ({ summary: async () => 'Login form with email and password' });
+  (actor as any).bot.getProvider = () => ({ chat: async () => ({ text: 'A login page with an email form' }) });
+  const envelope = await actor.ask('what do I see?');
+  expect(envelope.answer).toContain('login');
+});
+```
+
+- [ ] **Step 2: Run tests, verify fail** — `bun test boat/actor/tests/actor.test.ts`.
+
+- [ ] **Step 3: Implement**
+
+- `do(instruction)`:
+  1. Fast path: quote-extract or word-match the instruction against `collectInteractiveNodes(state.ariaSnapshot)`; when exactly one node matches by name (case-insensitive) and the instruction's verb maps to that node's default interaction, execute `I.click('<name>')` / `I.fillField(...)` via `explorer.action().execute(...)` with zero AI. The matching must be generic (role vocabulary from `INTERACTIVE_ROLES`), never keyed to specific words from any one app.
+  2. Otherwise: bounded agentic call — `provider.invokeConversation(conversation, createCodeceptJSTools(explorer, ...), { maxToolRoundtrips: 3, toolChoice: 'required' })` with a dedent system prompt: current compact ARIA + the instruction + rule to perform exactly the instructed interaction and stop. Collect executed codes from the tool results (same shape the Driller reads).
+  3. Failures feed `heal(...)` from Task 5.
+- `click(target)` / `fill(field, value)`: call the corresponding tool object from `createCodeceptJSTools` directly (`tools.click.execute({ locator: target })` — read the tool's exact input schema in `src/ai/tools.ts` first and match it); ladder failures feed `heal`.
+- `ask(question)`: `options.vision` → `researcher.answerQuestionAboutScreenshot(state, question)`; otherwise `provider.chat` over dedent prompt containing `researcher.summary(state)` + compact ARIA + the question. Non-mutating: envelope has `answer`, no `changes`, artifacts still written.
+- `verify(assertion)`: `explorer.capture()` then `navigator.verifyState(assertion, actionResult)`; verdict `{ passed: verified, evidence: <first successful step or failure note>, code: successfulCodes.join('\n') }`.
+- All command methods end by building `used` from actually executed code (never the requested input when they differ).
+
+- [ ] **Step 4: Run tests, verify pass** — `bun test boat/actor/tests/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run format
+git add boat/actor
+git commit -m "feat(actor): do, click, fill, ask, verify commands"
+```
+
+---
+
+### Task 7: go command and browser instance management
+
+**Files:**
+- Modify: `boat/actor/src/actor.ts`
+- Test: `boat/actor/tests/actor.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `navigator.visit(destination)` (`src/ai/navigator.ts:140` — handles both URLs and NL/state destinations, same call the TUI `/navigate` uses per `src/commands/navigate-command.ts`), Task 3 instance functions.
+- Produces:
+
+```typescript
+async go(target: string): Promise<EnvelopeData>;
+async browserStart(): Promise<void>;
+async browserStop(all?: boolean): Promise<void>;
+async browserStatus(): Promise<string>;
+```
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+test('go delegates to navigator.visit and returns envelope', async () => {
+  const { actor } = fakeActor();
+  const visited: string[] = [];
+  (actor as any).bot.agentNavigator = () => ({ visit: async (dest: string) => { visited.push(dest); } });
+  const envelope = await actor.go('billing settings');
+  expect(visited).toEqual(['billing settings']);
+  expect(envelope.ok).toBe(true);
+  expect(envelope.page.url).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement**
+
+- `go(target)`: `navigator.visit(target)` (it resolves URL vs intent internally); envelope from resulting state; navigation errors feed `heal`.
+- `browserStart/Stop/Status`: thin delegation to Task 3's browser-server functions with `options.instance`; `browserStop(true)` iterates `listInstances()`. Status string includes what `instanceInfo()` knows.
+- Autostart: already in `start()` (Task 4) — verify `go` path hits it when no daemon runs; with `options.session` set, the launched context loads storage state (Explorer already honors `session` — `src/explorer.ts:106,337`).
+
+- [ ] **Step 4: Run tests, verify pass; commit**
+
+```bash
+bun run format
+git add boat/actor
+git commit -m "feat(actor): go command and instance management"
+```
+
+---
+
+### Task 8: Config ladder — global config, global .env, per-host state dir
+
+**Files:**
+- Modify: `src/config.ts` (`ConfigParser.loadConfig` at line 324, `buildEnvConfig` at line 489, `resolveOutputRoot` at line 667)
+- Test: `tests/unit/config-ladder.test.ts`
+
+**Interfaces:**
+- Produces: `loadConfig` resolution order becomes: explicit `--config` path → project `explorbot.config.js|ts` in cwd → `~/.config/explorbot/config.js|ts` → env-var config (`buildEnvConfig`). `.env` loading order: cwd `.env` (existing behavior) then `~/.config/explorbot/.env` (only for keys not already set). New exported helper:
+
+```typescript
+export function resolveStateRoot(baseUrl: string, ephemeral?: boolean): string;
+```
+
+returning `~/.local/state/explorbot/<host>/` (created), or a `mkdtempSync` temp dir when `ephemeral`.
+
+- [ ] **Step 1: Read `src/config.ts` load path fully** (lines 297-560) before changing anything.
+
+- [ ] **Step 2: Write failing tests**
+
+`tests/unit/config-ladder.test.ts`:
+
+```typescript
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { resolveStateRoot } from '../../src/config.ts';
+
+describe('resolveStateRoot', () => {
+  test('derives persistent per-host dir', () => {
+    const dir = resolveStateRoot('https://app.example.com/login');
+    expect(dir).toBe(path.join(os.homedir(), '.local', 'state', 'explorbot', 'app.example.com'));
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  test('ephemeral returns fresh temp dir', () => {
+    const a = resolveStateRoot('https://app.example.com', true);
+    const b = resolveStateRoot('https://app.example.com', true);
+    expect(a).not.toBe(b);
+    expect(a).toContain('explorbot');
+  });
+});
+```
+
+Global-config precedence test: point `ConfigParser.loadConfig` at a temp `HOME` (set `process.env.HOME` in the test, restore in `afterEach`), write `~/.config/explorbot/config.js` exporting a marker value, assert it loads when cwd has no project config and that a project config wins when both exist. Follow existing config tests in `tests/unit/` for how ConfigParser is instantiated.
+
+- [ ] **Step 3: Run, verify fail.**
+
+- [ ] **Step 4: Implement**
+
+- `resolveStateRoot`: host from `new URL(baseUrl).host`; `mkdirSync(..., { recursive: true })`; ephemeral via `mkdtempSync(path.join(os.tmpdir(), 'explorbot-'))`.
+- In `loadConfig`: after project-config lookup misses, try `path.join(os.homedir(), '.config', 'explorbot', 'config.js')` then `.ts` through the existing `loadConfigModule`.
+- `.env`: where the existing cwd `.env` loads, additionally load `~/.config/explorbot/.env` without overwriting already-set keys.
+- In `buildEnvConfig` (config-free mode): when no project config, set `dirs` (knowledge/experience/output) under `resolveStateRoot(baseUrl, ephemeralFlag)`; ephemeral flag arrives via new `EXPLORBOT_EPHEMERAL` env var so the boat can pass it without new plumbing.
+
+- [ ] **Step 5: Run full unit suite** — `bun test tests/unit/` — PASS, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+bun run format
+git add src/config.ts tests/unit/config-ladder.test.ts
+git commit -m "feat: global config ladder and per-host state dirs"
+```
+
+---
+
+### Task 9: CLI wiring and --help contract
+
+**Files:**
+- Create: `boat/actor/src/cli.ts`, `boat/actor/bin/actbot-cli.ts`
+- Modify: `bin/explorbot-cli.ts` (add near line 874: `program.addCommand(createActCommands('act'))`)
+- Test: manual smoke via `--help` (Step 4)
+
+**Interfaces:**
+- Consumes: `Actor`/`ActorOptions` (Tasks 4-7), `renderEnvelope` (Task 1).
+- Produces: `export function createActCommands(name = 'act'): Command`.
+
+- [ ] **Step 1: Implement `boat/actor/src/cli.ts`**
+
+Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <expression>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `go <target>`, `browser <start|stop|status|list>`. Common options:
+
+```
+-v, --verbose            --debug
+-c, --config <path>      -p, --path <path>
+-i, --instance <name>    --session [file]
+--no-heal                --ephemeral
+--framework <name>       --vision   (ask only)
+--url <url>              (start page for config-free mode)
+```
+
+Every action handler: `setPreserveConsoleLogs(true)`, build `Actor`, `await actor.start()`, run the method, `console.log(renderEnvelope(result))`, `await actor.stop()`, `process.exit(result.ok ? 0 : 1)`. `--ephemeral` sets `process.env.EXPLORBOT_EPHEMERAL = '1'` before Actor construction. Zero business logic in handlers.
+
+- [ ] **Step 2: Write the --help contract text**
+
+The command description plus `addHelpText('after', ...)` on the `act` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise, click/fill = ladder, do = intent), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
+
+- [ ] **Step 3: Wire into main CLI and standalone bin**
+
+- `bin/explorbot-cli.ts`: `import { createActCommands } from '../boat/actor/src/cli.ts';` + `program.addCommand(createActCommands('act'));` next to the existing api/docs registrations (line ~874).
+- `boat/actor/bin/actbot-cli.ts`: mirror `boat/api-tester/bin` entry — a commander program that mounts the same subcommands at top level.
+
+- [ ] **Step 4: Smoke the help output**
+
+Run: `bun bin/explorbot-cli.ts act --help` and `bun boat/actor/bin/actbot-cli.ts --help`
+Expected: full contract text, all 8 subcommands listed, no banner noise with `EXPLORBOT_NO_BANNER=1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+bun run format && bun run lint:fix
+git add boat/actor bin/explorbot-cli.ts
+git commit -m "feat(actor): act CLI namespace and standalone actbot bin"
+```
+
+---
+
+### Task 10: End-to-end smoke, changelog, docs
+
+**Files:**
+- Create: `tests/node/actor-smoke.test.ts` (or `tests/regression/` — match where existing browser-driving tests live; inspect both dirs first)
+- Modify: `docs/reference/commands.md`, `CHANGELOG.md` (via `/changelog` skill at commit time)
+
+- [ ] **Step 1: Inspect existing e2e/browser test setup** — `tests/node/` and `tests/regression/` — reuse their fixture-server pattern for a local page (a form with a button and an input; fictional content only).
+
+- [ ] **Step 2: Write the smoke test**
+
+Scenarios, driven through the `Actor` class directly against the local fixture (real browser, no AI provider needed for these paths):
+1. `pw "page.click('text=Submit')"` on the fixture → `ok: true`, envelope contains `### Changes` and artifact files exist on disk.
+2. `pw` with an invalid expression → `ok: false`, `tool:`-prefixed error, exit path returns without browser action.
+3. `do 'click the "Submit" button'` → fast path, zero AI (assert no provider configured and it still works).
+4. Instance autostart honored: run without a pre-started daemon; assert endpoint file appears.
+
+Heal-path e2e requires an AI provider — cover it with an aimock integration test in `tests/integration/actor-heal.test.ts` following `tests/integration/planner.test.ts` (mock provider returns a recovery instruction; assert `healed: true` envelope and `onAttempt` trace).
+
+- [ ] **Step 3: Run everything**
+
+Run: `bun test boat/actor/tests/ tests/unit/ tests/integration/` plus the smoke file.
+Expected: all PASS.
+
+- [ ] **Step 4: Document**
+
+Add an "Actor boat" section to `docs/reference/commands.md`: command table, envelope sample, tiering guidance, instance/session flags, config-free example (`EXPLORBOT_AI_PROVIDER=groq explorbot act go https://app.example.com`).
+
+- [ ] **Step 5: Final checks and commit**
+
+```bash
+bun run format && bun run check:fix
+```
+
+Invoke the `/changelog` skill, then:
+
+```bash
+git add -A
+git commit -m "feat(actor): e2e smoke, docs and changelog"
+```
+
+---
+
+## Self-Review Notes
+
+- Spec coverage: pw/do/click/fill/ask/verify+assert/go (Tasks 4-7, 9), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
+- Vision `ask` degrades to text path when no `visionModel` configured (`provider.hasVision()`, `src/ai/provider.ts:635`) — implementer: guard in `ask`.
+- Type consistency: `EnvelopeData`/`InstanceInfo`/`HealAttempt` defined once in Task 1 and only consumed elsewhere; `ActorOptions` defined in Task 4 and consumed by 9.

--- a/docs/superpowers/plans/2026-08-01-actor-boat.md
+++ b/docs/superpowers/plans/2026-08-01-actor-boat.md
@@ -4,7 +4,7 @@
 
 **Goal:** Ship `boat/actor` — an intent-level browser driver CLI (`explorbot act ...`) that lets an orchestrating agent act on pages via Playwright calls or natural language while explorbot's cheap models handle perception, healing, and evidence.
 
-**Architecture:** A boat following the `boat/doc-collector` pattern: `Actor` class wraps `ExplorBot`, reuses Navigator/Researcher/Explorer/StateManager, adds a pure envelope renderer and a pw-expression validator. Core changes are minimal: named browser-server instances, a Navigator heal-attempt hook, and a global-config/per-host-state ladder in config loading.
+**Architecture:** A boat following the `boat/doc-collector` pattern: `Actor` class wraps `ExplorBot`, reuses Navigator/Researcher/Explorer/StateManager, adds a pure envelope renderer and a pw function wrapper. Core changes are minimal: named browser-server instances, a Navigator heal-attempt hook, and a global-config/per-host-state ladder in config loading.
 
 **Tech Stack:** Bun (never Node), TypeScript, commander, CodeceptJS/Playwright via Explorer, `bun:test`, Biome.
 
@@ -32,7 +32,7 @@ boat/actor/
 │   ├── cli.ts                 # createActCommands(name = 'act')
 │   ├── actor.ts               # Actor class (all business logic)
 │   ├── envelope.ts            # EnvelopeData type, renderEnvelope(), writeArtifacts()
-│   └── pw-parser.ts           # validatePwExpression(), toCodeceptWrapper()
+│   └── pw-parser.ts           # isFunctionExpression(), toCodeceptWrapper()
 └── tests/
     ├── envelope.test.ts
     ├── pw-parser.test.ts
@@ -121,7 +121,7 @@ import { type EnvelopeData, renderEnvelope, writeArtifacts } from '../src/envelo
 
 const base: EnvelopeData = {
   ok: true,
-  command: "pw page.click('text=Login')",
+  command: "pw ({ page }) => page.click('text=Login')",
   used: ["I.click('Login')"],
   page: { url: 'https://app.example.com/dashboard', previousUrl: 'https://app.example.com/login', title: 'Dashboard', state: 'dashboard_h1_dashboard', visits: 1 },
   changes: 'ariaDiff:\n  added:\n    - heading "Dashboard"',
@@ -231,17 +231,19 @@ git commit -m "feat(actor): boat scaffold and result envelope"
 
 ---
 
-### Task 2: pw expression validator
+### Task 2: pw function wrapper
+
+The `pw` argument is a function expression in the exact shape `I.usePlaywrightTo` accepts — `({ page, browserContext, browser }) => ...` — so callers destructure whichever Playwright objects they need. The parser only answers "is this a parseable function expression" (for clean `tool:` errors) and interpolates it verbatim into the CodeceptJS call that `Action.execute` expects.
 
 **Files:**
 - Create: `boat/actor/src/pw-parser.ts`
 - Test: `boat/actor/tests/pw-parser.test.ts`
 
 **Interfaces:**
-- Produces (used by Task 3):
+- Produces (used by Task 4):
 
 ```typescript
-export function validatePwExpression(expr: string): { valid: boolean; error?: string };
+export function isFunctionExpression(expr: string): { valid: boolean; error?: string };
 export function toCodeceptWrapper(expr: string): string;
 ```
 
@@ -251,38 +253,35 @@ export function toCodeceptWrapper(expr: string): string;
 
 ```typescript
 import { describe, expect, test } from 'bun:test';
-import { toCodeceptWrapper, validatePwExpression } from '../src/pw-parser.ts';
+import { isFunctionExpression, toCodeceptWrapper } from '../src/pw-parser.ts';
 
-describe('validatePwExpression', () => {
+describe('isFunctionExpression', () => {
   test.each([
-    "page.click('text=Login')",
-    "page.getByRole('button', { name: 'Submit' }).click()",
-    "page.fill('#email', 'user@example.com')",
-    "page.keyboard.press('Enter')",
-    "page.selectOption('select#tier', 'pro')",
-    "page.getByText('3 items').isVisible()",
+    "({ page }) => page.click('text=Login')",
+    "async ({ page }) => { await page.fill('#email', 'user@example.com'); await page.keyboard.press('Enter'); }",
+    "({ browserContext }) => browserContext.clearCookies()",
+    "({ page, browser }) => browser.version()",
+    "function ({ page }) { return page.title() }",
   ])('accepts %s', (expr) => {
-    expect(validatePwExpression(expr).valid).toBe(true);
+    expect(isFunctionExpression(expr).valid).toBe(true);
   });
 
   test.each([
-    ["fetch('https://evil.example')", 'must start with page.'],
-    ["process.exit(1)", 'must start with page.'],
-    ["page.click('a'); process.exit(1)", 'single expression'],
-    ["page.evaluate(() => require('fs'))", 'forbidden token'],
-    ["page.click('a'", 'unbalanced'],
+    "page.click('text=Login')",
+    "({ page }) => page.click('a'",
+    "just some text",
+    "",
   ])('rejects %s', (expr) => {
-    const result = validatePwExpression(expr);
+    const result = isFunctionExpression(expr);
     expect(result.valid).toBe(false);
     expect(result.error).toBeTruthy();
   });
 });
 
 describe('toCodeceptWrapper', () => {
-  test('wraps expression in usePlaywrightTo', () => {
-    const code = toCodeceptWrapper("page.click('text=Login')");
-    expect(code).toContain("I.usePlaywrightTo");
-    expect(code).toContain("await page.click('text=Login')");
+  test('interpolates the function verbatim into usePlaywrightTo', () => {
+    const code = toCodeceptWrapper("({ page }) => page.click('text=Login')");
+    expect(code).toBe("I.usePlaywrightTo('pw', ({ page }) => page.click('text=Login'))");
   });
 });
 ```
@@ -294,18 +293,27 @@ Expected: FAIL — module not found.
 
 - [ ] **Step 3: Implement `boat/actor/src/pw-parser.ts`**
 
-Validation rules (general, not example-driven):
-- Trimmed expression must start with `page.`.
-- Balanced `()`, `[]`, `{}` and closed string literals (single scan with a quote/bracket stack).
-- No statement separators outside strings: `;` splitting into a second non-empty statement fails with 'single expression only'.
-- Forbidden identifiers outside strings: `require`, `import`, `process`, `child_process`, `Bun`, `globalThis`, `eval`.
-- Return `{ valid: true }` or `{ valid: false, error: <specific reason> }`.
-
 ```typescript
+const FUNCTION_SHAPE = /^(async\s+)?(function\b|\()/;
+
+export function isFunctionExpression(expr: string): { valid: boolean; error?: string } {
+  const trimmed = expr.trim();
+  if (!trimmed) return { valid: false, error: 'empty expression; pass a function like ({ page }) => ...' };
+  if (!FUNCTION_SHAPE.test(trimmed)) return { valid: false, error: 'expression must be a function like ({ page }) => ... destructuring the playwright objects it needs' };
+  try {
+    new Function(`return (${trimmed})`);
+  } catch (e) {
+    return { valid: false, error: `not a valid function expression: ${(e as Error).message}` };
+  }
+  return { valid: true };
+}
+
 export function toCodeceptWrapper(expr: string): string {
-  return `I.usePlaywrightTo('pw', async ({ page }) => { await ${expr} })`;
+  return `I.usePlaywrightTo('pw', ${expr.trim()})`;
 }
 ```
+
+`new Function` is construction-only — the user's code is never invoked here (invoking would execute non-function inputs). The shape regex rejects bare call chains like `page.click(...)` with an error pointing at the expected form; the construction catch turns syntax errors (unbalanced brackets, garbage text) into the `tool:` error in the envelope. Note the shape regex also requires arrow parameters to be parenthesized — acceptable since the destructured `({ page })` form is the documented contract.
 
 - [ ] **Step 4: Run tests, verify pass**
 
@@ -317,7 +325,7 @@ Expected: PASS.
 ```bash
 bun run format
 git add boat/actor/src/pw-parser.ts boat/actor/tests/pw-parser.test.ts
-git commit -m "feat(actor): pw expression validator and codecept wrapper"
+git commit -m "feat(actor): pw function wrapper"
 ```
 
 ---
@@ -392,7 +400,7 @@ git commit -m "feat: named browser server instances"
 - Test: `boat/actor/tests/actor.test.ts`
 
 **Interfaces:**
-- Consumes: `renderEnvelope`/`writeArtifacts`/`EnvelopeData`/`InstanceInfo` (Task 1), `validatePwExpression`/`toCodeceptWrapper` (Task 2), `getAliveEndpoint(instance)`/`launchServer` (Task 3), `ExplorBot` API (`src/explorbot.ts`: `start()`, `stop()`, `visit(url)`, `getExplorer()`, `stateManager()`, `getCurrentState()`, `agentNavigator()`, `agentResearcher()`, `agentHistorian()`, `requestStore()`), `Explorer.action(): Action` (`src/explorer.ts:151`), `Action.execute(code)` / `Action.capturePageState()` (`src/action.ts:64-68`), `ActionResult` (`getStateHash()`, `ariaSnapshot`, `combinedHtml()`, `url`, `title`), `compactAriaSnapshot` (`src/utils/aria.ts`), `Diff`/`PageDiff` via `ActionResult` (`src/action-result.ts`).
+- Consumes: `renderEnvelope`/`writeArtifacts`/`EnvelopeData`/`InstanceInfo` (Task 1), `isFunctionExpression`/`toCodeceptWrapper` (Task 2), `getAliveEndpoint(instance)`/`launchServer` (Task 3), `ExplorBot` API (`src/explorbot.ts`: `start()`, `stop()`, `visit(url)`, `getExplorer()`, `stateManager()`, `getCurrentState()`, `agentNavigator()`, `agentResearcher()`, `agentHistorian()`, `requestStore()`), `Explorer.action(): Action` (`src/explorer.ts:151`), `Action.execute(code)` / `Action.capturePageState()` (`src/action.ts:64-68`), `ActionResult` (`getStateHash()`, `ariaSnapshot`, `combinedHtml()`, `url`, `title`), `compactAriaSnapshot` (`src/utils/aria.ts`), `Diff`/`PageDiff` via `ActionResult` (`src/action-result.ts`).
 - Produces (used by Tasks 5–7, 9):
 
 ```typescript
@@ -463,20 +471,20 @@ function fakeActor() {
 }
 
 describe('Actor.pw', () => {
-  test('rejects invalid expression as tool error without executing', async () => {
+  test('rejects non-function argument as tool error without executing', async () => {
     const { actor, executed } = fakeActor();
-    const envelope = await actor.pw("process.exit(1)");
+    const envelope = await actor.pw("page.click('text=Login')");
     expect(envelope.ok).toBe(false);
-    expect(envelope.failure?.error).toContain('page.');
+    expect(envelope.failure?.error).toContain('function');
     expect(executed.length).toBe(0);
   });
 
-  test('executes wrapped expression and returns success envelope data', async () => {
+  test('executes wrapped function and returns success envelope data', async () => {
     const { actor, executed } = fakeActor();
-    const envelope = await actor.pw("page.click('text=Login')");
+    const envelope = await actor.pw("({ page }) => page.click('text=Login')");
     expect(executed[0]).toContain("I.usePlaywrightTo");
     expect(envelope.ok).toBe(true);
-    expect(envelope.used).toEqual(["page.click('text=Login')"]);
+    expect(envelope.used).toEqual(["({ page }) => page.click('text=Login')"]);
     expect(envelope.page.url).toBe('https://app.example.com/dashboard');
     expect(envelope.page.previousUrl).toBe('https://app.example.com/login');
   });
@@ -494,7 +502,7 @@ Expected: FAIL — module not found.
 - Constructor stores options, builds `ExplorBot` options (`config`, `path`, `verbose`, `session`, `headless: true`) — but do NOT boot in constructor (DocBot pattern).
 - `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, launch via `launchServer` equivalent used by `explorbot browser start` (reuse, do not reimplement); then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`.
 - `pw(expression)`:
-  1. `validatePwExpression` — invalid → return tool-error envelope (`ok: false`, `failure.error` prefixed `tool:`), never execute.
+  1. `isFunctionExpression` — invalid → return tool-error envelope (`ok: false`, `failure.error` prefixed `tool:`), never execute.
   2. Capture `before = stateManager.getCurrentState()`.
   3. `const action = explorer.action(); await action.execute(toCodeceptWrapper(expression))`.
   4. On success build `EnvelopeData` with `used: [expression]`, page block from resulting `ActionResult` (`previousUrl` from `before`), `changes` from the pageDiff ariaChanges the Action pipeline computed (see `ActionResult.toToolResult` usage in `src/ai/tools.ts:1122` for how diffs are obtained — reuse the same path, do not recompute).
@@ -556,7 +564,7 @@ test('failed pw heals via navigator and reports healed envelope', async () => {
       return true;
     },
   });
-  const envelope = await actor.pw("page.click('text=Login')");
+  const envelope = await actor.pw("({ page }) => page.click('text=Login')");
   expect(envelope.ok).toBe(true);
   expect(envelope.healed).toBe(true);
   expect(envelope.used).toEqual(["I.click('#login-btn')"]);
@@ -578,7 +586,7 @@ test('exhausted heal returns failure envelope with attempts and compact aria', a
       return false;
     },
   });
-  const envelope = await actor.pw("page.click('text=Login')");
+  const envelope = await actor.pw("({ page }) => page.click('text=Login')");
   expect(envelope.ok).toBe(false);
   expect(envelope.failure?.attempts.length).toBe(1);
   expect(envelope.failure?.compactAria).toContain('button');
@@ -818,7 +826,7 @@ git commit -m "feat: global config ladder and per-host state dirs"
 
 - [ ] **Step 1: Implement `boat/actor/src/cli.ts`**
 
-Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <expression>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `go <target>`, `browser <start|stop|status|list>`. Common options:
+Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <fn>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `go <target>`, `browser <start|stop|status|list>`. Common options:
 
 ```
 -v, --verbose            --debug
@@ -866,8 +874,8 @@ git commit -m "feat(actor): act CLI namespace and standalone actbot bin"
 - [ ] **Step 2: Write the smoke test**
 
 Scenarios, driven through the `Actor` class directly against the local fixture (real browser, no AI provider needed for these paths):
-1. `pw "page.click('text=Submit')"` on the fixture → `ok: true`, envelope contains `### Changes` and artifact files exist on disk.
-2. `pw` with an invalid expression → `ok: false`, `tool:`-prefixed error, exit path returns without browser action.
+1. `pw "({ page }) => page.click('text=Submit')"` on the fixture → `ok: true`, envelope contains `### Changes` and artifact files exist on disk.
+2. `pw` with a non-function argument → `ok: false`, `tool:`-prefixed error, exit path returns without browser action.
 3. `do 'click the "Submit" button'` → fast path, zero AI (assert no provider configured and it still works).
 4. Instance autostart honored: run without a pre-started daemon; assert endpoint file appears.
 

--- a/docs/superpowers/plans/2026-08-01-actor-boat.md
+++ b/docs/superpowers/plans/2026-08-01-actor-boat.md
@@ -75,6 +75,7 @@ export interface EnvelopeData {
   page: { url: string; previousUrl?: string; title: string; state: string; visits: number };
   changes?: string | null;
   answer?: string;
+  research?: string;
   verdict?: { passed: boolean; evidence: string; code: string };
   failure?: { error: string; attempts: HealAttempt[]; reasoning?: string; compactAria?: string };
   instance: InstanceInfo;
@@ -622,7 +623,7 @@ git commit -m "feat(actor): heal loop over navigator recovery with attempt trace
 
 ---
 
-### Task 6: do, click, fill, ask, verify commands
+### Task 6: do, click, fill, ask, verify, research commands
 
 **Files:**
 - Modify: `boat/actor/src/actor.ts`
@@ -638,7 +639,10 @@ async click(target: string): Promise<EnvelopeData>;
 async fill(field: string, value: string): Promise<EnvelopeData>;
 async ask(question: string): Promise<EnvelopeData>;
 async verify(assertion: string): Promise<EnvelopeData>;
+async research(opts?: { data?: boolean; deep?: boolean; fresh?: boolean }): Promise<EnvelopeData>;
 ```
+
+`EnvelopeData` gains an optional `research?: string` field (Task 1's renderer: `### Research` replaces `### Changes` when set, mutually exclusive with `answer`/`verdict` — add a render test alongside the answer/verdict ones).
 
 - [ ] **Step 1: Write failing tests for the deterministic fast path**
 
@@ -663,6 +667,14 @@ test('verify returns verdict with assertion code', async () => {
   expect(envelope.verdict?.code).toBe("I.see('Dashboard')");
 });
 
+test('research returns UI map in envelope', async () => {
+  const { actor } = fakeActor();
+  (actor as any).bot.agentResearcher = () => ({ research: async () => '## Section: Login Form\n| Element | ARIA | CSS |' });
+  const envelope = await actor.research({ data: true });
+  expect(envelope.research).toContain('Login Form');
+  expect(envelope.ok).toBe(true);
+});
+
 test('ask without vision answers from researcher summary', async () => {
   const { actor } = fakeActor();
   (actor as any).bot.agentResearcher = () => ({ summary: async () => 'Login form with email and password' });
@@ -683,6 +695,7 @@ test('ask without vision answers from researcher summary', async () => {
 - `click(target)` / `fill(field, value)`: call the corresponding tool object from `createCodeceptJSTools` directly (`tools.click.execute({ locator: target })` — read the tool's exact input schema in `src/ai/tools.ts` first and match it); ladder failures feed `heal`.
 - `ask(question)`: `options.vision` → `researcher.answerQuestionAboutScreenshot(state, question)`; otherwise `provider.chat` over dedent prompt containing `researcher.summary(state)` + compact ARIA + the question. Non-mutating: envelope has `answer`, no `changes`, artifacts still written.
 - `verify(assertion)`: `explorer.capture()` then `navigator.verifyState(assertion, actionResult)`; verdict `{ passed: verified, evidence: <first successful step or failure note>, code: successfulCodes.join('\n') }`.
+- `research(opts)`: `researcher.research(state, { screenshot: true, data: opts.data, deep: opts.deep, force: opts.fresh })` (`src/ai/researcher.ts:94`); envelope `research` = returned UI map verbatim (staleness banner included when cached), no `changes`. Non-mutating; artifacts still written.
 - All command methods end by building `used` from actually executed code (never the requested input when they differ).
 
 - [ ] **Step 4: Run tests, verify pass** — `bun test boat/actor/tests/`.
@@ -826,7 +839,7 @@ git commit -m "feat: global config ladder and per-host state dirs"
 
 - [ ] **Step 1: Implement `boat/actor/src/cli.ts`**
 
-Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <fn>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `go <target>`, `browser <start|stop|status|list>`. Common options:
+Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <fn>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `research` (flags `--data`, `--deep`, `--fresh`), `go <target>`, `browser <start|stop|status|list>`. Common options:
 
 ```
 -v, --verbose            --debug
@@ -841,7 +854,7 @@ Every action handler: `setPreserveConsoleLogs(true)`, build `Actor`, `await acto
 
 - [ ] **Step 2: Write the --help contract text**
 
-The command description plus `addHelpText('after', ...)` on the `act` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise, click/fill = ladder, do = intent), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
+The command description plus `addHelpText('after', ...)` on the `act` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise, click/fill = ladder, do = intent), the recommended loop (research once for verified locators → drive with pw → verify), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
 
 - [ ] **Step 3: Wire into main CLI and standalone bin**
 
@@ -907,6 +920,6 @@ git commit -m "feat(actor): e2e smoke, docs and changelog"
 
 ## Self-Review Notes
 
-- Spec coverage: pw/do/click/fill/ask/verify+assert/go (Tasks 4-7, 9), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
+- Spec coverage: pw/do/click/fill/ask/verify+assert/research/go (Tasks 4-7, 9), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
 - Vision `ask` degrades to text path when no `visionModel` configured (`provider.hasVision()`, `src/ai/provider.ts:635`) — implementer: guard in `ask`.
 - Type consistency: `EnvelopeData`/`InstanceInfo`/`HealAttempt` defined once in Task 1 and only consumed elsewhere; `ActorOptions` defined in Task 4 and consumed by 9.

--- a/docs/superpowers/plans/2026-08-01-prima-boat.md
+++ b/docs/superpowers/plans/2026-08-01-prima-boat.md
@@ -636,7 +636,7 @@ git commit -m "feat(prima): heal loop over navigator recovery with attempt trace
 - Produces:
 
 ```typescript
-async do(instruction: string): Promise<EnvelopeData>;
+async do(instructions: string[]): Promise<EnvelopeData>;
 async click(target: string): Promise<EnvelopeData>;
 async fill(field: string, value: string): Promise<EnvelopeData>;
 async ask(question: string): Promise<EnvelopeData>;
@@ -646,17 +646,30 @@ async research(opts?: { data?: boolean; deep?: boolean; fresh?: boolean }): Prom
 
 `EnvelopeData` gains an optional `research?: string` field (Task 1's renderer: `### Research` replaces `### Changes` when set, mutually exclusive with `answer`/`verdict` — add a render test alongside the answer/verdict ones).
 
-- [ ] **Step 1: Write failing tests for the deterministic fast path**
+- [ ] **Step 1: Write failing tests**
 
 ```typescript
-test('do with unambiguous role+name executes without AI', async () => {
-  const { prima, executed } = fakePrima();
-  let aiCalled = false;
-  (prima as any).bot.getProvider = () => ({ invokeConversation: async () => { aiCalled = true; } });
-  const envelope = await prima.do('click the "Sign in" button');
-  expect(aiCalled).toBe(false);
-  expect(executed.some((code) => code.includes("I.click"))).toBe(true);
+test('do runs a bounded AI loop over the instruction set', async () => {
+  const { prima } = fakePrima();
+  const prompts: string[] = [];
+  (prima as any).bot.getProvider = () => ({
+    startConversation: () => ({ addUserText: (t: string) => prompts.push(t) }),
+    invokeConversation: async () => ({ toolExecutions: [{ toolName: 'click', args: { locator: 'Login' }, result: { success: true, code: "I.click('Login')" } }] }),
+  });
+  const envelope = await prima.do(['open the first invoice', 'download its PDF']);
+  expect(prompts.join('\n')).toContain('open the first invoice');
+  expect(prompts.join('\n')).toContain('download its PDF');
+  expect(envelope.used).toEqual(["I.click('Login')"]);
   expect(envelope.ok).toBe(true);
+});
+
+test('click is a single-instruction alias over do', async () => {
+  const { prima } = fakePrima();
+  const received: string[][] = [];
+  (prima as any).do = async (instructions: string[]) => { received.push(instructions); return { ok: true }; };
+  await prima.click('the login link');
+  expect(received[0].length).toBe(1);
+  expect(received[0][0]).toContain('the login link');
 });
 
 test('verify returns verdict with assertion code', async () => {
@@ -699,11 +712,8 @@ test('ask with noVision answers from researcher summary', async () => {
 
 - [ ] **Step 3: Implement**
 
-- `do(instruction)`:
-  1. Fast path: quote-extract or word-match the instruction against `collectInteractiveNodes(state.ariaSnapshot)`; when exactly one node matches by name (case-insensitive) and the instruction's verb maps to that node's default interaction, execute `I.click('<name>')` / `I.fillField(...)` via `explorer.action().execute(...)` with zero AI. The matching must be generic (role vocabulary from `INTERACTIVE_ROLES`), never keyed to specific words from any one app.
-  2. Otherwise: bounded agentic call — `provider.invokeConversation(conversation, createCodeceptJSTools(explorer, ...), { maxToolRoundtrips: 3, toolChoice: 'required' })` with a dedent system prompt: current compact ARIA + the instruction + rule to perform exactly the instructed interaction and stop. Collect executed codes from the tool results (same shape the Driller reads).
-  3. Failures feed `heal(...)` from Task 5.
-- `click(target)` / `fill(field, value)`: call the corresponding tool object from `createCodeceptJSTools` directly (`tools.click.execute({ locator: target })` — read the tool's exact input schema in `src/ai/tools.ts` first and match it); ladder failures feed `heal`.
+- `do(instructions)`: tester-style bounded AI loop, no deterministic path (callers describe elements, they never hold locators — precision belongs to `pw`). One conversation via `provider.startConversation(...)` with a dedent system prompt: current compact ARIA + relevant experience TOC + the numbered instruction list + rule to perform the instructions in order and stop when done. Execute `provider.invokeConversation(conversation, createCodeceptJSTools(explorer, ...), { maxToolRoundtrips: 5 })` per iteration, re-injecting fresh page context between iterations when state changed (same pattern as Driller's bounded loop, `src/ai/driller.ts:325-329`), capped at `min(instructions.length + 2, 6)` iterations. Collect executed codes from tool results into `used`. Failures feed `heal(...)` from Task 5.
+- `click(target)`: alias — `this.do([`click ${target}`])`. `fill(field, value)`: alias — `this.do([`fill ${field} with value: ${value}`])`. Phrase construction must stay general (verb + caller's description verbatim), never enumerate app-specific element names.
 - `ask(question)`: vision by default — `researcher.answerQuestionAboutScreenshot(state, question)`; falls to the text path when `options.noVision` or `!provider.hasVision()` (`src/ai/provider.ts:635`; append a one-line note to the answer when degrading for the latter reason). Text path: `provider.chat` over dedent prompt containing `researcher.summary(state)` + compact ARIA + the question. Non-mutating: envelope has `answer`, no `changes`, artifacts still written.
 - `verify(assertion)`: `explorer.capture()` then `navigator.verifyState(assertion, actionResult)`; verdict `{ passed: verified, evidence: <first successful step or failure note>, code: successfulCodes.join('\n') }`.
 - `research(opts)`: `researcher.research(state, { screenshot: true, data: opts.data, deep: opts.deep, force: opts.fresh })` (`src/ai/researcher.ts:94`); envelope `research` = returned UI map verbatim (staleness banner included when cached), no `changes`. Non-mutating; artifacts still written.
@@ -850,7 +860,7 @@ git commit -m "feat: global config ladder and per-host state dirs"
 
 - [ ] **Step 1: Implement `boat/prima/src/cli.ts`**
 
-Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <fn>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `research` (flags `--data`, `--deep`, `--fresh`), `go <target>`, `browser <start|stop|status|list>`. Common options:
+Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <fn>`, `do <instructions...>` (variadic — each arg is one high-level instruction), `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `research` (flags `--data`, `--deep`, `--fresh`), `go <target>`, `browser <start|stop|status|list>`. Common options:
 
 ```
 -v, --verbose            --debug
@@ -866,7 +876,7 @@ Every action handler: `setPreserveConsoleLogs(true)`, build `Prima`, `await prim
 
 - [ ] **Step 2: Write the --help contract text**
 
-The command description plus `addHelpText('after', ...)` on the `prima` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise, click/fill = ladder, do = intent), the recommended loop (research once for verified locators → drive with pw → verify), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
+The command description plus `addHelpText('after', ...)` on the `prima` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise with a locator you hold, click/fill = one described action AI-resolved, do = a set of high-level instructions run tester-style — never pass locators to NL commands, never pass descriptions to pw), the recommended loop (research once for verified locators → drive with pw → verify; reach for do/click when you have no locator), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
 
 - [ ] **Step 3: Wire into main CLI and standalone bin**
 
@@ -901,7 +911,7 @@ git commit -m "feat(prima): prima CLI namespace and standalone prima bin"
 Scenarios, driven through the `Prima` class directly against the local fixture (real browser, no AI provider needed for these paths):
 1. `pw "({ page }) => page.click('text=Submit')"` on the fixture → `ok: true`, envelope contains `### Changes` and artifact files exist on disk.
 2. `pw` with a non-function argument → `ok: false`, `tool:`-prefixed error, exit path returns without browser action.
-3. `do 'click the "Submit" button'` → fast path, zero AI (assert no provider configured and it still works).
+3. `do`/`click` are NOT in the browser smoke (they always require a model) — cover them in `tests/integration/prima-do.test.ts` via aimock: mock model returns click tool calls for a two-instruction `do`, assert both instructions appear in the prompt, `used` collects executed codes, envelope `ok: true`.
 4. Instance autostart honored: run without a pre-started daemon; assert endpoint file appears.
 
 Heal-path e2e requires an AI provider — cover it with an aimock integration test in `tests/integration/prima-heal.test.ts` following `tests/integration/planner.test.ts` (mock provider returns a recovery instruction; assert `healed: true` envelope and `onAttempt` trace).

--- a/docs/superpowers/plans/2026-08-01-prima-boat.md
+++ b/docs/superpowers/plans/2026-08-01-prima-boat.md
@@ -414,7 +414,7 @@ export interface PrimaOptions {
   heal?: boolean;
   ephemeral?: boolean;
   framework?: 'codeceptjs' | 'playwright';
-  vision?: boolean;
+  noVision?: boolean;
   url?: string;
 }
 export class Prima {
@@ -675,8 +675,17 @@ test('research returns UI map in envelope', async () => {
   expect(envelope.ok).toBe(true);
 });
 
-test('ask without vision answers from researcher summary', async () => {
+test('ask defaults to vision via screenshot analysis', async () => {
   const { prima } = fakePrima();
+  (prima as any).bot.getProvider = () => ({ hasVision: () => true });
+  (prima as any).bot.agentResearcher = () => ({ answerQuestionAboutScreenshot: async () => 'A login page with an email form' });
+  const envelope = await prima.ask('what do I see?');
+  expect(envelope.answer).toContain('login');
+});
+
+test('ask with noVision answers from researcher summary', async () => {
+  const { prima } = fakePrima();
+  (prima as any).options.noVision = true;
   (prima as any).bot.agentResearcher = () => ({ summary: async () => 'Login form with email and password' });
   (prima as any).bot.getProvider = () => ({ chat: async () => ({ text: 'A login page with an email form' }) });
   const envelope = await prima.ask('what do I see?');
@@ -693,7 +702,7 @@ test('ask without vision answers from researcher summary', async () => {
   2. Otherwise: bounded agentic call — `provider.invokeConversation(conversation, createCodeceptJSTools(explorer, ...), { maxToolRoundtrips: 3, toolChoice: 'required' })` with a dedent system prompt: current compact ARIA + the instruction + rule to perform exactly the instructed interaction and stop. Collect executed codes from the tool results (same shape the Driller reads).
   3. Failures feed `heal(...)` from Task 5.
 - `click(target)` / `fill(field, value)`: call the corresponding tool object from `createCodeceptJSTools` directly (`tools.click.execute({ locator: target })` — read the tool's exact input schema in `src/ai/tools.ts` first and match it); ladder failures feed `heal`.
-- `ask(question)`: `options.vision` → `researcher.answerQuestionAboutScreenshot(state, question)`; otherwise `provider.chat` over dedent prompt containing `researcher.summary(state)` + compact ARIA + the question. Non-mutating: envelope has `answer`, no `changes`, artifacts still written.
+- `ask(question)`: vision by default — `researcher.answerQuestionAboutScreenshot(state, question)`; falls to the text path when `options.noVision` or `!provider.hasVision()` (`src/ai/provider.ts:635`; append a one-line note to the answer when degrading for the latter reason). Text path: `provider.chat` over dedent prompt containing `researcher.summary(state)` + compact ARIA + the question. Non-mutating: envelope has `answer`, no `changes`, artifacts still written.
 - `verify(assertion)`: `explorer.capture()` then `navigator.verifyState(assertion, actionResult)`; verdict `{ passed: verified, evidence: <first successful step or failure note>, code: successfulCodes.join('\n') }`.
 - `research(opts)`: `researcher.research(state, { screenshot: true, data: opts.data, deep: opts.deep, force: opts.fresh })` (`src/ai/researcher.ts:94`); envelope `research` = returned UI map verbatim (staleness banner included when cached), no `changes`. Non-mutating; artifacts still written.
 - All command methods end by building `used` from actually executed code (never the requested input when they differ).
@@ -766,13 +775,13 @@ git commit -m "feat(prima): go command and instance management"
 - Test: `tests/unit/config-ladder.test.ts`
 
 **Interfaces:**
-- Produces: `loadConfig` resolution order becomes: explicit `--config` path → project `explorbot.config.js|ts` in cwd → `~/.config/explorbot/config.js|ts` → env-var config (`buildEnvConfig`). `.env` loading order: cwd `.env` (existing behavior) then `~/.config/explorbot/.env` (only for keys not already set). New exported helper:
+- Produces: `loadConfig` resolution order becomes: explicit `--config` path → project `explorbot.config.js|ts` in cwd → `~/.explorbot/config.js|ts` → env-var config (`buildEnvConfig`). `.env` loading order: cwd `.env` (existing behavior) then `~/.explorbot/.env` (only for keys not already set). All home paths via `os.homedir()` — one cross-platform dir, no XDG/AppData branching. New exported helper:
 
 ```typescript
 export function resolveStateRoot(baseUrl: string, ephemeral?: boolean): string;
 ```
 
-returning `~/.local/state/explorbot/<host>/` (created), or a `mkdtempSync` temp dir when `ephemeral`.
+returning `~/.explorbot/state/<host>/` (created), or a `mkdtempSync` temp dir when `ephemeral`.
 
 - [ ] **Step 1: Read `src/config.ts` load path fully** (lines 297-560) before changing anything.
 
@@ -790,7 +799,7 @@ import { resolveStateRoot } from '../../src/config.ts';
 describe('resolveStateRoot', () => {
   test('derives persistent per-host dir', () => {
     const dir = resolveStateRoot('https://app.example.com/login');
-    expect(dir).toBe(path.join(os.homedir(), '.local', 'state', 'explorbot', 'app.example.com'));
+    expect(dir).toBe(path.join(os.homedir(), '.explorbot', 'state', 'app.example.com'));
     expect(existsSync(dir)).toBe(true);
   });
 
@@ -803,7 +812,7 @@ describe('resolveStateRoot', () => {
 });
 ```
 
-Global-config precedence test: point `ConfigParser.loadConfig` at a temp `HOME` (set `process.env.HOME` in the test, restore in `afterEach`), write `~/.config/explorbot/config.js` exporting a marker value, assert it loads when cwd has no project config and that a project config wins when both exist. Follow existing config tests in `tests/unit/` for how ConfigParser is instantiated.
+Global-config precedence test: point `ConfigParser.loadConfig` at a temp `HOME` (set `process.env.HOME` in the test, restore in `afterEach`; note `os.homedir()` ignores `$HOME` on Windows — gate the test or stub `homedir` if CI runs there), write `~/.explorbot/config.js` exporting a marker value, assert it loads when cwd has no project config and that a project config wins when both exist. Follow existing config tests in `tests/unit/` for how ConfigParser is instantiated.
 
 - [ ] **Step 3: Run, verify fail.**
 
@@ -811,7 +820,7 @@ Global-config precedence test: point `ConfigParser.loadConfig` at a temp `HOME` 
 
 - `resolveStateRoot`: host from `new URL(baseUrl).host`; `mkdirSync(..., { recursive: true })`; ephemeral via `mkdtempSync(path.join(os.tmpdir(), 'explorbot-'))`.
 - In `loadConfig`: after project-config lookup misses, try `path.join(os.homedir(), '.config', 'explorbot', 'config.js')` then `.ts` through the existing `loadConfigModule`.
-- `.env`: where the existing cwd `.env` loads, additionally load `~/.config/explorbot/.env` without overwriting already-set keys.
+- `.env`: where the existing cwd `.env` loads, additionally load `~/.explorbot/.env` without overwriting already-set keys.
 - In `buildEnvConfig` (config-free mode): when no project config, set `dirs` (knowledge/experience/output) under `resolveStateRoot(baseUrl, ephemeralFlag)`; ephemeral flag arrives via new `EXPLORBOT_EPHEMERAL` env var so the boat can pass it without new plumbing.
 
 - [ ] **Step 5: Run full unit suite** — `bun test tests/unit/` — PASS, no regressions.
@@ -846,7 +855,7 @@ Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOpti
 -c, --config <path>      -p, --path <path>
 -i, --instance <name>    --session [file]
 --no-heal                --ephemeral
---framework <name>       --vision   (ask only)
+--framework <name>       --no-vision   (ask only)
 --url <url>              (start page for config-free mode)
 ```
 

--- a/docs/superpowers/plans/2026-08-01-prima-boat.md
+++ b/docs/superpowers/plans/2026-08-01-prima-boat.md
@@ -60,6 +60,7 @@ export interface InstanceInfo {
   name: string;
   tabs: number;
   startedAgo?: string;
+  attached?: string;
   others: Array<{ name: string; tabs: number }>;
 }
 export interface HealAttempt {
@@ -212,6 +213,7 @@ Pure string building. Rules:
 - Page line: `url: <url>   (changed: <prev> → <url>)` only when previousUrl differs.
 - State line: `state: <state>            (visit #<visits>)`.
 - Instance line exactly as tested; `others` empty → `| other instances: none`.
+- When `attached` is set, the browser line renders `browser: attached (<attached>)` instead of the running/started form (add a render test: `attached: 'playwright-cli session "default", workspace /w'` → contains `browser: attached (playwright-cli session "default"`).
 - Network artifact written as JSONL (one `JSON.stringify` per request).
 - Every attempt line: `<n>. <code>` padded, then `→ <outcome>`.
 
@@ -501,7 +503,7 @@ Expected: FAIL — module not found.
 
 `boat/prima/src/prima.ts` responsibilities in this task:
 - Constructor stores options, builds `ExplorBot` options (`config`, `path`, `verbose`, `session`, `headless: true`) — but do NOT boot in constructor (DocBot pattern).
-- `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, launch via `launchServer` equivalent used by `explorbot browser start` (reuse, do not reimplement); then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`.
+- `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, launch via `launchServer` equivalent used by `explorbot browser start` (reuse, do not reimplement); then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`. (Task 11 retrofits the playwright-cli attach ladder in front of this daemon path — keep the daemon logic in a private method Task 11 can call as its fallback.)
 - `pw(expression)`:
   1. `isFunctionExpression` — invalid → return tool-error envelope (`ok: false`, `failure.error` prefixed `tool:`), never execute.
   2. Capture `before = stateManager.getCurrentState()`.
@@ -857,6 +859,7 @@ Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOpti
 --no-heal                --ephemeral
 --framework <name>       --no-vision   (ask only)
 --url <url>              (start page for config-free mode)
+--endpoint <ep>          --pw-session <title>   (attach to playwright-cli browser, Task 11)
 ```
 
 Every action handler: `setPreserveConsoleLogs(true)`, build `Prima`, `await prima.start()`, run the method, `console.log(renderEnvelope(result))`, `await prima.stop()`, `process.exit(result.ok ? 0 : 1)`. `--ephemeral` sets `process.env.EXPLORBOT_EPHEMERAL = '1'` before Prima construction. Zero business logic in handlers.
@@ -927,8 +930,171 @@ git commit -m "feat(prima): e2e smoke, docs and changelog"
 
 ---
 
+### Task 11: playwright-cli browser attach (Playwright-protocol registry)
+
+Prima's default browser source becomes the playwright-cli daemon's browser for this workspace; prima's own daemon is the fallback. Every playwright-cli daemon browser is auto-`bind()`-ed as a Playwright-protocol server with a descriptor JSON in `~/.cache/ms-playwright/b/<guid>` (Linux `$XDG_CACHE_HOME/ms-playwright/b` fallback `~/.cache/...`; macOS `~/Library/Caches/ms-playwright/b`; Windows `%LOCALAPPDATA%\ms-playwright\b`) shaped `{ playwrightVersion, playwrightLib, title, endpoint, workspaceDir, browser: { browserName } }` where `title` is the playwright-cli session name (`default` unless `-s=`/`PLAYWRIGHT_CLI_SESSION`).
+
+**Files:**
+- Create: `boat/prima/src/pw-registry.ts`
+- Modify: `boat/prima/src/actor.ts` (`start()` ladder), `boat/prima/src/cli.ts` (`--endpoint`, `--pw-session`), `src/explorer.ts` (attach path: adopt existing browser/context)
+- Test: `boat/prima/tests/pw-registry.test.ts`, `boat/prima/tests/prima.test.ts` (extend)
+
+**Interfaces:**
+- Consumes: `PrimaOptions` (Task 4) gains `endpoint?: string; pwSession?: string`; `InstanceInfo.attached` (Task 1); Explorer internals `playwrightHelper.browser` / `_createContextPage` (`src/explorer.ts:107,146` — Explorer already assigns `playwrightHelper.browser`, so injection is supported).
+- Produces:
+
+```typescript
+export interface PwServerDescriptor {
+  file: string;
+  title: string;
+  endpoint: string;
+  workspaceDir: string;
+  browserName: string;
+  playwrightLib: string;
+}
+export function registryDir(): string;
+export function readDescriptors(dir?: string): PwServerDescriptor[];
+export function selectDescriptor(descriptors: PwServerDescriptor[], opts: { workspaceDir: string; title?: string }): { match?: PwServerDescriptor; candidates: PwServerDescriptor[] };
+```
+
+- [ ] **Step 1: Write failing registry tests**
+
+`boat/prima/tests/pw-registry.test.ts`:
+
+```typescript
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { readDescriptors, selectDescriptor } from '../src/pw-registry.ts';
+
+function writeDescriptor(dir: string, name: string, data: Record<string, unknown>) {
+  writeFileSync(path.join(dir, name), JSON.stringify({ playwrightVersion: '1.62.0', playwrightLib: '/lib/pw', endpoint: `/tmp/pw/${name}.sock`, browser: { browserName: 'chromium' }, ...data }));
+}
+
+describe('readDescriptors', () => {
+  test('parses descriptor files and skips malformed ones', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'pwb-'));
+    writeDescriptor(dir, 'a', { title: 'default', workspaceDir: '/work/app' });
+    writeFileSync(path.join(dir, 'broken'), 'not json');
+    const list = readDescriptors(dir);
+    expect(list.length).toBe(1);
+    expect(list[0].title).toBe('default');
+    expect(list[0].browserName).toBe('chromium');
+  });
+});
+
+describe('selectDescriptor', () => {
+  const dir = mkdtempSync(path.join(tmpdir(), 'pwb-'));
+  writeDescriptor(dir, 'a', { title: 'default', workspaceDir: '/work/app' });
+  writeDescriptor(dir, 'b', { title: 'auth', workspaceDir: '/work/app' });
+  writeDescriptor(dir, 'c', { title: 'default', workspaceDir: '/work/other' });
+  const all = readDescriptors(dir);
+
+  test('explicit title wins within workspace', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/app', title: 'auth' });
+    expect(match?.title).toBe('auth');
+  });
+
+  test('default title picked for workspace when present', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/app' });
+    expect(match?.title).toBe('default');
+  });
+
+  test('single survivor for workspace picked without title', () => {
+    const { match } = selectDescriptor(all, { workspaceDir: '/work/other' });
+    expect(match?.workspaceDir).toBe('/work/other');
+  });
+
+  test('no workspace match returns candidates empty', () => {
+    const { match, candidates } = selectDescriptor(all, { workspaceDir: '/elsewhere' });
+    expect(match).toBeUndefined();
+    expect(candidates.length).toBe(0);
+  });
+
+  test('ambiguity returns no match with candidates listed', () => {
+    const noDefault = all.filter((d) => d.title !== 'default');
+    const extra = [...noDefault, { ...noDefault[0], title: 'second' }];
+    const { match, candidates } = selectDescriptor(extra, { workspaceDir: '/work/app' });
+    expect(match).toBeUndefined();
+    expect(candidates.length).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify fail** — `bun test boat/prima/tests/pw-registry.test.ts`.
+
+- [ ] **Step 3: Implement `pw-registry.ts`**
+
+- `registryDir()`: per-OS cache root (`process.platform`: darwin → `~/Library/Caches/ms-playwright/b`; win32 → `path.join(process.env.LOCALAPPDATA ?? path.join(os.homedir(), 'AppData', 'Local'), 'ms-playwright', 'b')`; else `path.join(process.env.XDG_CACHE_HOME ?? path.join(os.homedir(), '.cache'), 'ms-playwright', 'b')`).
+- `readDescriptors(dir = registryDir())`: `readdirSync` (return `[]` when dir missing), JSON.parse each file, skip on parse error or missing `endpoint`/`title`/`workspaceDir`, map to `PwServerDescriptor`.
+- `selectDescriptor`: filter by `workspaceDir` (compare `path.resolve` of both); explicit title → exact match; no title → prefer `title === 'default'`, else single survivor; ambiguity or explicit-title miss → `{ candidates }` with no match.
+
+- [ ] **Step 4: Run, verify pass; commit**
+
+```bash
+bun run format
+git add boat/prima/src/pw-registry.ts boat/prima/tests/pw-registry.test.ts
+git commit -m "feat(prima): playwright-cli browser-server registry discovery"
+```
+
+- [ ] **Step 5: Write failing attach-ladder test in `prima.test.ts`**
+
+```typescript
+test('start attaches to workspace playwright-cli browser before own daemon', async () => {
+  const prima = new Prima({});
+  const calls: string[] = [];
+  (prima as any).discover = () => ({ match: { title: 'default', endpoint: '/tmp/pw/a.sock', workspaceDir: process.cwd(), browserName: 'chromium', playwrightLib: '/lib/pw', file: 'a' }, candidates: [] });
+  (prima as any).attachToEndpoint = async (d: unknown) => { calls.push('attach'); };
+  (prima as any).startOwnDaemon = async () => { calls.push('daemon'); };
+  await prima.start();
+  expect(calls).toEqual(['attach']);
+});
+
+test('start falls back to own daemon when nothing attachable', async () => {
+  const prima = new Prima({});
+  const calls: string[] = [];
+  (prima as any).discover = () => ({ candidates: [] });
+  (prima as any).attachToEndpoint = async () => { calls.push('attach'); };
+  (prima as any).startOwnDaemon = async () => { calls.push('daemon'); };
+  await prima.start();
+  expect(calls).toEqual(['daemon']);
+});
+
+test('ambiguous sessions surface as tool error listing candidates', async () => {
+  const prima = new Prima({});
+  (prima as any).discover = () => ({ candidates: [{ title: 'auth' }, { title: 'smoke' }] });
+  await expect(prima.start()).rejects.toThrow(/auth.*smoke|smoke.*auth/);
+});
+```
+
+- [ ] **Step 6: Run, verify fail; implement the ladder in `Prima.start()`**
+
+Order: `options.endpoint` (skip discovery, attach directly) → `discover()` = `selectDescriptor(readDescriptors(), { workspaceDir: resolved cwd, title: options.pwSession ?? process.env.PLAYWRIGHT_CLI_SESSION })` → match → `attachToEndpoint(descriptor)` → no match, candidates non-empty → throw Error listing candidate titles (CLI renders it as a `tool:` failure envelope) → no candidates → `startOwnDaemon()` (Task 4's daemon logic, extracted private method). Record attachment description for `InstanceInfo.attached` (`playwright-cli session "<title>", workspace <dir>`).
+
+`attachToEndpoint(descriptor)`:
+- Liveness probe: attempt `playwright[descriptor.browserName].connect(descriptor.endpoint, { timeout: 3000 })` with our own playwright-core import; on handshake/version failure, retry once with `require(descriptor.playwrightLib)` (daemon's own lib — the version-skew escape playwright-cli itself uses); on both failing, treat descriptor as dead and continue the ladder.
+- Inject into Explorer: assign the connected browser to `playwrightHelper.browser` and adopt the browser's existing default context and its last open page instead of `_createContextPage()` (add an Explorer attach path beside `src/explorer.ts:107`; keep it the smallest change that skips context creation and skips `storageState` — `--session` is ignored in attached mode).
+- Lifecycle guards: mark `this.attachedExternally = true`; `stop()`/`browserStop()` call `browser.close()`, which for a `connect()`ed browser is documented as disconnect-only ("clears all created contexts belonging to this browser and disconnects from the browser server" — pre-existing contexts survive; since prima adopts the existing context rather than creating one, nothing of the shared browser is torn down). Never remove registry/endpoint files. Add a unit test asserting `stop()` in attached mode does not invoke the daemon-kill path.
+
+- [ ] **Step 7: Run all boat tests** — `bun test boat/prima/tests/` — PASS.
+
+- [ ] **Step 8: Wire CLI flags and help**
+
+`--endpoint <ep>` and `--pw-session <title>` in `addCommonOptions` (Task 9); extend `browser list` output with attachable playwright-cli sessions from `readDescriptors()` for this workspace; extend the `--help` contract text: prima attaches to the workspace's playwright-cli browser by default — mixed playwright-cli + prima workflows on the same tabs are the intended usage.
+
+- [ ] **Step 9: Commit**
+
+```bash
+bun run format
+git add boat/prima src/explorer.ts
+git commit -m "feat(prima): attach to playwright-cli browser via protocol registry"
+```
+
+---
+
 ## Self-Review Notes
 
-- Spec coverage: pw/do/click/fill/ask/verify+assert/research/go (Tasks 4-7, 9), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
+- Spec coverage: pw/do/click/fill/ask/verify+assert/research/go (Tasks 4-7, 9), playwright-cli attach ladder + `--endpoint`/`--pw-session` + attached lifecycle (Task 11), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
 - Vision `ask` degrades to text path when no `visionModel` configured (`provider.hasVision()`, `src/ai/provider.ts:635`) — implementer: guard in `ask`.
 - Type consistency: `EnvelopeData`/`InstanceInfo`/`HealAttempt` defined once in Task 1 and only consumed elsewhere; `PrimaOptions` defined in Task 4 and consumed by 9.

--- a/docs/superpowers/plans/2026-08-01-prima-boat.md
+++ b/docs/superpowers/plans/2026-08-01-prima-boat.md
@@ -1,23 +1,23 @@
-# Actor Boat Implementation Plan
+# Prima Boat Implementation Plan
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Ship `boat/actor` — an intent-level browser driver CLI (`explorbot act ...`) that lets an orchestrating agent act on pages via Playwright calls or natural language while explorbot's cheap models handle perception, healing, and evidence.
+**Goal:** Ship `boat/prima` — an intent-level browser driver CLI (`explorbot prima ...`) that lets an orchestrating agent act on pages via Playwright calls or natural language while explorbot's cheap models handle perception, healing, and evidence.
 
-**Architecture:** A boat following the `boat/doc-collector` pattern: `Actor` class wraps `ExplorBot`, reuses Navigator/Researcher/Explorer/StateManager, adds a pure envelope renderer and a pw function wrapper. Core changes are minimal: named browser-server instances, a Navigator heal-attempt hook, and a global-config/per-host-state ladder in config loading.
+**Architecture:** A boat following the `boat/doc-collector` pattern: `Prima` class wraps `ExplorBot`, reuses Navigator/Researcher/Explorer/StateManager, adds a pure envelope renderer and a pw function wrapper. Core changes are minimal: named browser-server instances, a Navigator heal-attempt hook, and a global-config/per-host-state ladder in config loading.
 
-**Tech Stack:** Bun (never Node), TypeScript, commander, CodeceptJS/Playwright via Explorer, `bun:test`, Biome.
+**Tech Stack:** TypeScript on Bun (Node.js supported through the package build step), commander, CodeceptJS/Playwright via Explorer, `bun:test`, Biome.
 
-**Spec:** `docs/superpowers/specs/2026-08-01-actor-boat-design.md` — read it first.
+**Spec:** `docs/superpowers/specs/2026-08-01-prima-boat-design.md` — read it first.
 
 **Execution model:** Run implementation subagents on Opus (user directive).
 
 ## Global Constraints
 
-- Bun only; never Node.js APIs where Bun equivalents exist; tests via `bun:test`.
+- Tests via `bun:test`; keep sources compatible with the existing package build step (`dist/` output runs on Node.js, `bun` condition points at `src/` — see `docs/contributing/npm-package.md`).
 - No code comments unless explicitly specified; premature exit over if/else; no ternary operators; no `...(cond ? {} : {})` spreads; `?.` over `&&` chains; private methods after public; types at end of file; `dedent` for prompts.
 - Prompts and tool descriptions must be GENERAL — never encode a specific failing example.
-- Business logic lives in the `Actor` class / agents; CLI handlers only parse options and delegate (repo rule).
+- Business logic lives in the `Prima` class / agents; CLI handlers only parse options and delegate (repo rule).
 - Run `bun run format` after each code change; `bun run lint:fix` after big ones.
 - Clean stdout: respect `EXPLORBOT_NO_BANNER`; envelope output goes to `console.log`, logs go through `tag()` logger.
 - DO NOT duplicate existing code — reuse `src/utils/aria.ts`, `src/action-result.ts`, `src/browser-server.ts`, Historian converters.
@@ -25,23 +25,23 @@
 ## File Structure
 
 ```
-boat/actor/
-├── package.json               # name "actbot", bin actbot
-├── bin/actbot-cli.ts          # standalone CLI entry
+boat/prima/
+├── package.json               # name "prima", bin prima
+├── bin/prima-cli.ts          # standalone CLI entry
 ├── src/
-│   ├── cli.ts                 # createActCommands(name = 'act')
-│   ├── actor.ts               # Actor class (all business logic)
+│   ├── cli.ts                 # createPrimaCommands(name = 'prima')
+│   ├── prima.ts               # Prima class (all business logic)
 │   ├── envelope.ts            # EnvelopeData type, renderEnvelope(), writeArtifacts()
 │   └── pw-parser.ts           # isFunctionExpression(), toCodeceptWrapper()
 └── tests/
     ├── envelope.test.ts
     ├── pw-parser.test.ts
-    └── actor.test.ts          # duck-typed ExplorBot mocks
+    └── prima.test.ts          # duck-typed ExplorBot mocks
 Core modifications:
 ├── src/browser-server.ts      # named instances (endpoint file per instance)
 ├── src/ai/navigator.ts        # resolveState onAttempt hook (small)
 ├── src/config.ts              # global config + global .env + per-host state dir
-└── bin/explorbot-cli.ts       # program.addCommand(createActCommands('act'))
+└── bin/explorbot-cli.ts       # program.addCommand(createPrimaCommands('prima'))
 ```
 
 ---
@@ -49,8 +49,8 @@ Core modifications:
 ### Task 1: Envelope module
 
 **Files:**
-- Create: `boat/actor/package.json`, `boat/actor/src/envelope.ts`
-- Test: `boat/actor/tests/envelope.test.ts`
+- Create: `boat/prima/package.json`, `boat/prima/src/envelope.ts`
+- Test: `boat/prima/tests/envelope.test.ts`
 
 **Interfaces:**
 - Produces (used by Tasks 3–7 and 9):
@@ -87,15 +87,15 @@ export function writeArtifacts(dir: string, snapshot: { aria: string | null; htm
 
 - [ ] **Step 1: Scaffold the boat package**
 
-`boat/actor/package.json` (mirror `boat/api-tester/package.json` shape):
+`boat/prima/package.json` (mirror `boat/api-tester/package.json` shape):
 
 ```json
 {
-  "name": "actbot",
+  "name": "prima",
   "version": "1.0.0",
   "description": "High-level browser driver CLI for orchestrating agents",
   "type": "module",
-  "bin": { "actbot": "./bin/actbot-cli.ts" },
+  "bin": { "prima": "./bin/prima-cli.ts" },
   "scripts": {
     "format": "biome format --write .",
     "lint:fix": "biome lint --write .",
@@ -110,7 +110,7 @@ export function writeArtifacts(dir: string, snapshot: { aria: string | null; htm
 
 - [ ] **Step 2: Write failing envelope tests**
 
-`boat/actor/tests/envelope.test.ts`:
+`boat/prima/tests/envelope.test.ts`:
 
 ```typescript
 import { describe, expect, test } from 'bun:test';
@@ -188,7 +188,7 @@ describe('renderEnvelope', () => {
 
 describe('writeArtifacts', () => {
   test('writes aria, html and network files and returns absolute paths', () => {
-    const dir = mkdtempSync(path.join(tmpdir(), 'act-'));
+    const dir = mkdtempSync(path.join(tmpdir(), 'prima-'));
     const result = writeArtifacts(dir, { aria: '- button "Login"', html: '<html></html>', requests: [{ url: '/api/user', status: 200 }] });
     expect(readFileSync(result.aria, 'utf-8')).toContain('button "Login"');
     expect(readFileSync(result.html, 'utf-8')).toContain('<html>');
@@ -200,10 +200,10 @@ describe('writeArtifacts', () => {
 
 - [ ] **Step 3: Run tests, verify they fail**
 
-Run: `bun test boat/actor/tests/envelope.test.ts`
+Run: `bun test boat/prima/tests/envelope.test.ts`
 Expected: FAIL — cannot resolve `../src/envelope.ts`.
 
-- [ ] **Step 4: Implement `boat/actor/src/envelope.ts`**
+- [ ] **Step 4: Implement `boat/prima/src/envelope.ts`**
 
 Pure string building. Rules:
 - Sections always in order: Result, Page, then exactly one of Changes/Answer/Verdict (Changes only when `changes` is a non-empty string), Failure + Healing attempts + Current page (only when `failure` set), Instance, Artifacts (only when set).
@@ -219,15 +219,15 @@ Keep it one exported function plus small private helpers below it; no classes.
 
 - [ ] **Step 5: Run tests, verify pass**
 
-Run: `bun test boat/actor/tests/envelope.test.ts`
+Run: `bun test boat/prima/tests/envelope.test.ts`
 Expected: PASS (7 tests).
 
 - [ ] **Step 6: Format and commit**
 
 ```bash
 bun run format
-git add boat/actor
-git commit -m "feat(actor): boat scaffold and result envelope"
+git add boat/prima
+git commit -m "feat(prima): boat scaffold and result envelope"
 ```
 
 ---
@@ -237,8 +237,8 @@ git commit -m "feat(actor): boat scaffold and result envelope"
 The `pw` argument is a function expression in the exact shape `I.usePlaywrightTo` accepts — `({ page, browserContext, browser }) => ...` — so callers destructure whichever Playwright objects they need. The parser only answers "is this a parseable function expression" (for clean `tool:` errors) and interpolates it verbatim into the CodeceptJS call that `Action.execute` expects.
 
 **Files:**
-- Create: `boat/actor/src/pw-parser.ts`
-- Test: `boat/actor/tests/pw-parser.test.ts`
+- Create: `boat/prima/src/pw-parser.ts`
+- Test: `boat/prima/tests/pw-parser.test.ts`
 
 **Interfaces:**
 - Produces (used by Task 4):
@@ -250,7 +250,7 @@ export function toCodeceptWrapper(expr: string): string;
 
 - [ ] **Step 1: Write failing tests**
 
-`boat/actor/tests/pw-parser.test.ts`:
+`boat/prima/tests/pw-parser.test.ts`:
 
 ```typescript
 import { describe, expect, test } from 'bun:test';
@@ -289,10 +289,10 @@ describe('toCodeceptWrapper', () => {
 
 - [ ] **Step 2: Run tests, verify fail**
 
-Run: `bun test boat/actor/tests/pw-parser.test.ts`
+Run: `bun test boat/prima/tests/pw-parser.test.ts`
 Expected: FAIL — module not found.
 
-- [ ] **Step 3: Implement `boat/actor/src/pw-parser.ts`**
+- [ ] **Step 3: Implement `boat/prima/src/pw-parser.ts`**
 
 ```typescript
 const FUNCTION_SHAPE = /^(async\s+)?(function\b|\()/;
@@ -318,15 +318,15 @@ export function toCodeceptWrapper(expr: string): string {
 
 - [ ] **Step 4: Run tests, verify pass**
 
-Run: `bun test boat/actor/tests/pw-parser.test.ts`
+Run: `bun test boat/prima/tests/pw-parser.test.ts`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 bun run format
-git add boat/actor/src/pw-parser.ts boat/actor/tests/pw-parser.test.ts
-git commit -m "feat(actor): pw function wrapper"
+git add boat/prima/src/pw-parser.ts boat/prima/tests/pw-parser.test.ts
+git commit -m "feat(prima): pw function wrapper"
 ```
 
 ---
@@ -394,18 +394,18 @@ git commit -m "feat: named browser server instances"
 
 ---
 
-### Task 4: Actor class core — lifecycle and pw command
+### Task 4: Prima class core — lifecycle and pw command
 
 **Files:**
-- Create: `boat/actor/src/actor.ts`
-- Test: `boat/actor/tests/actor.test.ts`
+- Create: `boat/prima/src/prima.ts`
+- Test: `boat/prima/tests/prima.test.ts`
 
 **Interfaces:**
 - Consumes: `renderEnvelope`/`writeArtifacts`/`EnvelopeData`/`InstanceInfo` (Task 1), `isFunctionExpression`/`toCodeceptWrapper` (Task 2), `getAliveEndpoint(instance)`/`launchServer` (Task 3), `ExplorBot` API (`src/explorbot.ts`: `start()`, `stop()`, `visit(url)`, `getExplorer()`, `stateManager()`, `getCurrentState()`, `agentNavigator()`, `agentResearcher()`, `agentHistorian()`, `requestStore()`), `Explorer.action(): Action` (`src/explorer.ts:151`), `Action.execute(code)` / `Action.capturePageState()` (`src/action.ts:64-68`), `ActionResult` (`getStateHash()`, `ariaSnapshot`, `combinedHtml()`, `url`, `title`), `compactAriaSnapshot` (`src/utils/aria.ts`), `Diff`/`PageDiff` via `ActionResult` (`src/action-result.ts`).
 - Produces (used by Tasks 5–7, 9):
 
 ```typescript
-export interface ActorOptions {
+export interface PrimaOptions {
   verbose?: boolean;
   config?: string;
   path?: string;
@@ -417,8 +417,8 @@ export interface ActorOptions {
   vision?: boolean;
   url?: string;
 }
-export class Actor {
-  constructor(options?: ActorOptions);
+export class Prima {
+  constructor(options?: PrimaOptions);
   async start(): Promise<void>;
   async stop(): Promise<void>;
   async pw(expression: string): Promise<EnvelopeData>;
@@ -426,15 +426,15 @@ export class Actor {
 }
 ```
 
-- [ ] **Step 1: Study `boat/doc-collector/src/docbot.ts`** — the Actor mirrors how DocBot wraps ExplorBot (constructor builds `new ExplorBot({...})`, `start()` boots it, agents accessed lazily).
+- [ ] **Step 1: Study `boat/doc-collector/src/docbot.ts`** — the Prima mirrors how DocBot wraps ExplorBot (constructor builds `new ExplorBot({...})`, `start()` boots it, agents accessed lazily).
 
 - [ ] **Step 2: Write failing tests with duck-typed mocks**
 
-`boat/actor/tests/actor.test.ts` — follow the duck-type-mock style of `tests/integration/` (mock Explorer/StateManager, no real browser):
+`boat/prima/tests/prima.test.ts` — follow the duck-type-mock style of `tests/integration/` (mock Explorer/StateManager, no real browser):
 
 ```typescript
 import { describe, expect, test } from 'bun:test';
-import { Actor } from '../src/actor.ts';
+import { Prima } from '../src/prima.ts';
 
 function fakeState(over: Record<string, unknown> = {}) {
   return {
@@ -447,11 +447,11 @@ function fakeState(over: Record<string, unknown> = {}) {
   };
 }
 
-function fakeActor() {
-  const actor = new Actor({ instance: 'default' });
+function fakePrima() {
+  const prima = new Prima({ instance: 'default' });
   const executed: string[] = [];
   const after = fakeState({ url: 'https://app.example.com/dashboard', title: 'Dashboard', getStateHash: () => 'dashboard_h1_dashboard' });
-  (actor as any).bot = {
+  (prima as any).bot = {
     getExplorer: () => ({
       action: () => ({
         execute: async (code: string) => {
@@ -467,22 +467,22 @@ function fakeActor() {
     }),
     requestStore: () => ({ getRequests: () => [] }),
   };
-  (actor as any).artifactsDir = '/tmp/act-test';
-  return { actor, executed };
+  (prima as any).artifactsDir = '/tmp/prima-test';
+  return { prima, executed };
 }
 
-describe('Actor.pw', () => {
+describe('Prima.pw', () => {
   test('rejects non-function argument as tool error without executing', async () => {
-    const { actor, executed } = fakeActor();
-    const envelope = await actor.pw("page.click('text=Login')");
+    const { prima, executed } = fakePrima();
+    const envelope = await prima.pw("page.click('text=Login')");
     expect(envelope.ok).toBe(false);
     expect(envelope.failure?.error).toContain('function');
     expect(executed.length).toBe(0);
   });
 
   test('executes wrapped function and returns success envelope data', async () => {
-    const { actor, executed } = fakeActor();
-    const envelope = await actor.pw("({ page }) => page.click('text=Login')");
+    const { prima, executed } = fakePrima();
+    const envelope = await prima.pw("({ page }) => page.click('text=Login')");
     expect(executed[0]).toContain("I.usePlaywrightTo");
     expect(envelope.ok).toBe(true);
     expect(envelope.used).toEqual(["({ page }) => page.click('text=Login')"]);
@@ -494,12 +494,12 @@ describe('Actor.pw', () => {
 
 - [ ] **Step 3: Run tests, verify fail**
 
-Run: `bun test boat/actor/tests/actor.test.ts`
+Run: `bun test boat/prima/tests/prima.test.ts`
 Expected: FAIL — module not found.
 
-- [ ] **Step 4: Implement Actor core**
+- [ ] **Step 4: Implement Prima core**
 
-`boat/actor/src/actor.ts` responsibilities in this task:
+`boat/prima/src/prima.ts` responsibilities in this task:
 - Constructor stores options, builds `ExplorBot` options (`config`, `path`, `verbose`, `session`, `headless: true`) — but do NOT boot in constructor (DocBot pattern).
 - `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, launch via `launchServer` equivalent used by `explorbot browser start` (reuse, do not reimplement); then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`.
 - `pw(expression)`:
@@ -510,21 +510,21 @@ Expected: FAIL — module not found.
   5. Write artifacts via `writeArtifacts(this.nextArtifactDir(), { aria: result.ariaSnapshot, html: result.combinedHtml(), requests: this.bot.requestStore().getRequests() })`.
   6. On execution error: this task returns a plain failure envelope (heal comes in Task 5).
 - `instanceInfo()`: name from options; tabs from `explorer` playwright context pages count (add a small public accessor if none exists — check `src/explorer.ts:79` `playwrightHelper?.page`); others from `listInstances()` (Task 3) excluding self; tabs for others may be reported as 0 when unreachable — do not connect to other instances.
-- `nextArtifactDir()`: `<output>/act/<ISO-timestamp>/`, one per command invocation.
+- `nextArtifactDir()`: `<output>/prima/<ISO-timestamp>/`, one per command invocation.
 
 Mockability rule: everything the tests stub lives behind `this.bot` — keep all ExplorBot access via that single field.
 
 - [ ] **Step 5: Run tests, verify pass**
 
-Run: `bun test boat/actor/tests/`
+Run: `bun test boat/prima/tests/`
 Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 bun run format
-git add boat/actor
-git commit -m "feat(actor): Actor core with pw execution and instance info"
+git add boat/prima
+git commit -m "feat(prima): Prima core with pw execution and instance info"
 ```
 
 ---
@@ -532,25 +532,25 @@ git commit -m "feat(actor): Actor core with pw execution and instance info"
 ### Task 5: Heal loop
 
 **Files:**
-- Modify: `src/ai/navigator.ts:192` (`resolveState` signature), `boat/actor/src/actor.ts`
-- Test: `boat/actor/tests/actor.test.ts` (extend), `tests/integration/` untouched
+- Modify: `src/ai/navigator.ts:192` (`resolveState` signature), `boat/prima/src/prima.ts`
+- Test: `boat/prima/tests/prima.test.ts` (extend), `tests/integration/` untouched
 
 **Interfaces:**
 - Consumes: `navigator.resolveState(message, actionResult, opts)` (`src/ai/navigator.ts:192`).
-- Produces: `resolveState` opts gains `onAttempt?: (attempt: { code: string; error?: string }) => void`, invoked once per executed recovery attempt with the exact code string and the error message when it failed. Actor gains private `heal(...)` used by pw (and Task 6 commands).
+- Produces: `resolveState` opts gains `onAttempt?: (attempt: { code: string; error?: string }) => void`, invoked once per executed recovery attempt with the exact code string and the error message when it failed. Prima gains private `heal(...)` used by pw (and Task 6 commands).
 
 - [ ] **Step 1: Extend `resolveState` with the attempt hook**
 
 Read `src/ai/navigator.ts` `resolveState` implementation; find where recovery code executes (each `action.execute`/attempt site). Add `opts.onAttempt` invocation at each attempt completion with `{ code, error: lastError?.message }`. Smallest change possible; no behavior change when the callback is absent.
 
-- [ ] **Step 2: Write failing Actor heal test**
+- [ ] **Step 2: Write failing Prima heal test**
 
-Extend `boat/actor/tests/actor.test.ts`; stub `agentNavigator` on the fake bot:
+Extend `boat/prima/tests/prima.test.ts`; stub `agentNavigator` on the fake bot:
 
 ```typescript
 test('failed pw heals via navigator and reports healed envelope', async () => {
-  const { actor } = fakeActor();
-  (actor as any).bot.getExplorer = () => ({
+  const { prima } = fakePrima();
+  (prima as any).bot.getExplorer = () => ({
     action: () => ({
       execute: async () => {
         throw new Error("locator 'text=Login' not found");
@@ -558,22 +558,22 @@ test('failed pw heals via navigator and reports healed envelope', async () => {
     }),
     capture: async () => fakeState(),
   });
-  (actor as any).bot.agentNavigator = () => ({
+  (prima as any).bot.agentNavigator = () => ({
     resolveState: async (_msg: string, _result: unknown, opts: any) => {
       opts?.onAttempt?.({ code: "I.click('Login')", error: 'not visible' });
       opts?.onAttempt?.({ code: "I.click('#login-btn')" });
       return true;
     },
   });
-  const envelope = await actor.pw("({ page }) => page.click('text=Login')");
+  const envelope = await prima.pw("({ page }) => page.click('text=Login')");
   expect(envelope.ok).toBe(true);
   expect(envelope.healed).toBe(true);
   expect(envelope.used).toEqual(["I.click('#login-btn')"]);
 });
 
 test('exhausted heal returns failure envelope with attempts and compact aria', async () => {
-  const { actor } = fakeActor();
-  (actor as any).bot.getExplorer = () => ({
+  const { prima } = fakePrima();
+  (prima as any).bot.getExplorer = () => ({
     action: () => ({
       execute: async () => {
         throw new Error("locator 'text=Login' not found");
@@ -581,13 +581,13 @@ test('exhausted heal returns failure envelope with attempts and compact aria', a
     }),
     capture: async () => fakeState(),
   });
-  (actor as any).bot.agentNavigator = () => ({
+  (prima as any).bot.agentNavigator = () => ({
     resolveState: async (_msg: string, _result: unknown, opts: any) => {
       opts?.onAttempt?.({ code: "I.click('Login')", error: 'not visible' });
       return false;
     },
   });
-  const envelope = await actor.pw("({ page }) => page.click('text=Login')");
+  const envelope = await prima.pw("({ page }) => page.click('text=Login')");
   expect(envelope.ok).toBe(false);
   expect(envelope.failure?.attempts.length).toBe(1);
   expect(envelope.failure?.compactAria).toContain('button');
@@ -596,10 +596,10 @@ test('exhausted heal returns failure envelope with attempts and compact aria', a
 
 - [ ] **Step 3: Run tests, verify fail**
 
-Run: `bun test boat/actor/tests/actor.test.ts`
+Run: `bun test boat/prima/tests/prima.test.ts`
 Expected: new tests FAIL (heal not implemented).
 
-- [ ] **Step 4: Implement heal in Actor**
+- [ ] **Step 4: Implement heal in Prima**
 
 Private `heal(errorMessage, actionResult, originalCode)`:
 - Skip entirely when `options.heal === false` — go straight to failure envelope.
@@ -610,15 +610,15 @@ Private `heal(errorMessage, actionResult, originalCode)`:
 
 - [ ] **Step 5: Run boat tests and repo unit tests**
 
-Run: `bun test boat/actor/tests/ tests/unit/`
+Run: `bun test boat/prima/tests/ tests/unit/`
 Expected: PASS.
 
 - [ ] **Step 6: Commit**
 
 ```bash
 bun run format
-git add src/ai/navigator.ts boat/actor
-git commit -m "feat(actor): heal loop over navigator recovery with attempt trace"
+git add src/ai/navigator.ts boat/prima
+git commit -m "feat(prima): heal loop over navigator recovery with attempt trace"
 ```
 
 ---
@@ -626,8 +626,8 @@ git commit -m "feat(actor): heal loop over navigator recovery with attempt trace
 ### Task 6: do, click, fill, ask, verify, research commands
 
 **Files:**
-- Modify: `boat/actor/src/actor.ts`
-- Test: `boat/actor/tests/actor.test.ts` (extend)
+- Modify: `boat/prima/src/prima.ts`
+- Test: `boat/prima/tests/prima.test.ts` (extend)
 
 **Interfaces:**
 - Consumes: `collectInteractiveNodes(snapshot)` (`src/utils/aria.ts`), `createCodeceptJSTools` (`src/ai/tools.ts:30`) — tool objects expose `.execute(input)`; `provider.invokeConversation` with `maxToolRoundtrips` (Driller pattern, `src/ai/driller.ts:325-329`); `researcher.answerQuestionAboutScreenshot(state, question)` and `researcher.summary(state)` (`src/ai/researcher.ts:544, 659`); `navigator.verifyState(message, actionResult)` (`src/ai/navigator.ts:618`) returning `{ verified, successfulCodes, assertionSteps, totalAttempted }`.
@@ -648,43 +648,43 @@ async research(opts?: { data?: boolean; deep?: boolean; fresh?: boolean }): Prom
 
 ```typescript
 test('do with unambiguous role+name executes without AI', async () => {
-  const { actor, executed } = fakeActor();
+  const { prima, executed } = fakePrima();
   let aiCalled = false;
-  (actor as any).bot.getProvider = () => ({ invokeConversation: async () => { aiCalled = true; } });
-  const envelope = await actor.do('click the "Sign in" button');
+  (prima as any).bot.getProvider = () => ({ invokeConversation: async () => { aiCalled = true; } });
+  const envelope = await prima.do('click the "Sign in" button');
   expect(aiCalled).toBe(false);
   expect(executed.some((code) => code.includes("I.click"))).toBe(true);
   expect(envelope.ok).toBe(true);
 });
 
 test('verify returns verdict with assertion code', async () => {
-  const { actor } = fakeActor();
-  (actor as any).bot.agentNavigator = () => ({
+  const { prima } = fakePrima();
+  (prima as any).bot.agentNavigator = () => ({
     verifyState: async () => ({ verified: true, successfulCodes: ["I.see('Dashboard')"], assertionSteps: [], totalAttempted: 1 }),
   });
-  const envelope = await actor.verify('user sees the dashboard');
+  const envelope = await prima.verify('user sees the dashboard');
   expect(envelope.verdict?.passed).toBe(true);
   expect(envelope.verdict?.code).toBe("I.see('Dashboard')");
 });
 
 test('research returns UI map in envelope', async () => {
-  const { actor } = fakeActor();
-  (actor as any).bot.agentResearcher = () => ({ research: async () => '## Section: Login Form\n| Element | ARIA | CSS |' });
-  const envelope = await actor.research({ data: true });
+  const { prima } = fakePrima();
+  (prima as any).bot.agentResearcher = () => ({ research: async () => '## Section: Login Form\n| Element | ARIA | CSS |' });
+  const envelope = await prima.research({ data: true });
   expect(envelope.research).toContain('Login Form');
   expect(envelope.ok).toBe(true);
 });
 
 test('ask without vision answers from researcher summary', async () => {
-  const { actor } = fakeActor();
-  (actor as any).bot.agentResearcher = () => ({ summary: async () => 'Login form with email and password' });
-  (actor as any).bot.getProvider = () => ({ chat: async () => ({ text: 'A login page with an email form' }) });
-  const envelope = await actor.ask('what do I see?');
+  const { prima } = fakePrima();
+  (prima as any).bot.agentResearcher = () => ({ summary: async () => 'Login form with email and password' });
+  (prima as any).bot.getProvider = () => ({ chat: async () => ({ text: 'A login page with an email form' }) });
+  const envelope = await prima.ask('what do I see?');
   expect(envelope.answer).toContain('login');
 });
 ```
 
-- [ ] **Step 2: Run tests, verify fail** — `bun test boat/actor/tests/actor.test.ts`.
+- [ ] **Step 2: Run tests, verify fail** — `bun test boat/prima/tests/prima.test.ts`.
 
 - [ ] **Step 3: Implement**
 
@@ -698,14 +698,14 @@ test('ask without vision answers from researcher summary', async () => {
 - `research(opts)`: `researcher.research(state, { screenshot: true, data: opts.data, deep: opts.deep, force: opts.fresh })` (`src/ai/researcher.ts:94`); envelope `research` = returned UI map verbatim (staleness banner included when cached), no `changes`. Non-mutating; artifacts still written.
 - All command methods end by building `used` from actually executed code (never the requested input when they differ).
 
-- [ ] **Step 4: Run tests, verify pass** — `bun test boat/actor/tests/`.
+- [ ] **Step 4: Run tests, verify pass** — `bun test boat/prima/tests/`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 bun run format
-git add boat/actor
-git commit -m "feat(actor): do, click, fill, ask, verify commands"
+git add boat/prima
+git commit -m "feat(prima): do, click, fill, ask, verify commands"
 ```
 
 ---
@@ -713,8 +713,8 @@ git commit -m "feat(actor): do, click, fill, ask, verify commands"
 ### Task 7: go command and browser instance management
 
 **Files:**
-- Modify: `boat/actor/src/actor.ts`
-- Test: `boat/actor/tests/actor.test.ts` (extend)
+- Modify: `boat/prima/src/prima.ts`
+- Test: `boat/prima/tests/prima.test.ts` (extend)
 
 **Interfaces:**
 - Consumes: `navigator.visit(destination)` (`src/ai/navigator.ts:140` — handles both URLs and NL/state destinations, same call the TUI `/navigate` uses per `src/commands/navigate-command.ts`), Task 3 instance functions.
@@ -731,10 +731,10 @@ async browserStatus(): Promise<string>;
 
 ```typescript
 test('go delegates to navigator.visit and returns envelope', async () => {
-  const { actor } = fakeActor();
+  const { prima } = fakePrima();
   const visited: string[] = [];
-  (actor as any).bot.agentNavigator = () => ({ visit: async (dest: string) => { visited.push(dest); } });
-  const envelope = await actor.go('billing settings');
+  (prima as any).bot.agentNavigator = () => ({ visit: async (dest: string) => { visited.push(dest); } });
+  const envelope = await prima.go('billing settings');
   expect(visited).toEqual(['billing settings']);
   expect(envelope.ok).toBe(true);
   expect(envelope.page.url).toBeTruthy();
@@ -753,8 +753,8 @@ test('go delegates to navigator.visit and returns envelope', async () => {
 
 ```bash
 bun run format
-git add boat/actor
-git commit -m "feat(actor): go command and instance management"
+git add boat/prima
+git commit -m "feat(prima): go command and instance management"
 ```
 
 ---
@@ -829,15 +829,15 @@ git commit -m "feat: global config ladder and per-host state dirs"
 ### Task 9: CLI wiring and --help contract
 
 **Files:**
-- Create: `boat/actor/src/cli.ts`, `boat/actor/bin/actbot-cli.ts`
-- Modify: `bin/explorbot-cli.ts` (add near line 874: `program.addCommand(createActCommands('act'))`)
+- Create: `boat/prima/src/cli.ts`, `boat/prima/bin/prima-cli.ts`
+- Modify: `bin/explorbot-cli.ts` (add near line 874: `program.addCommand(createPrimaCommands('prima'))`)
 - Test: manual smoke via `--help` (Step 4)
 
 **Interfaces:**
-- Consumes: `Actor`/`ActorOptions` (Tasks 4-7), `renderEnvelope` (Task 1).
-- Produces: `export function createActCommands(name = 'act'): Command`.
+- Consumes: `Prima`/`PrimaOptions` (Tasks 4-7), `renderEnvelope` (Task 1).
+- Produces: `export function createPrimaCommands(name = 'prima'): Command`.
 
-- [ ] **Step 1: Implement `boat/actor/src/cli.ts`**
+- [ ] **Step 1: Implement `boat/prima/src/cli.ts`**
 
 Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOptions`, subcommands). Subcommands: `pw <fn>`, `do <instruction>`, `click <target>`, `fill <field> <value>`, `ask <question>`, `verify <assertion>` (alias `assert`), `research` (flags `--data`, `--deep`, `--fresh`), `go <target>`, `browser <start|stop|status|list>`. Common options:
 
@@ -850,28 +850,28 @@ Mirror `boat/doc-collector/src/cli.ts` structure (`addCommonOptions`, `buildOpti
 --url <url>              (start page for config-free mode)
 ```
 
-Every action handler: `setPreserveConsoleLogs(true)`, build `Actor`, `await actor.start()`, run the method, `console.log(renderEnvelope(result))`, `await actor.stop()`, `process.exit(result.ok ? 0 : 1)`. `--ephemeral` sets `process.env.EXPLORBOT_EPHEMERAL = '1'` before Actor construction. Zero business logic in handlers.
+Every action handler: `setPreserveConsoleLogs(true)`, build `Prima`, `await prima.start()`, run the method, `console.log(renderEnvelope(result))`, `await prima.stop()`, `process.exit(result.ok ? 0 : 1)`. `--ephemeral` sets `process.env.EXPLORBOT_EPHEMERAL = '1'` before Prima construction. Zero business logic in handlers.
 
 - [ ] **Step 2: Write the --help contract text**
 
-The command description plus `addHelpText('after', ...)` on the `act` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise, click/fill = ladder, do = intent), the recommended loop (research once for verified locators → drive with pw → verify), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
+The command description plus `addHelpText('after', ...)` on the `prima` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise, click/fill = ladder, do = intent), the recommended loop (research once for verified locators → drive with pw → verify), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
 
 - [ ] **Step 3: Wire into main CLI and standalone bin**
 
-- `bin/explorbot-cli.ts`: `import { createActCommands } from '../boat/actor/src/cli.ts';` + `program.addCommand(createActCommands('act'));` next to the existing api/docs registrations (line ~874).
-- `boat/actor/bin/actbot-cli.ts`: mirror `boat/api-tester/bin` entry — a commander program that mounts the same subcommands at top level.
+- `bin/explorbot-cli.ts`: `import { createPrimaCommands } from '../boat/prima/src/cli.ts';` + `program.addCommand(createPrimaCommands('prima'));` next to the existing api/docs registrations (line ~874).
+- `boat/prima/bin/prima-cli.ts`: mirror `boat/api-tester/bin` entry — a commander program that mounts the same subcommands at top level.
 
 - [ ] **Step 4: Smoke the help output**
 
-Run: `bun bin/explorbot-cli.ts act --help` and `bun boat/actor/bin/actbot-cli.ts --help`
+Run: `bun bin/explorbot-cli.ts prima --help` and `bun boat/prima/bin/prima-cli.ts --help`
 Expected: full contract text, all 8 subcommands listed, no banner noise with `EXPLORBOT_NO_BANNER=1`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 bun run format && bun run lint:fix
-git add boat/actor bin/explorbot-cli.ts
-git commit -m "feat(actor): act CLI namespace and standalone actbot bin"
+git add boat/prima bin/explorbot-cli.ts
+git commit -m "feat(prima): prima CLI namespace and standalone prima bin"
 ```
 
 ---
@@ -879,29 +879,29 @@ git commit -m "feat(actor): act CLI namespace and standalone actbot bin"
 ### Task 10: End-to-end smoke, changelog, docs
 
 **Files:**
-- Create: `tests/node/actor-smoke.test.ts` (or `tests/regression/` — match where existing browser-driving tests live; inspect both dirs first)
+- Create: `tests/node/prima-smoke.test.ts` (or `tests/regression/` — match where existing browser-driving tests live; inspect both dirs first)
 - Modify: `docs/reference/commands.md`, `CHANGELOG.md` (via `/changelog` skill at commit time)
 
 - [ ] **Step 1: Inspect existing e2e/browser test setup** — `tests/node/` and `tests/regression/` — reuse their fixture-server pattern for a local page (a form with a button and an input; fictional content only).
 
 - [ ] **Step 2: Write the smoke test**
 
-Scenarios, driven through the `Actor` class directly against the local fixture (real browser, no AI provider needed for these paths):
+Scenarios, driven through the `Prima` class directly against the local fixture (real browser, no AI provider needed for these paths):
 1. `pw "({ page }) => page.click('text=Submit')"` on the fixture → `ok: true`, envelope contains `### Changes` and artifact files exist on disk.
 2. `pw` with a non-function argument → `ok: false`, `tool:`-prefixed error, exit path returns without browser action.
 3. `do 'click the "Submit" button'` → fast path, zero AI (assert no provider configured and it still works).
 4. Instance autostart honored: run without a pre-started daemon; assert endpoint file appears.
 
-Heal-path e2e requires an AI provider — cover it with an aimock integration test in `tests/integration/actor-heal.test.ts` following `tests/integration/planner.test.ts` (mock provider returns a recovery instruction; assert `healed: true` envelope and `onAttempt` trace).
+Heal-path e2e requires an AI provider — cover it with an aimock integration test in `tests/integration/prima-heal.test.ts` following `tests/integration/planner.test.ts` (mock provider returns a recovery instruction; assert `healed: true` envelope and `onAttempt` trace).
 
 - [ ] **Step 3: Run everything**
 
-Run: `bun test boat/actor/tests/ tests/unit/ tests/integration/` plus the smoke file.
+Run: `bun test boat/prima/tests/ tests/unit/ tests/integration/` plus the smoke file.
 Expected: all PASS.
 
 - [ ] **Step 4: Document**
 
-Add an "Actor boat" section to `docs/reference/commands.md`: command table, envelope sample, tiering guidance, instance/session flags, config-free example (`EXPLORBOT_AI_PROVIDER=groq explorbot act go https://app.example.com`).
+Add an "Prima boat" section to `docs/reference/commands.md`: command table, envelope sample, tiering guidance, instance/session flags, config-free example (`EXPLORBOT_AI_PROVIDER=groq explorbot prima go https://app.example.com`).
 
 - [ ] **Step 5: Final checks and commit**
 
@@ -913,7 +913,7 @@ Invoke the `/changelog` skill, then:
 
 ```bash
 git add -A
-git commit -m "feat(actor): e2e smoke, docs and changelog"
+git commit -m "feat(prima): e2e smoke, docs and changelog"
 ```
 
 ---
@@ -922,4 +922,4 @@ git commit -m "feat(actor): e2e smoke, docs and changelog"
 
 - Spec coverage: pw/do/click/fill/ask/verify+assert/research/go (Tasks 4-7, 9), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
 - Vision `ask` degrades to text path when no `visionModel` configured (`provider.hasVision()`, `src/ai/provider.ts:635`) — implementer: guard in `ask`.
-- Type consistency: `EnvelopeData`/`InstanceInfo`/`HealAttempt` defined once in Task 1 and only consumed elsewhere; `ActorOptions` defined in Task 4 and consumed by 9.
+- Type consistency: `EnvelopeData`/`InstanceInfo`/`HealAttempt` defined once in Task 1 and only consumed elsewhere; `PrimaOptions` defined in Task 4 and consumed by 9.

--- a/docs/superpowers/plans/2026-08-01-prima-boat.md
+++ b/docs/superpowers/plans/2026-08-01-prima-boat.md
@@ -503,7 +503,7 @@ Expected: FAIL — module not found.
 
 `boat/prima/src/prima.ts` responsibilities in this task:
 - Constructor stores options, builds `ExplorBot` options (`config`, `path`, `verbose`, `session`, `headless: true`) — but do NOT boot in constructor (DocBot pattern).
-- `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, launch via `launchServer` equivalent used by `explorbot browser start` (reuse, do not reimplement); then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`. (Task 11 retrofits the playwright-cli attach ladder in front of this daemon path — keep the daemon logic in a private method Task 11 can call as its fallback.)
+- `start()`: resolve instance endpoint via `getAliveEndpoint(this.options.instance ?? 'default')`; when absent, throw an Error instructing the caller to create a session first — start one with playwright-cli (`playwright-cli open <url>`) or `prima browser start` (the CLI renders it as a `tool:` failure envelope, exit 1). NEVER launch a browser implicitly. Then `await this.bot.start()`. When `options.url` is set and no current state exists, `await this.bot.visit(options.url)`. (Task 11 retrofits the playwright-cli attach ladder in front of this owned-instance path — keep the owned-instance lookup in a private method Task 11 calls late in its ladder.)
 - `pw(expression)`:
   1. `isFunctionExpression` — invalid → return tool-error envelope (`ok: false`, `failure.error` prefixed `tool:`), never execute.
   2. Capture `before = stateManager.getCurrentState()`.
@@ -605,6 +605,7 @@ Expected: new tests FAIL (heal not implemented).
 
 Private `heal(errorMessage, actionResult, originalCode)`:
 - Skip entirely when `options.heal === false` — go straight to failure envelope.
+- Skip with an envelope note (`healed: false (ai unavailable)`) when no AI provider is usable — `pw` must keep working without AI.
 - Collect attempts array via `onAttempt`; call `navigator.resolveState(errorMessage, actionResult, { onAttempt })`.
 - `true` → success envelope: `healed: true`, `healNote` = last attempt outcome summary, `used` = codes of successful attempts (last attempt without error), current state re-read from `stateManager.getCurrentState()`.
 - `false` → failure envelope: `error`, `attempts` (map error→outcome, success→'ok'), `compactAria` from `compactAriaSnapshot(state.ariaSnapshot, true)` (`src/utils/aria.ts`), reasoning left to Task 8's compaction if trivial — set `reasoning` to a one-line join of distinct outcomes for now (general, not model-generated).
@@ -714,6 +715,7 @@ test('ask with noVision answers from researcher summary', async () => {
 
 - `do(instructions)`: tester-style bounded AI loop, no deterministic path (callers describe elements, they never hold locators — precision belongs to `pw`). One conversation via `provider.startConversation(...)` with a dedent system prompt: current compact ARIA + relevant experience TOC + the numbered instruction list + rule to perform the instructions in order and stop when done. Execute `provider.invokeConversation(conversation, createCodeceptJSTools(explorer, ...), { maxToolRoundtrips: 5 })` per iteration, re-injecting fresh page context between iterations when state changed (same pattern as Driller's bounded loop, `src/ai/driller.ts:325-329`), capped at `min(instructions.length + 2, 6)` iterations. Collect executed codes from tool results into `used`. Failures feed `heal(...)` from Task 5.
 - `click(target)`: alias — `this.do([`click ${target}`])`. `fill(field, value)`: alias — `this.do([`fill ${field} with value: ${value}`])`. Phrase construction must stay general (verb + caller's description verbatim), never enumerate app-specific element names.
+- AI-availability guard: every model-requiring command (`do`, `click`, `fill`, `ask`, `verify`, `research`, intent-`go`) checks provider availability first (provider construction failed, or no model configured — surface the underlying reason from `bot.getProvider()`/config); on failure return a tool-error envelope whose message states the reason and suggests the fallback: use playwright-cli for direct browser control, or fix AI config (`~/.explorbot/config.js` / `EXPLORBOT_AI_PROVIDER`). Add a test: provider getter throws → `do` returns `ok: false` with error containing 'playwright-cli'. The message must describe the failure layer generally — never hardcode a specific provider's error text.
 - `ask(question)`: vision by default — `researcher.answerQuestionAboutScreenshot(state, question)`; falls to the text path when `options.noVision` or `!provider.hasVision()` (`src/ai/provider.ts:635`; append a one-line note to the answer when degrading for the latter reason). Text path: `provider.chat` over dedent prompt containing `researcher.summary(state)` + compact ARIA + the question. Non-mutating: envelope has `answer`, no `changes`, artifacts still written.
 - `verify(assertion)`: `explorer.capture()` then `navigator.verifyState(assertion, actionResult)`; verdict `{ passed: verified, evidence: <first successful step or failure note>, code: successfulCodes.join('\n') }`.
 - `research(opts)`: `researcher.research(state, { screenshot: true, data: opts.data, deep: opts.deep, force: opts.fresh })` (`src/ai/researcher.ts:94`); envelope `research` = returned UI map verbatim (staleness banner included when cached), no `changes`. Non-mutating; artifacts still written.
@@ -768,7 +770,7 @@ test('go delegates to navigator.visit and returns envelope', async () => {
 
 - `go(target)`: `navigator.visit(target)` (it resolves URL vs intent internally); envelope from resulting state; navigation errors feed `heal`.
 - `browserStart/Stop/Status`: thin delegation to Task 3's browser-server functions with `options.instance`; `browserStop(true)` iterates `listInstances()`. Status string includes what `instanceInfo()` knows.
-- Autostart: already in `start()` (Task 4) — verify `go` path hits it when no daemon runs; with `options.session` set, the launched context loads storage state (Explorer already honors `session` — `src/explorer.ts:106,337`).
+- No implicit launch: verify `go` (like every command) fails with the create-a-session guidance when no browser is available. `browserStart()` is the only launch path; with `options.session` set there, the launched context loads storage state (Explorer already honors `session` — `src/explorer.ts:106,337`).
 
 - [ ] **Step 4: Run tests, verify pass; commit**
 
@@ -876,7 +878,7 @@ Every action handler: `setPreserveConsoleLogs(true)`, build `Prima`, `await prim
 
 - [ ] **Step 2: Write the --help contract text**
 
-The command description plus `addHelpText('after', ...)` on the `prima` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise with a locator you hold, click/fill = one described action AI-resolved, do = a set of high-level instructions run tester-style — never pass locators to NL commands, never pass descriptions to pw), the recommended loop (research once for verified locators → drive with pw → verify; reach for do/click when you have no locator), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, autostart behavior, the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
+The command description plus `addHelpText('after', ...)` on the `prima` group is the sole teaching surface for orchestrating agents. It must compactly cover (dedent block, ~40 lines): the tiering (pw = precise with a locator you hold, click/fill = one described action AI-resolved, do = a set of high-level instructions run tester-style — never pass locators to NL commands, never pass descriptions to pw), the recommended loop (research once for verified locators → drive with pw → verify; reach for do/click when you have no locator), the envelope sections and their meaning, `used:` as reusable verified code, heal semantics and `--no-heal`, failure = inline compact ARIA + artifact file paths for deep dives, `--instance` vs `--session`, the no-implicit-launch rule (create sessions via playwright-cli or `prima browser start`), the AI-unavailable fallback (use playwright-cli directly), the close-when-finished convention driven by `### Instance`, and one usage example per tier. General shapes only — no app-specific examples.
 
 - [ ] **Step 3: Wire into main CLI and standalone bin**
 
@@ -912,7 +914,8 @@ Scenarios, driven through the `Prima` class directly against the local fixture (
 1. `pw "({ page }) => page.click('text=Submit')"` on the fixture → `ok: true`, envelope contains `### Changes` and artifact files exist on disk.
 2. `pw` with a non-function argument → `ok: false`, `tool:`-prefixed error, exit path returns without browser action.
 3. `do`/`click` are NOT in the browser smoke (they always require a model) — cover them in `tests/integration/prima-do.test.ts` via aimock: mock model returns click tool calls for a two-instruction `do`, assert both instructions appear in the prompt, `used` collects executed codes, envelope `ok: true`.
-4. Instance autostart honored: run without a pre-started daemon; assert endpoint file appears.
+4. No implicit launch: run without any browser session → failure envelope containing the create-a-session guidance (`playwright-cli open` mentioned), exit code 1, and no endpoint file created.
+5. `pw` with no AI provider configured: executes normally, envelope notes healing unavailable.
 
 Heal-path e2e requires an AI provider — cover it with an aimock integration test in `tests/integration/prima-heal.test.ts` following `tests/integration/planner.test.ts` (mock provider returns a recovery instruction; assert `healed: true` envelope and `onAttempt` trace).
 
@@ -1056,19 +1059,26 @@ test('start attaches to workspace playwright-cli browser before own daemon', asy
   const calls: string[] = [];
   (prima as any).discover = () => ({ match: { title: 'default', endpoint: '/tmp/pw/a.sock', workspaceDir: process.cwd(), browserName: 'chromium', playwrightLib: '/lib/pw', file: 'a' }, candidates: [] });
   (prima as any).attachToEndpoint = async (d: unknown) => { calls.push('attach'); };
-  (prima as any).startOwnDaemon = async () => { calls.push('daemon'); };
+  (prima as any).connectOwnInstance = async () => { calls.push('own'); return true; };
   await prima.start();
   expect(calls).toEqual(['attach']);
 });
 
-test('start falls back to own daemon when nothing attachable', async () => {
+test('start uses explicitly started own instance when nothing attachable', async () => {
   const prima = new Prima({});
   const calls: string[] = [];
   (prima as any).discover = () => ({ candidates: [] });
   (prima as any).attachToEndpoint = async () => { calls.push('attach'); };
-  (prima as any).startOwnDaemon = async () => { calls.push('daemon'); };
+  (prima as any).connectOwnInstance = async () => { calls.push('own'); return true; };
   await prima.start();
-  expect(calls).toEqual(['daemon']);
+  expect(calls).toEqual(['own']);
+});
+
+test('start fails with playwright-cli guidance when no session exists anywhere', async () => {
+  const prima = new Prima({});
+  (prima as any).discover = () => ({ candidates: [] });
+  (prima as any).connectOwnInstance = async () => false;
+  await expect(prima.start()).rejects.toThrow(/playwright-cli open/);
 });
 
 test('ambiguous sessions surface as tool error listing candidates', async () => {
@@ -1080,7 +1090,7 @@ test('ambiguous sessions surface as tool error listing candidates', async () => 
 
 - [ ] **Step 6: Run, verify fail; implement the ladder in `Prima.start()`**
 
-Order: `options.endpoint` (skip discovery, attach directly) → `discover()` = `selectDescriptor(readDescriptors(), { workspaceDir: resolved cwd, title: options.pwSession ?? process.env.PLAYWRIGHT_CLI_SESSION })` → match → `attachToEndpoint(descriptor)` → no match, candidates non-empty → throw Error listing candidate titles (CLI renders it as a `tool:` failure envelope) → no candidates → `startOwnDaemon()` (Task 4's daemon logic, extracted private method). Record attachment description for `InstanceInfo.attached` (`playwright-cli session "<title>", workspace <dir>`).
+Order: `options.endpoint` (skip discovery, attach directly) → `discover()` = `selectDescriptor(readDescriptors(), { workspaceDir: resolved cwd, title: options.pwSession ?? process.env.PLAYWRIGHT_CLI_SESSION })` → match → `attachToEndpoint(descriptor)` → no match, candidates non-empty → throw Error listing candidate titles (CLI renders it as a `tool:` failure envelope) → no candidates → `connectOwnInstance()` (Task 4's alive-endpoint lookup, extracted private method returning boolean; it never launches) → false → throw Error with the create-a-session guidance naming `playwright-cli open <url>` first and `prima browser start` second. Record attachment description for `InstanceInfo.attached` (`playwright-cli session "<title>", workspace <dir>`).
 
 `attachToEndpoint(descriptor)`:
 - Liveness probe: attempt `playwright[descriptor.browserName].connect(descriptor.endpoint, { timeout: 3000 })` with our own playwright-core import; on handshake/version failure, retry once with `require(descriptor.playwrightLib)` (daemon's own lib — the version-skew escape playwright-cli itself uses); on both failing, treat descriptor as dead and continue the ladder.
@@ -1105,6 +1115,6 @@ git commit -m "feat(prima): attach to playwright-cli browser via protocol regist
 
 ## Self-Review Notes
 
-- Spec coverage: pw/do/click/fill/ask/verify+assert/research/go (Tasks 4-7, 9), playwright-cli attach ladder + `--endpoint`/`--pw-session` + attached lifecycle (Task 11), envelope + used code (1, 4), heal + attempt trace + `--no-heal` (5), instances + autostart + `--session` reuse (3, 4, 7), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
+- Spec coverage: pw/do/click/fill/ask/verify+assert/research/go (Tasks 4-7, 9), playwright-cli attach ladder + `--endpoint`/`--pw-session` + attached lifecycle (Task 11), envelope + used code (1, 4), heal + attempt trace + `--no-heal` + ai-unavailable skip (5), instances + no-implicit-launch + `--session` reuse (3, 4, 7), AI-unavailable fallback guidance (6), config-free ladder + per-host state + `--ephemeral` (8), `--help`-only discovery (9), testing incl. aimock heal test (10). Framework flag (`--framework`) is parsed (9) and stored (4); Historian-based conversion of `used:` into Playwright dialect is deliberately deferred until `used` collection stabilizes — v1 emits the executed CodeceptJS (pw commands echo the Playwright expression itself), which satisfies "actual used locator" for both dialect inputs. If reviewers want full conversion in v1, extend Task 6 with `historian.toPlaywrightCode` per `src/ai/historian/playwright.ts:21`.
 - Vision `ask` degrades to text path when no `visionModel` configured (`provider.hasVision()`, `src/ai/provider.ts:635`) — implementer: guard in `ask`.
 - Type consistency: `EnvelopeData`/`InstanceInfo`/`HealAttempt` defined once in Task 1 and only consumed elsewhere; `PrimaOptions` defined in Task 4 and consumed by 9.

--- a/docs/superpowers/specs/2026-08-01-actor-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-actor-boat-design.md
@@ -44,7 +44,7 @@ Registered in `bin/explorbot-cli.ts` via `program.addCommand(createActCommands('
 ## Command Surface
 
 ```
-explorbot act pw "page.click('text=Login')"   # raw Playwright call, healed on failure
+explorbot act pw "({ page }) => page.click('text=Login')"   # raw Playwright fn, healed on failure
 explorbot act do "click the login link"        # NL action via Navigator
 explorbot act click "Login"                    # targeted click via existing fallback ladder
 explorbot act fill "Search" "wireless mouse"   # targeted fill via existing ladder
@@ -67,7 +67,7 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 
 ### Execution paths
 
-- **pw**: expression validated as a `page.*` call chain (no arbitrary JS), executed against the daemon's Playwright page through the Explorer/Action pipeline so state capture, ariaDiff, and experience recording come for free. Deterministic and near-instant on the happy path.
+- **pw**: the argument is a function expression in the exact shape `I.usePlaywrightTo` accepts — `({ page, browserContext, browser }) => ...` — checked only for being a parseable function, then interpolated directly into `I.usePlaywrightTo('pw', <fn>)` and executed through the Explorer/Action pipeline so state capture, ariaDiff, and experience recording come for free. Destructure whichever Playwright objects the call needs. Deterministic and near-instant on the happy path.
 - **do**: one bounded Navigator invocation (max ~3 tool roundtrips) reusing the existing click/type/form tool ladders. Deterministic fast path first: if the instruction resolves to exactly one interactive ARIA node by role+name, execute with zero AI calls.
 - **click / fill**: the existing multi-fallback ladders directly (text → ARIA → experience candidates); cheap-model disambiguation only when multiple candidates match.
 - **ask**: Researcher answers from current compact ARIA / cached UI map; `--vision` routes through the vision model. Non-mutating.
@@ -90,7 +90,7 @@ The uniform response contract: every command prints the same block structure in 
 ```
 ### Result
 ok: true
-command: pw page.click('text=Login')
+command: pw ({ page }) => page.click('text=Login')
 healed: false
 used: I.click('Login')
 

--- a/docs/superpowers/specs/2026-08-01-actor-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-actor-boat-design.md
@@ -49,6 +49,7 @@ explorbot act do "click the login link"        # NL action via Navigator
 explorbot act click "Login"                    # targeted click via existing fallback ladder
 explorbot act fill "Search" "wireless mouse"   # targeted fill via existing ladder
 explorbot act ask "what do I see here?"        # cheap-model page Q&A via Researcher
+explorbot act research [--data] [--deep] [--fresh]  # verified UI map for precise pw driving
 explorbot act verify "user is logged in"       # AI assertion (alias: assert)
 explorbot act go "billing settings"            # URL or NL navigation
 explorbot act browser start|stop|status|list   # instance management (stop --all)
@@ -71,6 +72,7 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 - **do**: one bounded Navigator invocation (max ~3 tool roundtrips) reusing the existing click/type/form tool ladders. Deterministic fast path first: if the instruction resolves to exactly one interactive ARIA node by role+name, execute with zero AI calls.
 - **click / fill**: the existing multi-fallback ladders directly (text → ARIA → experience candidates); cheap-model disambiguation only when multiple candidates match.
 - **ask**: Researcher answers from current compact ARIA / cached UI map; `--vision` routes through the vision model. Non-mutating.
+- **research**: `researcher.research(state, { screenshot: true, data, deep, force })`. The envelope's `### Research` section carries the UI map inline — it is the deliverable: verified, live-tested locators that let the orchestrator drive `pw` precisely without reading raw ARIA. `--data` adds extracted data sections, `--deep` deep analysis, `--fresh` bypasses the cache; cached results keep the existing staleness banner. Non-mutating.
 - **verify / assert**: `navigator.verifyState()` on the cheap model; verdict plus the assertion code that proved it.
 - **go**: URL-shaped input navigates directly; intent-shaped input uses Navigator's stateful navigation with visited-state history and knowledge. Autostarts the instance like every other command.
 
@@ -118,7 +120,7 @@ network: <abs path>/output/act/<ts>/network.jsonl
 ```
 
 - `used:` — the exact code that worked (healed form when healed), rendered in the configured framework via Historian's converters. Sessions thereby double as a verified-locator oracle for test generation.
-- `### Changes` becomes `### Answer` for `ask` and `### Verdict` (pass/fail + evidence line + assertion code) for `verify`.
+- `### Changes` becomes `### Answer` for `ask`, `### Verdict` (pass/fail + evidence line + assertion code) for `verify`, and `### Research` (the UI map, inline) for `research`.
 - `### Instance` appears on every response — tab counts and other live instances — so the orchestrator sees leftover state and knows to close it when finished.
 - Artifact paths are always absolute; full HTML, full ARIA, and the network log are always written, never inlined.
 
@@ -198,4 +200,5 @@ Experience accumulates per target host across runs from any directory — zero-s
 - Persistent per-host state dir by default in config-free mode; `--ephemeral` for temp.
 - `used:` code in envelope via Historian converters; `verify` exposes assertion code.
 - click/fill exposed as ladder-backed sugar; select/pressKey/hover/drag stay behind `pw`.
+- `research` exposed with `--data`/`--deep`/`--fresh`; UI map inline as the deliverable (verified locators enable precise `pw` driving).
 - Implementation runs on Opus.

--- a/docs/superpowers/specs/2026-08-01-actor-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-actor-boat-design.md
@@ -1,0 +1,201 @@
+# Actor Boat — High-Level Browser Driver for Orchestrating Agents
+
+**Date:** 2026-08-01
+**Status:** Draft for review
+**Implementation model:** Opus
+
+## Problem
+
+Coding agents (Claude Code on Opus/Fable) drive browsers through playwright-cli or Playwright MCP. Every action forces page state (aria snapshots) into the orchestrator's context: the expensive model pays to read the tree, pick a ref, and re-read after every step, and each snapshot stays in conversation history compounding cost for the rest of the session. A 20-step flow means 20+ expensive perception roundtrips.
+
+Explorbot already owns the layers that fix this: cheap-model perception (Navigator, Researcher), semantic diffs (ariaDiff, pageDiff), state tracking, and experience replay. The Actor boat exposes those layers as an intent-level CLI so the orchestrator sends instructions and receives compact evidence — page data never enters the expensive context on the happy path.
+
+## Goals
+
+- Orchestrator issues precise Playwright calls or natural-language instructions; explorbot's cheap models run the perception–action micro-loop.
+- Every response is a uniform envelope: evidence of what happened, never a raw page dump.
+- Failures exhaust cheap healing first, then return a compacted investigation so the orchestrator can drop down a level and drive directly.
+- Zero project setup: works from any directory via env vars and a global user config, with per-host persistent state.
+- Every successful action reports the exact code that worked, so sessions double as verified-locator material for test generation.
+
+## Non-Goals
+
+- Not a replacement for playwright-cli as a general browser tool.
+- No MCP server, no SKILL.md package in v1 — the contract is taught entirely by `--help` text.
+- No new core agents unless heal orchestration proves to need one (then it lives inside the boat).
+
+## Architecture
+
+A boat, following the existing `boat/api-tester` / `boat/doc-collector` pattern:
+
+```
+boat/actor/
+├── package.json          # name: "actbot", own bin
+├── bin/actbot-cli.ts     # standalone CLI
+└── src/
+    ├── cli.ts            # createActCommands('act') → composed into main CLI
+    ├── actor.ts          # Actor class wrapping ExplorBot (like DocBot)
+    ├── envelope.ts       # result envelope: inline render + artifact files
+    └── config.ts
+```
+
+Registered in `bin/explorbot-cli.ts` via `program.addCommand(createActCommands('act'))`. The `Actor` class wraps `ExplorBot`, reusing `agentNavigator()`, `agentResearcher()`, `stateManager()`, Historian, and the Explorer/Action capture pipeline. Business logic lives in the Actor class and agents; CLI handlers stay thin, per repo convention.
+
+## Command Surface
+
+```
+explorbot act pw "page.click('text=Login')"   # raw Playwright call, healed on failure
+explorbot act do "click the login link"        # NL action via Navigator
+explorbot act click "Login"                    # targeted click via existing fallback ladder
+explorbot act fill "Search" "wireless mouse"   # targeted fill via existing ladder
+explorbot act ask "what do I see here?"        # cheap-model page Q&A via Researcher
+explorbot act verify "user is logged in"       # AI assertion (alias: assert)
+explorbot act go "billing settings"            # URL or NL navigation
+explorbot act browser start|stop|status|list   # instance management (stop --all)
+```
+
+Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with deterministic fallback ladders (AI only on ambiguity), `do` = intent (cheap-model planning). `select`, `pressKey`, `hover`, `drag` intentionally stay behind `pw` — a subcommand without a ladder is surface without value.
+
+### Common flags
+
+- `--instance <name>` / `-i` — which named browser daemon to talk to. Default instance otherwise.
+- `--session [file]` — existing auth-session semantics; an autostarted instance launches with the saved cookies/storage state.
+- `--no-heal` — fail fast without cheap-model recovery.
+- `--ephemeral` — throwaway temp state dir instead of the per-host persistent one.
+- `--framework playwright|codeceptjs` — output dialect for `used:` code (default from `ai.agents.historian.framework`).
+- `--vision` — force screenshot pass for `ask`.
+
+### Execution paths
+
+- **pw**: expression validated as a `page.*` call chain (no arbitrary JS), executed against the daemon's Playwright page through the Explorer/Action pipeline so state capture, ariaDiff, and experience recording come for free. Deterministic and near-instant on the happy path.
+- **do**: one bounded Navigator invocation (max ~3 tool roundtrips) reusing the existing click/type/form tool ladders. Deterministic fast path first: if the instruction resolves to exactly one interactive ARIA node by role+name, execute with zero AI calls.
+- **click / fill**: the existing multi-fallback ladders directly (text → ARIA → experience candidates); cheap-model disambiguation only when multiple candidates match.
+- **ask**: Researcher answers from current compact ARIA / cached UI map; `--vision` routes through the vision model. Non-mutating.
+- **verify / assert**: `navigator.verifyState()` on the cheap model; verdict plus the assertion code that proved it.
+- **go**: URL-shaped input navigates directly; intent-shaped input uses Navigator's stateful navigation with visited-state history and knowledge. Autostarts the instance like every other command.
+
+### Examples of `do`
+
+- `act do "click the login link"` → ARIA has one `link "Login"` → `I.click('Login')`, zero AI.
+- `act do "search for 'wireless mouse'"` → cheap model plans fill + Enter → both lines reported in `used:`.
+- `act do "dismiss the cookie banner"` → ambiguous → cheap model picks `button "Accept all"` from compact ARIA.
+- `act do "open the newest invoice"` → list interpretation → cheap model over the UI map picks the first row link.
+
+## The Envelope
+
+The uniform response contract: every command prints the same block structure in the same order to stdout, success or failure. Two jobs: evidence (prove what happened without showing the page) and housekeeping (what is open, what to clean up, where to dig deeper).
+
+### Success (~200–400 tokens inline)
+
+```
+### Result
+ok: true
+command: pw page.click('text=Login')
+healed: false
+used: I.click('Login')
+
+### Page
+url: https://app.example.com/dashboard   (changed: /login → /dashboard)
+title: Dashboard
+state: dashboard_h1_dashboard            (new state, visit #1)
+
+### Changes
+ariaDiff:
+  added:
+    - heading "Dashboard"
+    - button "New Project"
+  removed:
+    - textbox "Email"
+
+### Instance
+instance: default (3 tabs) | other instances: auth-test (1 tab)
+browser: running (started 12m ago)
+
+### Artifacts
+aria:    <abs path>/output/act/<ts>/aria.yml
+html:    <abs path>/output/act/<ts>/page.html
+network: <abs path>/output/act/<ts>/network.jsonl
+```
+
+- `used:` — the exact code that worked (healed form when healed), rendered in the configured framework via Historian's converters. Sessions thereby double as a verified-locator oracle for test generation.
+- `### Changes` becomes `### Answer` for `ask` and `### Verdict` (pass/fail + evidence line + assertion code) for `verify`.
+- `### Instance` appears on every response — tab counts and other live instances — so the orchestrator sees leftover state and knows to close it when finished.
+- Artifact paths are always absolute; full HTML, full ARIA, and the network log are always written, never inlined.
+
+### Failure (after healing exhausted, ~1–2k tokens inline)
+
+Same sections, plus:
+
+```
+### Failure
+error: locator 'text=Login' not found (timeout 5s)
+
+### Healing attempts (3)
+1. I.click('Login')                    → not visible
+2. scroll + retry                      → covered by cookie banner
+3. click 'Accept cookies', retry       → navigation timeout
+reasoning (compacted): ~5-line cheap-model summary of what it observed and why each attempt was chosen
+
+### Current page (compact ARIA, inline)
+- button "Accept cookies"
+- link "Login"
+...
+```
+
+Inline: ariaDiff, error, compact ARIA. On disk: full HTML, full ARIA, network log. The orchestrator investigates from the inline compact ARIA and reads artifact files only when it needs depth.
+
+## Heal Loop
+
+On `pw`, `do`, `click`, or `fill` failure, the failing intent goes to Navigator's existing recovery ladder on the cheap model: alternative locators from ARIA/experience, scroll-into-view, overlay dismissal, retry. Capped at 3 attempts by default; `--no-heal` disables. Every attempt logs `{action, code, result, ariaDiff}`; reasoning is compacted to ~5 lines at the end. Heal success returns a success envelope with `healed: true` and writes the fix to experience so the next run replays it without AI. Heal exhaustion returns the failure envelope.
+
+Tool errors (daemon unreachable, AI provider missing, invalid `pw` expression) are reported as `ok: false` with a `### Failure` naming the failed layer — never disguised as page failures.
+
+## Instances & Sessions
+
+- Named browser daemons via `--instance`; state persists across CLI invocations through the existing `explorbot browser start` server and `.browser-endpoint` discovery.
+- Any `act` command with no running daemon autostarts one for its instance; combined with `--session [file]`, the autostarted browser launches already authenticated.
+- `act browser start|stop|status|list` manages instances explicitly; `stop --all` kills everything.
+
+## Config-Free Operation
+
+Resolution ladder, first hit wins per setting:
+
+1. Project config — `explorbot.config.js|ts` in cwd.
+2. Global user config — `~/.config/explorbot/config.js|ts` (models, providers, keys).
+3. Env vars — existing `EXPLORBOT_*` set, from process env, cwd `.env`, or `~/.config/explorbot/.env`.
+
+The ladder lives in core config loading (`buildEnvConfig` grows global-config and global-`.env` sources); the boat inherits it.
+
+With no project config, working dirs move to a persistent per-host state dir:
+
+```
+~/.local/state/explorbot/<host>/
+├── experience/
+├── knowledge/
+└── output/act/...
+```
+
+Experience accumulates per target host across runs from any directory — zero-setup feel with memory. `--ephemeral` opts into a throwaway temp dir (CI, demos).
+
+## Discovery
+
+`explorbot act --help` (and `actbot --help`) is the sole teaching surface: it must compactly document the envelope shape, heal semantics, tiering (`pw` vs `click`/`fill` vs `do`), instance/session flags, and the artifact-file pattern. Clean stdout throughout (no banner).
+
+## Testing
+
+- Unit: envelope rendering (success, failure, ask/verify variants), `pw` expression validation, config ladder resolution.
+- Integration: heal-loop prompts via the existing `@copilotkit/aimock` harness per `docs/contributing/ai-integration-tests.md`; fictional fixture data only.
+- End-to-end smoke against a local fixture page: `pw` success, healed failure, exhausted failure, `do` fast path (zero AI), instance autostart with `--session`.
+
+## Decisions Log
+
+- Heal-first on all action failures (not fail-fast, not opt-in). `--no-heal` escape hatch.
+- Failure delivery: ariaDiff + error + compact ARIA inline; full HTML/ARIA/network as files.
+- Full command surface in v1 (pw, do, click, fill, ask, verify/assert, go, browser mgmt).
+- Discovery via `--help` only; no SKILL.md or MCP in v1.
+- Boat architecture (`boat/actor`, namespace `act`), not core commands.
+- `--instance` for daemon switching; `--session` keeps existing auth-state meaning.
+- Persistent per-host state dir by default in config-free mode; `--ephemeral` for temp.
+- `used:` code in envelope via Historian converters; `verify` exposes assertion code.
+- click/fill exposed as ladder-backed sugar; select/pressKey/hover/drag stay behind `pw`.
+- Implementation runs on Opus.

--- a/docs/superpowers/specs/2026-08-01-prima-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-prima-boat-design.md
@@ -61,7 +61,7 @@ Tiering: `pw` = precise, no AI — for when the orchestrator already holds a ver
 
 - `--endpoint <ep>` / `--pw-session <title>` — attach to a specific Playwright-protocol browser server (playwright-cli registry) instead of the ladder's automatic pick.
 - `--instance <name>` / `-i` — which named prima-owned browser daemon to talk to when not attached. Default instance otherwise.
-- `--session [file]` — existing auth-session semantics; an autostarted instance launches with the saved cookies/storage state.
+- `--session [file]` — existing auth-session semantics; a browser launched via explicit `prima browser start` loads the saved cookies/storage state. Ignored in attached mode.
 - `--no-heal` — fail fast without cheap-model recovery.
 - `--ephemeral` — throwaway temp state dir instead of the per-host persistent one.
 - `--framework playwright|codeceptjs` — output dialect for `used:` code (default from `ai.agents.historian.framework`).
@@ -75,7 +75,7 @@ Tiering: `pw` = precise, no AI — for when the orchestrator already holds a ver
 - **ask**: vision by default — Researcher answers from a fresh screenshot via the vision model; `--no-vision` (or no `visionModel` configured, with a note in the envelope) falls back to compact ARIA / cached UI map. Non-mutating.
 - **research**: `researcher.research(state, { screenshot: true, data, deep, force })`. The envelope's `### Research` section carries the UI map inline — it is the deliverable: verified, live-tested locators that let the orchestrator drive `pw` precisely without reading raw ARIA. `--data` adds extracted data sections, `--deep` deep analysis, `--fresh` bypasses the cache; cached results keep the existing staleness banner. Non-mutating.
 - **verify / assert**: `navigator.verifyState()` on the cheap model; verdict plus the assertion code that proved it.
-- **go**: URL-shaped input navigates directly; intent-shaped input uses Navigator's stateful navigation with visited-state history and knowledge. Autostarts the instance like every other command.
+- **go**: URL-shaped input navigates directly; intent-shaped input uses Navigator's stateful navigation with visited-state history and knowledge. Like every command, requires an existing browser session — it never launches one.
 
 ### Examples of `do`
 
@@ -163,7 +163,8 @@ Prima is a smart layer over whatever browser already exists, not an owner of a c
 2. `PLAYWRIGHT_CLI_SESSION` env, matched against registry titles for this workspace.
 3. Live registry descriptor with `workspaceDir` equal to the resolved cwd and `title` of `default`.
 4. Exactly one live descriptor for this workspace → use it; multiple → tool-error envelope listing candidate titles.
-5. Fall back to prima's own daemon (`--instance` semantics below), autostarting if needed.
+5. A prima-owned instance previously started explicitly via `prima browser start` (`--instance` semantics below), if alive.
+6. Nothing available → **fail** with a tool-error envelope instructing the caller to create a session first: start one with playwright-cli (`playwright-cli open <url>`) — the preferred path — or `prima browser start`. Prima never launches a browser implicitly.
 
 Descriptors may be stale — always liveness-probe (attempt connect) before selecting; skip dead ones. Version skew: prefer connecting with our own playwright-core; if the wire handshake rejects, load the daemon's own lib from `descriptor.playwrightLib` (the same trick playwright-cli uses).
 
@@ -174,8 +175,18 @@ A CDP attach mode (`--cdp <url>`, for a user's real Chrome, CI browsers, or a pl
 ## Instances & Sessions
 
 - Named browser daemons via `--instance`; state persists across CLI invocations through the existing `explorbot browser start` server and `.browser-endpoint` discovery. Used only when the resolution ladder found no playwright-cli browser to attach to.
-- Any `prima` command with no attachable browser and no running daemon autostarts one for its instance; combined with `--session [file]`, the autostarted browser launches already authenticated.
-- `prima browser start|stop|status|list` manages instances explicitly; `stop --all` kills every owned instance (attached browsers are only detached). `list` shows owned instances and attachable playwright-cli sessions for this workspace.
+- No implicit launching: a `prima` command with no attachable browser and no running owned instance fails with the create-a-session guidance above.
+- `prima browser start|stop|status|list` manages owned instances explicitly; `start` combined with `--session [file]` launches already authenticated; `stop --all` kills every owned instance (attached browsers are only detached). `list` shows owned instances and attachable playwright-cli sessions for this workspace.
+
+## Degraded Modes
+
+Prima is a layer over playwright-cli, so when prima itself cannot help, its job is to say so and point back down:
+
+- **No browser session** (ladder step 6 above): tool-error envelope with the create-a-session instruction. Exit code 1.
+- **AI unavailable** — no provider configured, missing/expired credentials, provider errors at startup: commands that require a model (`do`, `click`, `fill`, `ask`, `verify`, `research`, intent-`go`) fail fast with a tool-error envelope stating the specific reason (general shape: which layer failed and why) and suggesting the fallback: use playwright-cli for direct browser control, or fix the AI config (`~/.explorbot/config.js` / `EXPLORBOT_AI_PROVIDER`). No partial AI attempts.
+- **`pw` stays useful without AI**: it executes normally (it needs no model); healing is skipped with a `healed: false (ai unavailable)` note in the envelope. URL-`go` likewise works.
+
+The distinction rule from the heal section applies everywhere: tool-layer failures (browser missing, AI missing, invalid input) are never disguised as page failures.
 
 ## Config-Free Operation
 
@@ -208,7 +219,7 @@ Experience accumulates per target host across runs from any directory — zero-s
 
 - Unit: envelope rendering (success, failure, ask/verify variants), `pw` expression validation, config ladder resolution.
 - Integration: heal-loop prompts via the existing `@copilotkit/aimock` harness per `docs/contributing/ai-integration-tests.md`; fictional fixture data only.
-- End-to-end smoke against a local fixture page: `pw` success, healed failure, exhausted failure, instance autostart with `--session`; `do`/`click` covered by aimock integration tests (they always require a model).
+- End-to-end smoke against a local fixture page: `pw` success, healed failure, exhausted failure, no-browser failure with create-a-session guidance, `pw` without AI (heal-skipped note); `do`/`click` covered by aimock integration tests (they always require a model), plus an AI-unavailable test asserting the playwright-cli fallback suggestion.
 
 ## Decisions Log
 
@@ -223,6 +234,8 @@ Experience accumulates per target host across runs from any directory — zero-s
 - `ask` is vision-first; `--no-vision` opts into the ARIA text path.
 - Prima attaches to playwright-cli's browser by default via the Playwright-protocol registry (`~/.cache/ms-playwright/b/`), matched by `workspaceDir` + session `title`; own daemon is the fallback, never the first choice.
 - Attached browsers are never closed by prima; CDP attach (`--cdp`) deferred to a follow-up.
+- No implicit browser launch: missing session → fail with "create one via playwright-cli" guidance; own daemon only via explicit `prima browser start`.
+- AI unavailable → NL commands fail fast suggesting playwright-cli as fallback; `pw`/URL-`go` keep working with healing skipped.
 - `used:` code in envelope via Historian converters; `verify` exposes assertion code.
 - click/fill are single-instruction aliases over the same AI resolution as `do`; `do` accepts multiple high-level instructions run tester-style. No deterministic no-AI paths in NL commands — precision belongs to `pw`/playwright-cli. select/pressKey/hover/drag stay behind `pw`.
 - `research` exposed with `--data`/`--deep`/`--fresh`; UI map inline as the deliverable (verified locators enable precise `pw` driving).

--- a/docs/superpowers/specs/2026-08-01-prima-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-prima-boat-design.md
@@ -59,7 +59,8 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 
 ### Common flags
 
-- `--instance <name>` / `-i` — which named browser daemon to talk to. Default instance otherwise.
+- `--endpoint <ep>` / `--pw-session <title>` — attach to a specific Playwright-protocol browser server (playwright-cli registry) instead of the ladder's automatic pick.
+- `--instance <name>` / `-i` — which named prima-owned browser daemon to talk to when not attached. Default instance otherwise.
 - `--session [file]` — existing auth-session semantics; an autostarted instance launches with the saved cookies/storage state.
 - `--no-heal` — fail fast without cheap-model recovery.
 - `--ephemeral` — throwaway temp state dir instead of the per-host persistent one.
@@ -152,11 +153,29 @@ On `pw`, `do`, `click`, or `fill` failure, the failing intent goes to Navigator'
 
 Tool errors (daemon unreachable, AI provider missing, invalid `pw` expression) are reported as `ok: false` with a `### Failure` naming the failed layer — never disguised as page failures.
 
+## Connectivity — Sharing the Browser with playwright-cli
+
+Prima is a smart layer over whatever browser already exists, not an owner of a competing one. Every playwright-cli daemon browser is auto-`bind()`-ed as a Playwright-protocol browser server (public `browser.bind()` API, Playwright 1.62+), with a descriptor JSON in `~/.cache/ms-playwright/b/<guid>`: `{ playwrightVersion, playwrightLib, title: <session name>, endpoint, workspaceDir, browser: { browserName, ... } }`. Connecting to `endpoint` yields the same live Browser — same contexts, same tabs — exactly what `playwright-cli attach` does internally.
+
+**Browser resolution ladder (every prima command):**
+
+1. Explicit `--endpoint <ep>` (raw Playwright-protocol endpoint) or `--pw-session <title>` (registry lookup by title).
+2. `PLAYWRIGHT_CLI_SESSION` env, matched against registry titles for this workspace.
+3. Live registry descriptor with `workspaceDir` equal to the resolved cwd and `title` of `default`.
+4. Exactly one live descriptor for this workspace → use it; multiple → tool-error envelope listing candidate titles.
+5. Fall back to prima's own daemon (`--instance` semantics below), autostarting if needed.
+
+Descriptors may be stale — always liveness-probe (attempt connect) before selecting; skip dead ones. Version skew: prefer connecting with our own playwright-core; if the wire handshake rejects, load the daemon's own lib from `descriptor.playwrightLib` (the same trick playwright-cli uses).
+
+**Attached-mode rules:** prima never closes a browser it did not launch — `prima browser stop` detaches only; `--session` (auth storage-state) is ignored in attached mode (the attached browser owns its cookies); prima adopts the browser's existing default context and active page rather than creating a fresh context. The envelope's `### Instance` block reports the attachment (`browser: attached (playwright-cli session "default", workspace <dir>)`) so the orchestrator knows this browser is not its to kill.
+
+A CDP attach mode (`--cdp <url>`, for a user's real Chrome, CI browsers, or a playwright-cli browser with `launchOptions.args: ["--remote-debugging-port=..."]` injected via `.playwright/cli.config.json`) is a documented follow-up, not v1.
+
 ## Instances & Sessions
 
-- Named browser daemons via `--instance`; state persists across CLI invocations through the existing `explorbot browser start` server and `.browser-endpoint` discovery.
-- Any `prima` command with no running daemon autostarts one for its instance; combined with `--session [file]`, the autostarted browser launches already authenticated.
-- `prima browser start|stop|status|list` manages instances explicitly; `stop --all` kills everything.
+- Named browser daemons via `--instance`; state persists across CLI invocations through the existing `explorbot browser start` server and `.browser-endpoint` discovery. Used only when the resolution ladder found no playwright-cli browser to attach to.
+- Any `prima` command with no attachable browser and no running daemon autostarts one for its instance; combined with `--session [file]`, the autostarted browser launches already authenticated.
+- `prima browser start|stop|status|list` manages instances explicitly; `stop --all` kills every owned instance (attached browsers are only detached). `list` shows owned instances and attachable playwright-cli sessions for this workspace.
 
 ## Config-Free Operation
 
@@ -202,6 +221,8 @@ Experience accumulates per target host across runs from any directory — zero-s
 - Persistent per-host state dir by default in config-free mode; `--ephemeral` for temp.
 - All global paths under a single cross-platform `~/.explorbot/` dir (config.js, .env, state/<host>/) — no XDG/Library/AppData branching.
 - `ask` is vision-first; `--no-vision` opts into the ARIA text path.
+- Prima attaches to playwright-cli's browser by default via the Playwright-protocol registry (`~/.cache/ms-playwright/b/`), matched by `workspaceDir` + session `title`; own daemon is the fallback, never the first choice.
+- Attached browsers are never closed by prima; CDP attach (`--cdp`) deferred to a follow-up.
 - `used:` code in envelope via Historian converters; `verify` exposes assertion code.
 - click/fill exposed as ladder-backed sugar; select/pressKey/hover/drag stay behind `pw`.
 - `research` exposed with `--data`/`--deep`/`--fresh`; UI map inline as the deliverable (verified locators enable precise `pw` driving).

--- a/docs/superpowers/specs/2026-08-01-prima-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-prima-boat-design.md
@@ -1,4 +1,4 @@
-# Actor Boat — High-Level Browser Driver for Orchestrating Agents
+# Prima Boat — High-Level Browser Driver for Orchestrating Agents
 
 **Date:** 2026-08-01
 **Status:** Draft for review
@@ -8,7 +8,7 @@
 
 Coding agents (Claude Code on Opus/Fable) drive browsers through playwright-cli or Playwright MCP. Every action forces page state (aria snapshots) into the orchestrator's context: the expensive model pays to read the tree, pick a ref, and re-read after every step, and each snapshot stays in conversation history compounding cost for the rest of the session. A 20-step flow means 20+ expensive perception roundtrips.
 
-Explorbot already owns the layers that fix this: cheap-model perception (Navigator, Researcher), semantic diffs (ariaDiff, pageDiff), state tracking, and experience replay. The Actor boat exposes those layers as an intent-level CLI so the orchestrator sends instructions and receives compact evidence — page data never enters the expensive context on the happy path.
+Explorbot already owns the layers that fix this: cheap-model perception (Navigator, Researcher), semantic diffs (ariaDiff, pageDiff), state tracking, and experience replay. The Prima boat exposes those layers as an intent-level CLI so the orchestrator sends instructions and receives compact evidence — page data never enters the expensive context on the happy path.
 
 ## Goals
 
@@ -29,30 +29,30 @@ Explorbot already owns the layers that fix this: cheap-model perception (Navigat
 A boat, following the existing `boat/api-tester` / `boat/doc-collector` pattern:
 
 ```
-boat/actor/
-├── package.json          # name: "actbot", own bin
-├── bin/actbot-cli.ts     # standalone CLI
+boat/prima/
+├── package.json          # name: "prima", own bin
+├── bin/prima-cli.ts     # standalone CLI
 └── src/
-    ├── cli.ts            # createActCommands('act') → composed into main CLI
-    ├── actor.ts          # Actor class wrapping ExplorBot (like DocBot)
+    ├── cli.ts            # createPrimaCommands('prima') → composed into main CLI
+    ├── prima.ts          # Prima class wrapping ExplorBot (like DocBot)
     ├── envelope.ts       # result envelope: inline render + artifact files
     └── config.ts
 ```
 
-Registered in `bin/explorbot-cli.ts` via `program.addCommand(createActCommands('act'))`. The `Actor` class wraps `ExplorBot`, reusing `agentNavigator()`, `agentResearcher()`, `stateManager()`, Historian, and the Explorer/Action capture pipeline. Business logic lives in the Actor class and agents; CLI handlers stay thin, per repo convention.
+Registered in `bin/explorbot-cli.ts` via `program.addCommand(createPrimaCommands('prima'))`. The `Prima` class wraps `ExplorBot`, reusing `agentNavigator()`, `agentResearcher()`, `stateManager()`, Historian, and the Explorer/Action capture pipeline. Business logic lives in the Prima class and agents; CLI handlers stay thin, per repo convention.
 
 ## Command Surface
 
 ```
-explorbot act pw "({ page }) => page.click('text=Login')"   # raw Playwright fn, healed on failure
-explorbot act do "click the login link"        # NL action via Navigator
-explorbot act click "Login"                    # targeted click via existing fallback ladder
-explorbot act fill "Search" "wireless mouse"   # targeted fill via existing ladder
-explorbot act ask "what do I see here?"        # cheap-model page Q&A via Researcher
-explorbot act research [--data] [--deep] [--fresh]  # verified UI map for precise pw driving
-explorbot act verify "user is logged in"       # AI assertion (alias: assert)
-explorbot act go "billing settings"            # URL or NL navigation
-explorbot act browser start|stop|status|list   # instance management (stop --all)
+explorbot prima pw "({ page }) => page.click('text=Login')"   # raw Playwright fn, healed on failure
+explorbot prima do "click the login link"        # NL action via Navigator
+explorbot prima click "Login"                    # targeted click via existing fallback ladder
+explorbot prima fill "Search" "wireless mouse"   # targeted fill via existing ladder
+explorbot prima ask "what do I see here?"        # cheap-model page Q&A via Researcher
+explorbot prima research [--data] [--deep] [--fresh]  # verified UI map for precise pw driving
+explorbot prima verify "user is logged in"       # AI assertion (alias: assert)
+explorbot prima go "billing settings"            # URL or NL navigation
+explorbot prima browser start|stop|status|list   # instance management (stop --all)
 ```
 
 Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with deterministic fallback ladders (AI only on ambiguity), `do` = intent (cheap-model planning). `select`, `pressKey`, `hover`, `drag` intentionally stay behind `pw` — a subcommand without a ladder is surface without value.
@@ -78,10 +78,10 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 
 ### Examples of `do`
 
-- `act do "click the login link"` → ARIA has one `link "Login"` → `I.click('Login')`, zero AI.
-- `act do "search for 'wireless mouse'"` → cheap model plans fill + Enter → both lines reported in `used:`.
-- `act do "dismiss the cookie banner"` → ambiguous → cheap model picks `button "Accept all"` from compact ARIA.
-- `act do "open the newest invoice"` → list interpretation → cheap model over the UI map picks the first row link.
+- `prima do "click the login link"` → ARIA has one `link "Login"` → `I.click('Login')`, zero AI.
+- `prima do "search for 'wireless mouse'"` → cheap model plans fill + Enter → both lines reported in `used:`.
+- `prima do "dismiss the cookie banner"` → ambiguous → cheap model picks `button "Accept all"` from compact ARIA.
+- `prima do "open the newest invoice"` → list interpretation → cheap model over the UI map picks the first row link.
 
 ## The Envelope
 
@@ -114,9 +114,9 @@ instance: default (3 tabs) | other instances: auth-test (1 tab)
 browser: running (started 12m ago)
 
 ### Artifacts
-aria:    <abs path>/output/act/<ts>/aria.yml
-html:    <abs path>/output/act/<ts>/page.html
-network: <abs path>/output/act/<ts>/network.jsonl
+aria:    <abs path>/output/prima/<ts>/aria.yml
+html:    <abs path>/output/prima/<ts>/page.html
+network: <abs path>/output/prima/<ts>/network.jsonl
 ```
 
 - `used:` — the exact code that worked (healed form when healed), rendered in the configured framework via Historian's converters. Sessions thereby double as a verified-locator oracle for test generation.
@@ -155,8 +155,8 @@ Tool errors (daemon unreachable, AI provider missing, invalid `pw` expression) a
 ## Instances & Sessions
 
 - Named browser daemons via `--instance`; state persists across CLI invocations through the existing `explorbot browser start` server and `.browser-endpoint` discovery.
-- Any `act` command with no running daemon autostarts one for its instance; combined with `--session [file]`, the autostarted browser launches already authenticated.
-- `act browser start|stop|status|list` manages instances explicitly; `stop --all` kills everything.
+- Any `prima` command with no running daemon autostarts one for its instance; combined with `--session [file]`, the autostarted browser launches already authenticated.
+- `prima browser start|stop|status|list` manages instances explicitly; `stop --all` kills everything.
 
 ## Config-Free Operation
 
@@ -174,14 +174,14 @@ With no project config, working dirs move to a persistent per-host state dir:
 ~/.local/state/explorbot/<host>/
 ├── experience/
 ├── knowledge/
-└── output/act/...
+└── output/prima/...
 ```
 
 Experience accumulates per target host across runs from any directory — zero-setup feel with memory. `--ephemeral` opts into a throwaway temp dir (CI, demos).
 
 ## Discovery
 
-`explorbot act --help` (and `actbot --help`) is the sole teaching surface: it must compactly document the envelope shape, heal semantics, tiering (`pw` vs `click`/`fill` vs `do`), instance/session flags, and the artifact-file pattern. Clean stdout throughout (no banner).
+`explorbot prima --help` (and `prima --help`) is the sole teaching surface: it must compactly document the envelope shape, heal semantics, tiering (`pw` vs `click`/`fill` vs `do`), instance/session flags, and the artifact-file pattern. Clean stdout throughout (no banner).
 
 ## Testing
 
@@ -195,7 +195,7 @@ Experience accumulates per target host across runs from any directory — zero-s
 - Failure delivery: ariaDiff + error + compact ARIA inline; full HTML/ARIA/network as files.
 - Full command surface in v1 (pw, do, click, fill, ask, verify/assert, go, browser mgmt).
 - Discovery via `--help` only; no SKILL.md or MCP in v1.
-- Boat architecture (`boat/actor`, namespace `act`), not core commands.
+- Boat architecture (`boat/prima`, namespace `prima`), not core commands.
 - `--instance` for daemon switching; `--session` keeps existing auth-state meaning.
 - Persistent per-host state dir by default in config-free mode; `--ephemeral` for temp.
 - `used:` code in envelope via Historian converters; `verify` exposes assertion code.

--- a/docs/superpowers/specs/2026-08-01-prima-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-prima-boat-design.md
@@ -46,8 +46,8 @@ Registered in `bin/explorbot-cli.ts` via `program.addCommand(createPrimaCommands
 ```
 explorbot prima pw "({ page }) => page.click('text=Login')"   # raw Playwright fn, healed on failure
 explorbot prima do "click the login link"        # NL action via Navigator
-explorbot prima click "Login"                    # targeted click via existing fallback ladder
-explorbot prima fill "Search" "wireless mouse"   # targeted fill via existing ladder
+explorbot prima click "the login link"           # single AI-resolved action (alias over do)
+explorbot prima fill "search box" "wireless mouse"  # single AI-resolved fill (alias over do)
 explorbot prima ask "what do I see here?"        # cheap-model page Q&A via Researcher
 explorbot prima research [--data] [--deep] [--fresh]  # verified UI map for precise pw driving
 explorbot prima verify "user is logged in"       # AI assertion (alias: assert)
@@ -55,7 +55,7 @@ explorbot prima go "billing settings"            # URL or NL navigation
 explorbot prima browser start|stop|status|list   # instance management (stop --all)
 ```
 
-Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with deterministic fallback ladders (AI only on ambiguity), `do` = intent (cheap-model planning). `select`, `pressKey`, `hover`, `drag` intentionally stay behind `pw` — a subcommand without a ladder is surface without value.
+Tiering: `pw` = precise, no AI — for when the orchestrator already holds a verified locator (from `research`) or drives via playwright-cli conventions; `click`/`fill` = one high-level action, always AI-resolved — the orchestrator never sees ARIA/HTML, so "the login link" is a description, not a locator, and the cheap model resolves it against the page; `do` = a set of high-level instructions executed tester-style in one AI loop. There are NO deterministic no-AI paths in the NL commands — precision without AI is exactly what `pw`/playwright-cli exist for, and duplicating it here would be surface without value. `select`, `pressKey`, `hover`, `drag` stay behind `pw`.
 
 ### Common flags
 
@@ -70,8 +70,8 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 ### Execution paths
 
 - **pw**: the argument is a function expression in the exact shape `I.usePlaywrightTo` accepts — `({ page, browserContext, browser }) => ...` — checked only for being a parseable function, then interpolated directly into `I.usePlaywrightTo('pw', <fn>)` and executed through the Explorer/Action pipeline so state capture, ariaDiff, and experience recording come for free. Destructure whichever Playwright objects the call needs. Deterministic and near-instant on the happy path.
-- **do**: one bounded Navigator invocation (max ~3 tool roundtrips) reusing the existing click/type/form tool ladders. Deterministic fast path first: if the instruction resolves to exactly one interactive ARIA node by role+name, execute with zero AI calls.
-- **click / fill**: the existing multi-fallback ladders directly (text → ARIA → experience candidates); cheap-model disambiguation only when multiple candidates match.
+- **do**: takes one or more high-level instructions and performs them tester-style — a bounded cheap-model loop over the existing CodeceptJS tools (click/type/form ladders), holding page context (compact ARIA + relevant experience) the orchestrator never sees, iterating until the instructions are done or the budget is exhausted. Multi-step by design: `prima do "open the first invoice" "download its PDF"`.
+- **click / fill**: shorter aliases over the same AI resolution — a single instruction (`click <description>`, `fill <field description> <value>`) resolved by the cheap model against the current page (Navigator-style state resolution) and executed via the tool ladders. Never deterministic: the caller supplies a description, not a locator.
 - **ask**: vision by default — Researcher answers from a fresh screenshot via the vision model; `--no-vision` (or no `visionModel` configured, with a note in the envelope) falls back to compact ARIA / cached UI map. Non-mutating.
 - **research**: `researcher.research(state, { screenshot: true, data, deep, force })`. The envelope's `### Research` section carries the UI map inline — it is the deliverable: verified, live-tested locators that let the orchestrator drive `pw` precisely without reading raw ARIA. `--data` adds extracted data sections, `--deep` deep analysis, `--fresh` bypasses the cache; cached results keep the existing staleness banner. Non-mutating.
 - **verify / assert**: `navigator.verifyState()` on the cheap model; verdict plus the assertion code that proved it.
@@ -79,7 +79,7 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 
 ### Examples of `do`
 
-- `prima do "click the login link"` → ARIA has one `link "Login"` → `I.click('Login')`, zero AI.
+- `prima do "click the login link"` → cheap model resolves the description against compact ARIA → `I.click('Login')`.
 - `prima do "search for 'wireless mouse'"` → cheap model plans fill + Enter → both lines reported in `used:`.
 - `prima do "dismiss the cookie banner"` → ambiguous → cheap model picks `button "Accept all"` from compact ARIA.
 - `prima do "open the newest invoice"` → list interpretation → cheap model over the UI map picks the first row link.
@@ -208,7 +208,7 @@ Experience accumulates per target host across runs from any directory — zero-s
 
 - Unit: envelope rendering (success, failure, ask/verify variants), `pw` expression validation, config ladder resolution.
 - Integration: heal-loop prompts via the existing `@copilotkit/aimock` harness per `docs/contributing/ai-integration-tests.md`; fictional fixture data only.
-- End-to-end smoke against a local fixture page: `pw` success, healed failure, exhausted failure, `do` fast path (zero AI), instance autostart with `--session`.
+- End-to-end smoke against a local fixture page: `pw` success, healed failure, exhausted failure, instance autostart with `--session`; `do`/`click` covered by aimock integration tests (they always require a model).
 
 ## Decisions Log
 
@@ -224,6 +224,6 @@ Experience accumulates per target host across runs from any directory — zero-s
 - Prima attaches to playwright-cli's browser by default via the Playwright-protocol registry (`~/.cache/ms-playwright/b/`), matched by `workspaceDir` + session `title`; own daemon is the fallback, never the first choice.
 - Attached browsers are never closed by prima; CDP attach (`--cdp`) deferred to a follow-up.
 - `used:` code in envelope via Historian converters; `verify` exposes assertion code.
-- click/fill exposed as ladder-backed sugar; select/pressKey/hover/drag stay behind `pw`.
+- click/fill are single-instruction aliases over the same AI resolution as `do`; `do` accepts multiple high-level instructions run tester-style. No deterministic no-AI paths in NL commands — precision belongs to `pw`/playwright-cli. select/pressKey/hover/drag stay behind `pw`.
 - `research` exposed with `--data`/`--deep`/`--fresh`; UI map inline as the deliverable (verified locators enable precise `pw` driving).
 - Implementation runs on Opus.

--- a/docs/superpowers/specs/2026-08-01-prima-boat-design.md
+++ b/docs/superpowers/specs/2026-08-01-prima-boat-design.md
@@ -64,14 +64,14 @@ Tiering: `pw` = precise (no AI on happy path), `click`/`fill` = targeted with de
 - `--no-heal` — fail fast without cheap-model recovery.
 - `--ephemeral` — throwaway temp state dir instead of the per-host persistent one.
 - `--framework playwright|codeceptjs` — output dialect for `used:` code (default from `ai.agents.historian.framework`).
-- `--vision` — force screenshot pass for `ask`.
+- `--no-vision` — `ask` answers from compact ARIA/UI map instead of the default screenshot pass.
 
 ### Execution paths
 
 - **pw**: the argument is a function expression in the exact shape `I.usePlaywrightTo` accepts — `({ page, browserContext, browser }) => ...` — checked only for being a parseable function, then interpolated directly into `I.usePlaywrightTo('pw', <fn>)` and executed through the Explorer/Action pipeline so state capture, ariaDiff, and experience recording come for free. Destructure whichever Playwright objects the call needs. Deterministic and near-instant on the happy path.
 - **do**: one bounded Navigator invocation (max ~3 tool roundtrips) reusing the existing click/type/form tool ladders. Deterministic fast path first: if the instruction resolves to exactly one interactive ARIA node by role+name, execute with zero AI calls.
 - **click / fill**: the existing multi-fallback ladders directly (text → ARIA → experience candidates); cheap-model disambiguation only when multiple candidates match.
-- **ask**: Researcher answers from current compact ARIA / cached UI map; `--vision` routes through the vision model. Non-mutating.
+- **ask**: vision by default — Researcher answers from a fresh screenshot via the vision model; `--no-vision` (or no `visionModel` configured, with a note in the envelope) falls back to compact ARIA / cached UI map. Non-mutating.
 - **research**: `researcher.research(state, { screenshot: true, data, deep, force })`. The envelope's `### Research` section carries the UI map inline — it is the deliverable: verified, live-tested locators that let the orchestrator drive `pw` precisely without reading raw ARIA. `--data` adds extracted data sections, `--deep` deep analysis, `--fresh` bypasses the cache; cached results keep the existing staleness banner. Non-mutating.
 - **verify / assert**: `navigator.verifyState()` on the cheap model; verdict plus the assertion code that proved it.
 - **go**: URL-shaped input navigates directly; intent-shaped input uses Navigator's stateful navigation with visited-state history and knowledge. Autostarts the instance like every other command.
@@ -163,15 +163,17 @@ Tool errors (daemon unreachable, AI provider missing, invalid `pw` expression) a
 Resolution ladder, first hit wins per setting:
 
 1. Project config — `explorbot.config.js|ts` in cwd.
-2. Global user config — `~/.config/explorbot/config.js|ts` (models, providers, keys).
-3. Env vars — existing `EXPLORBOT_*` set, from process env, cwd `.env`, or `~/.config/explorbot/.env`.
+2. Global user config — `~/.explorbot/config.js|ts` (models, providers, keys).
+3. Env vars — existing `EXPLORBOT_*` set, from process env, cwd `.env`, or `~/.explorbot/.env`.
+
+All global paths resolve through `os.homedir()`, so the same single directory works on Linux (`/home/<user>/.explorbot`), macOS (`/Users/<user>/.explorbot`), and Windows (`C:\Users\<user>\.explorbot`) — no per-OS conventions (XDG, Library, AppData) to document or branch on.
 
 The ladder lives in core config loading (`buildEnvConfig` grows global-config and global-`.env` sources); the boat inherits it.
 
 With no project config, working dirs move to a persistent per-host state dir:
 
 ```
-~/.local/state/explorbot/<host>/
+~/.explorbot/state/<host>/
 ├── experience/
 ├── knowledge/
 └── output/prima/...
@@ -198,6 +200,8 @@ Experience accumulates per target host across runs from any directory — zero-s
 - Boat architecture (`boat/prima`, namespace `prima`), not core commands.
 - `--instance` for daemon switching; `--session` keeps existing auth-state meaning.
 - Persistent per-host state dir by default in config-free mode; `--ephemeral` for temp.
+- All global paths under a single cross-platform `~/.explorbot/` dir (config.js, .env, state/<host>/) — no XDG/Library/AppData branching.
+- `ask` is vision-first; `--no-vision` opts into the ARIA text path.
 - `used:` code in envelope via Historian converters; `verify` exposes assertion code.
 - click/fill exposed as ladder-backed sugar; select/pressKey/hover/drag stay behind `pw`.
 - `research` exposed with `--data`/`--deep`/`--fresh`; UI map inline as the deliverable (verified locators enable precise `pw` driving).

--- a/docs/superpowers/specs/2026-08-03-global-config-design.md
+++ b/docs/superpowers/specs/2026-08-03-global-config-design.md
@@ -1,0 +1,121 @@
+# Global Configuration Mode
+
+**Date:** 2026-08-03
+**Status:** Approved in brainstorming, pending spec review
+
+## Problem
+
+Explorbot requires a project directory with `explorbot.config.js`, or a stack of `EXPLORBOT_*` environment variables on every invocation. The env-var mode is deliberately stateless: output goes to a temp directory, experience is never written, the Historian is off. A coding agent that wants to explore a site it visited yesterday starts from zero.
+
+The prima boat spec (`2026-08-01-prima-boat-design.md`) already commits to a global user config and per-host persistent state under `~/.explorbot`. This spec defines that mechanism for the whole tool — core commands and every boat — plus the `init --global` command that sets it up.
+
+## Goals
+
+- `explorbot init --global` configures AI models and keys once, in `~/.explorbot`.
+- Any explorbot command run from any directory uses that config when no project config exists.
+- Each explored site gets a persistent subfolder under `~/.explorbot/sites/` with knowledge, experience, and output — full project semantics, so learning accumulates across runs.
+- Sites auto-register on first visit; later runs reference them by bare host.
+- All boats (prima, api-tester, doc-collector) inherit the mechanism with no boat changes.
+- Cross-platform through `os.homedir()` alone — no XDG/Library/AppData branching.
+
+## Non-Goals
+
+- No per-setting merging between config sources. A config file wins wholesale, as documented today.
+- No site aliases, environments (staging/prod), or a central `sites.json`.
+- No changes to the env-var config-free mode; it remains the last resort with its current stateless behavior.
+
+## Directory Layout
+
+```
+~/.explorbot/
+├── config.js          # global AI config (models, keys, agent settings)
+├── .env               # API keys and EXPLORBOT_* vars
+└── sites/
+    ├── app.example.com/
+    │   ├── site.json  # { url, createdAt, lastRunAt }
+    │   ├── knowledge/
+    │   ├── experience/
+    │   └── output/    # states, plans, reports, tests
+    └── localhost_3000/
+        └── ...
+```
+
+Folder names derive from the target URL's host and port, lowercased, with characters invalid in directory names replaced by `_` (so `localhost:3000` → `localhost_3000`).
+
+## Config Resolution Ladder
+
+All changes live in core `ConfigParser` (`src/config.ts`); boats inherit them because they obtain AI config and dirs through it.
+
+**Env loading.** `loadConfig()` loads `~/.explorbot/.env` first, then cwd `.env`. Nearest wins on duplicate keys.
+
+**Config lookup.** `findConfigFile()` gains one rung after the existing project paths: `~/.explorbot/config.js|mjs|ts`. First hit wins. The full order per invocation:
+
+1. Project config in cwd (existing paths, including `config/` and `src/config/`).
+2. Global config `~/.explorbot/config.*` → **global mode**.
+3. `EXPLORBOT_*` env-built config (existing behavior, unchanged: temp output, experience off, Historian off).
+4. Nothing → error, now also suggesting `explorbot init --global`.
+
+Precedence keeps the documented rule: a config file always wins when present. The global config beats `EXPLORBOT_AI_MODEL` and friends; env vars matter only when no config file loads. `EXPLORBOT_URL` and command-line URLs still apply in global mode because the URL is per-invocation there. The prima spec's "first hit wins per setting" line is amended to this wholesale rule.
+
+**Global mode.** Active when the loaded config path is the global one:
+
+- `dirs` resolve to `~/.explorbot/sites/<host>/{knowledge,experience,output}`; `getProjectRoot()` returns the site dir. States, plans, reports, and generated tests land there.
+- Full project semantics: experience read and write enabled, Historian on, reporter as configured.
+- A `dirs` section in the global config is ignored; the site layout is fixed.
+- A `web.url` in the global config is a load-time error — the global config is site-agnostic; the URL comes per command or from a registered site.
+
+## Site Resolution & Auto-Registration
+
+In global mode the target site comes from the command's URL argument, else `EXPLORBOT_URL`. One argument carries both site and path:
+
+- **Absolute URL** (`https://app.example.com/login`) — host+port become the site folder. First visit auto-registers: creates `sites/<host>/` with `site.json` and the three subdirs. Every run updates `lastRunAt`.
+- **Bare reference** (`app.example.com/login`, `localhost_3000`) — the token before the first `/` is matched against registered sites by folder name or by the host of their `site.json` URL; the rest is the path. Unknown reference → error listing registered sites and suggesting an absolute URL to register a new one.
+- **Leading-slash path** (`/login`) — needs a base URL from `EXPLORBOT_URL`; otherwise error listing registered sites.
+
+`explorbot sites` lists registered sites — folder name, base URL, last run — via a `SitesCommand` class in `src/commands/`.
+
+## `explorbot init --global`
+
+An interactive React Ink wizard (same interaction pattern as `explorbot learn`):
+
+1. Pick a provider from the supported list (`PROVIDERS` in `src/config.ts`).
+2. Enter the API key (stored in `~/.explorbot/.env` under the provider's conventional variable).
+3. Optionally validate the key with a single test AI call.
+4. Writes `~/.explorbot/config.js` with provider code and the recommended model IDs from `models.json` snapshotted in — no `web.url`, no `dirs` — plus a comment pointing at the providers doc for later edits.
+
+Prints next steps: `explorbot explore https://your-app.example.com` from anywhere.
+
+Non-interactive path for agents: `explorbot init --global --provider <name> [--api-key <key>]` skips the wizard; the key may also come from the environment. `--force` overwrites an existing global config, mirroring project `init`. Logic lives in the init command class in `src/commands/`; the CLI handler stays thin.
+
+Project `init` is unchanged.
+
+## Boats
+
+No boat changes. AI config, dirs, and project root flow through core `ConfigParser`:
+
+- **prima** — its spec's `state/<host>` layout is renamed to `sites/<host>`; its Config-Free Operation section now defers to this spec.
+- **api-tester** — the site folder derives from the endpoint host (`EXPLORBOT_URL` / absolute endpoint).
+- **doc-collector** — from the absolute URL argument of `docs collect`.
+
+Boat-specific config files (`docbot.config.js`, apibot) stay project-local; their options all have defaults, so global-mode runs use those.
+
+## Testing
+
+Unit tests only — nothing here prompts a model except the wizard's optional key validation:
+
+- Ladder order: project config beats global; global beats env-built; env-built error message names `init --global`.
+- Env file order: global `.env` loaded, cwd `.env` overrides.
+- Global mode dir resolution: site dirs, project root, `dirs`-ignored and `web.url`-error rules.
+- Host sanitization: ports, case, invalid characters.
+- Auto-registration: folder + `site.json` created once, `lastRunAt` updated.
+- Bare-reference resolution: folder name, host match, unknown-reference error listing sites.
+- Non-interactive `init --global --provider` writes both files; `--force` semantics.
+
+## Decisions Log
+
+- Global config is a rung in core `ConfigParser`'s lookup, not a flag and not env-only — boats inherit for free.
+- Site folders live under `~/.explorbot/sites/<host>/`, each with `site.json` meta enabling bare-host references and `explorbot sites`.
+- Global mode runs with full project semantics (experience on, Historian on) — the point is memory across runs.
+- Config file beats env vars wholesale, consistent with existing docs; prima spec's per-setting wording amended.
+- `init --global` is an interactive wizard with a `--provider` non-interactive escape for agents.
+- `web.url` in global config errors; `dirs` in global config is ignored.

--- a/docs/superpowers/specs/2026-08-03-global-config-design.md
+++ b/docs/superpowers/specs/2026-08-03-global-config-design.md
@@ -74,7 +74,22 @@ In global mode the target site comes from the command's URL argument, else `EXPL
 
 `explorbot sites` lists registered sites — folder name, base URL, last run — via a `SitesCommand` class in `src/commands/`.
 
-## `explorbot init --global`
+## `explorbot init` — Local or Global
+
+Plain `explorbot init` in an interactive terminal first asks which installation to set up:
+
+```
+? Where should explorbot be initialized?
+❯ Local    — creates the config file in the current directory
+  Global   — initializes explorbot to run from anywhere on this machine
+```
+
+- **Local** runs the existing project flow, unchanged.
+- **Global** runs the global wizard below.
+- When a global config already exists, the Global option is disabled and labeled `(already installed)`; reinstalling requires `explorbot init --global --force`.
+- Outside a TTY (agents, CI), plain `init` skips the chooser and runs the local flow exactly as today. `--global` skips the chooser and goes straight to the global wizard; any other init flag (`--config-path`, `--path`) implies local.
+
+### The global wizard
 
 An interactive React Ink wizard (same interaction pattern as `explorbot learn`):
 
@@ -87,7 +102,7 @@ Prints next steps: `explorbot explore https://your-app.example.com` from anywher
 
 Non-interactive path for agents: `explorbot init --global --provider <name> [--api-key <key>]` skips the wizard; the key may also come from the environment. `--force` overwrites an existing global config, mirroring project `init`. Logic lives in the init command class in `src/commands/`; the CLI handler stays thin.
 
-Project `init` is unchanged.
+The local flow itself is unchanged.
 
 ## Boats
 
@@ -110,6 +125,7 @@ Unit tests only — nothing here prompts a model except the wizard's optional ke
 - Auto-registration: folder + `site.json` created once, `lastRunAt` updated.
 - Bare-reference resolution: folder name, host match, unknown-reference error listing sites.
 - Non-interactive `init --global --provider` writes both files; `--force` semantics.
+- Init chooser: Global option disabled when the global config exists; non-TTY plain `init` falls back to the local flow.
 
 ## Decisions Log
 
@@ -118,4 +134,5 @@ Unit tests only — nothing here prompts a model except the wizard's optional ke
 - Global mode runs with full project semantics (experience on, Historian on) — the point is memory across runs.
 - Config file beats env vars wholesale, consistent with existing docs; prima spec's per-setting wording amended.
 - `init --global` is an interactive wizard with a `--provider` non-interactive escape for agents.
+- Plain `init` opens a Local/Global chooser in interactive terminals; Global shows `(already installed)` and is disabled once configured.
 - `web.url` in global config errors; `dirs` in global config is ignored.

--- a/docs/workflow/agentic-usage.md
+++ b/docs/workflow/agentic-usage.md
@@ -103,10 +103,10 @@ Config-free runs are built to leave no trace in the working directory:
 
 - **Output goes to a per-host state directory** — `~/.explorbot/state/<host>/`, keyed by the host of the URL under test, so repeated runs against the same app collect their states, plans, research, and reports in one place. `EXPLORBOT_OUTPUT` points them somewhere else. Read the path Explorbot resolved from the `Configuration built from EXPLORBOT_* environment variables. Output: …` line.
 - **`EXPLORBOT_EPHEMERAL=1` keeps nothing between runs** — output goes to a fresh temp directory instead, for throwaway CI jobs and demos. The [prima boat](../reference/commands.md#prima-boat) exposes the same switch as `--ephemeral`.
-- **Experience is not written.** Nothing accumulates between runs, so a run is reproducible. Reading existing experience still works if the directory has any.
+- **Experience is written into the per-host state directory.** What worked on a page is remembered and reused by later runs against the same host. `EXPLORBOT_EPHEMERAL=1` turns writing off, so an ephemeral run stays reproducible.
 - **The Historian is off.** No generated CodeceptJS or Playwright test files. Plans and reports are still written.
 
-For a long-lived agent that should learn across runs, use a real config file with experience writing enabled. The per-host state directory preserves run artifacts, but config-free mode still does not write experience.
+For a long-lived agent, the per-host state directory is what carries knowledge across runs; a real config file gives the same memory in a location you choose and check in.
 
 ### Reading results
 

--- a/docs/workflow/agentic-usage.md
+++ b/docs/workflow/agentic-usage.md
@@ -26,7 +26,8 @@ No `init`, no config file, no project directory, no model IDs to look up. A conf
 | `EXPLORBOT_URL` | yes | Base URL to test; the API boat reads it as the base endpoint |
 | `EXPLORBOT_VISION_MODEL` | no | Screenshot analysis; overrides the provider recommendation |
 | `EXPLORBOT_AGENTIC_MODEL` | no | Captain and Pilot decisions; overrides the provider recommendation |
-| `EXPLORBOT_OUTPUT` | no | Output root for states, plans, research, and reports. Defaults to a fresh temp directory |
+| `EXPLORBOT_OUTPUT` | no | Output root for states, plans, research, and reports. Defaults to the per-host state dir under ~/.explorbot/state |
+| `EXPLORBOT_EPHEMERAL` | no | Keep no state between runs — output goes to a fresh temp directory instead of the per-host state dir |
 | `EXPLORBOT_KNOWLEDGE` | no | Inline knowledge text, applied to every page |
 | `EXPLORBOT_KNOWLEDGE_FILE` | no | Path to a knowledge markdown file |
 | `EXPLORBOT_API_SPEC` | no | OpenAPI spec path for the API boat |
@@ -100,11 +101,12 @@ EXPLORBOT_KNOWLEDGE_FILE=./checkout-knowledge.md npx explorbot explore /checkout
 
 Config-free runs are built to leave no trace in the working directory:
 
-- **Output goes to a temp directory** unless `EXPLORBOT_OUTPUT` is set. Read the path from the `Configuration built from EXPLORBOT_* environment variables. Output: …` line.
+- **Output goes to a per-host state directory** — `~/.explorbot/state/<host>/`, keyed by the host of the URL under test, so repeated runs against the same app collect their states, plans, research, and reports in one place. `EXPLORBOT_OUTPUT` points them somewhere else. Read the path Explorbot resolved from the `Configuration built from EXPLORBOT_* environment variables. Output: …` line.
+- **`EXPLORBOT_EPHEMERAL=1` keeps nothing between runs** — output goes to a fresh temp directory instead, for throwaway CI jobs and demos. The [prima boat](../reference/commands.md#prima-boat) exposes the same switch as `--ephemeral`.
 - **Experience is not written.** Nothing accumulates between runs, so a run is reproducible. Reading existing experience still works if the directory has any.
 - **The Historian is off.** No generated CodeceptJS or Playwright test files. Plans and reports are still written.
 
-For a long-lived agent that should learn across runs, use a real config file with experience writing enabled. A stable `EXPLORBOT_OUTPUT` preserves run artifacts, but config-free mode still does not write experience.
+For a long-lived agent that should learn across runs, use a real config file with experience writing enabled. The per-host state directory preserves run artifacts, but config-free mode still does not write experience.
 
 ### Reading results
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,22 @@
   "bin": {
     "explorbot": "./dist/bin/explorbot-cli.js"
   },
-  "files": ["dist/", "src/**/*.ts", "src/**/*.tsx", "bin/**/*.ts", "boat/api-tester/src/**/*.ts", "boat/doc-collector/src/**/*.ts", "boat/doc-collector/bin/**/*.ts", "boat/doc-collector/package.json", "rules/", "assets/sample-files/", "models.json"],
+  "files": [
+    "dist/",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "bin/**/*.ts",
+    "boat/api-tester/src/**/*.ts",
+    "boat/doc-collector/src/**/*.ts",
+    "boat/doc-collector/bin/**/*.ts",
+    "boat/doc-collector/package.json",
+    "boat/prima/src/**/*.ts",
+    "boat/prima/bin/**/*.ts",
+    "boat/prima/package.json",
+    "rules/",
+    "assets/sample-files/",
+    "models.json"
+  ],
   "scripts": {
     "build": "bun run build:bin",
     "build:bin": "bun build bin/explorbot-cli.ts --outdir bin --target node --external commander --format esm",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     }
   },
   "bin": {
-    "explorbot": "./dist/bin/explorbot-cli.js"
+    "explorbot": "./dist/bin/explorbot-cli.js",
+    "prima": "./dist/boat/prima/bin/prima-cli.js"
   },
   "files": [
     "dist/",

--- a/scripts/build-npm.sh
+++ b/scripts/build-npm.sh
@@ -19,14 +19,15 @@ done
 cp package.json "$DIST_DIR/package.json"
 cp models.json "$DIST_DIR/models.json"
 
-CLI="$DIST_DIR/bin/explorbot-cli.js"
-if [ -f "$CLI" ]; then
-  if [[ "$(uname)" == "Darwin" ]]; then
-    sed -i '' '1s|^#!.*|#!/usr/bin/env node|' "$CLI"
-  else
-    sed -i '1s|^#!.*|#!/usr/bin/env node|' "$CLI"
+for CLI in "$DIST_DIR/bin/explorbot-cli.js" "$DIST_DIR/boat/prima/bin/prima-cli.js"; do
+  if [ -f "$CLI" ]; then
+    if [[ "$(uname)" == "Darwin" ]]; then
+      sed -i '' '1s|^#!.*|#!/usr/bin/env node|' "$CLI"
+    else
+      sed -i '1s|^#!.*|#!/usr/bin/env node|' "$CLI"
+    fi
+    chmod +x "$CLI"
   fi
-  chmod +x "$CLI"
-fi
+done
 
 echo "Build complete: $DIST_DIR/"

--- a/src/action.ts
+++ b/src/action.ts
@@ -65,8 +65,8 @@ class Action {
     return this.recovery(() => this.captureOnce(opts));
   }
 
-  async execute(code: string): Promise<Action> {
-    return this.recovery(() => this.executeOnce(code));
+  async execute(code: string, opts: ExecuteOptions = {}): Promise<Action> {
+    return this.recovery(() => this.executeOnce(code, opts.verbatim));
   }
 
   private async captureOnce({ includeScreenshot = false, codeBlock }: { includeScreenshot?: boolean; codeBlock?: string } = {}): Promise<ActionResult> {
@@ -270,7 +270,7 @@ class Action {
     }
   }
 
-  private async executeOnce(code: string): Promise<Action> {
+  private async executeOnce(code: string, verbatim = false): Promise<Action> {
     let error: Error | null = null;
 
     setActivity('🔎 Browsing...', 'action');
@@ -287,8 +287,8 @@ class Action {
     const tracer = trace.getTracer('ai');
     const stepSpan = activeSpan ? tracer.startSpan('codeceptjs.step', undefined, trace.setSpan(context.active(), activeSpan)) : null;
     setStepSpanParent(stepSpan);
-    const sanitizedCode = sanitizeCodeBlock(codeString);
-    const isPlaywright = hasPlaywrightCommands(sanitizedCode);
+    const sanitizedCode = verbatim ? codeString : sanitizeCodeBlock(codeString);
+    const isPlaywright = !verbatim && hasPlaywrightCommands(sanitizedCode);
 
     try {
       debugLog('Executing action:', codeString);
@@ -385,6 +385,10 @@ class Action {
 export default Action;
 
 export type RecoveryRunner = <T>(fn: () => Promise<T>) => Promise<T>;
+
+export interface ExecuteOptions {
+  verbatim?: boolean;
+}
 
 function errorToString(error: any): string {
   if (error.cliMessage) {

--- a/src/ai/navigator.ts
+++ b/src/ai/navigator.ts
@@ -189,7 +189,7 @@ class Navigator implements Agent {
     }
   }
 
-  async resolveState(message: string, actionResult: ActionResult, opts?: { action?: Action; expectedUrl?: string }): Promise<boolean> {
+  async resolveState(message: string, actionResult: ActionResult, opts?: { action?: Action; expectedUrl?: string; onAttempt?: (attempt: { code: string; error?: string }) => void }): Promise<boolean> {
     tag('info').log('AI Navigator resolving state at', actionResult.url);
     debugLog('Resolution message:', message);
 
@@ -363,11 +363,14 @@ class Navigator implements Agent {
           }
         }
 
+        if (attemptOk) opts?.onAttempt?.({ code: codeBlock });
+
         if (!attemptOk) {
           const raw = action.lastError?.message || 'attempt failed';
           const firstMeaningful = raw.split('\n').find((l) => l.trim() && !l.trim().startsWith('at ')) || raw;
           const shortErr = firstMeaningful.replace(/\s+/g, ' ').trim().slice(0, 220);
           batchFailures.push({ code: codeBlock, error: shortErr });
+          opts?.onAttempt?.({ code: codeBlock, error: shortErr });
         }
 
         if (expectedUrl) {

--- a/src/ai/navigator.ts
+++ b/src/ai/navigator.ts
@@ -190,6 +190,8 @@ class Navigator implements Agent {
   }
 
   async resolveState(message: string, actionResult: ActionResult, opts?: { action?: Action; expectedUrl?: string; onAttempt?: (attempt: { code: string; error?: string }) => void }): Promise<boolean> {
+    if (!this.provider) throw new Error('AI-assisted recovery is unavailable: no AI model is configured.');
+
     tag('info').log('AI Navigator resolving state at', actionResult.url);
     debugLog('Resolution message:', message);
 

--- a/src/browser-server.ts
+++ b/src/browser-server.ts
@@ -101,6 +101,19 @@ async function launchServer(opts: { browser?: string; show?: boolean }, instance
   return server;
 }
 
+async function stopServer(instance = 'default'): Promise<boolean> {
+  const endpoint = await getAliveEndpoint(instance);
+  if (!endpoint) return false;
+
+  try {
+    const browser = await chromium.connect(endpoint, { timeout: 3000 });
+    await browser.close();
+  } catch {}
+
+  removeEndpointFile(instance);
+  return true;
+}
+
 async function getAliveEndpoint(instance = 'default'): Promise<string | null> {
   const endpoint = readEndpoint(instance);
   if (!endpoint) return null;
@@ -109,4 +122,4 @@ async function getAliveEndpoint(instance = 'default'): Promise<string | null> {
   return null;
 }
 
-export { readEndpoint, removeEndpointFile, isServerRunning, launchServer, getEndpointFilePath, getAliveEndpoint, listInstances };
+export { readEndpoint, removeEndpointFile, isServerRunning, launchServer, stopServer, getEndpointFilePath, getAliveEndpoint, listInstances };

--- a/src/browser-server.ts
+++ b/src/browser-server.ts
@@ -48,6 +48,7 @@ function listInstances(): Array<{ name: string; endpoint: string }> {
     if (!fileName.startsWith(ENDPOINT_FILENAME)) continue;
     const suffix = fileName.slice(ENDPOINT_FILENAME.length);
     if (suffix && !suffix.startsWith('-')) continue;
+    if (suffix === '-') continue;
     const name = suffix.slice(1) || 'default';
     if (!INSTANCE_NAME_PATTERN.test(name)) continue;
     instances.push({ name, endpoint: readFileSync(path.join(dir, fileName), 'utf8').trim() });

--- a/src/browser-server.ts
+++ b/src/browser-server.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { chromium, firefox, webkit } from 'playwright-core';
+import { chromium, firefox, webkit } from 'playwright';
 import { ConfigParser } from './config.js';
 import { getCliName } from './utils/cli-name.ts';
 import { log } from './utils/logger.js';

--- a/src/browser-server.ts
+++ b/src/browser-server.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { chromium, firefox, webkit } from 'playwright-core';
 import { ConfigParser } from './config.js';
@@ -7,21 +7,26 @@ import { log } from './utils/logger.js';
 import { type NextStepSection, printNextSteps } from './utils/next-steps.ts';
 
 const ENDPOINT_FILENAME = '.browser-endpoint';
+const INSTANCE_NAME_PATTERN = /^[a-z0-9-]+$/;
 
-function getEndpointFilePath(): string {
+function getEndpointFilePath(instance = 'default'): string {
+  if (!INSTANCE_NAME_PATTERN.test(instance)) {
+    throw new Error(`Invalid browser instance name: "${instance}". Use lowercase letters, digits and dashes.`);
+  }
   const configParser = ConfigParser.getInstance();
   const outputDir = configParser.getOutputDir();
-  return path.join(outputDir, ENDPOINT_FILENAME);
+  if (instance === 'default') return path.join(outputDir, ENDPOINT_FILENAME);
+  return path.join(outputDir, `${ENDPOINT_FILENAME}-${instance}`);
 }
 
-function readEndpoint(): string | null {
-  const filePath = getEndpointFilePath();
+function readEndpoint(instance = 'default'): string | null {
+  const filePath = getEndpointFilePath(instance);
   if (!existsSync(filePath)) return null;
   return readFileSync(filePath, 'utf8').trim();
 }
 
-function writeEndpoint(wsEndpoint: string): void {
-  const filePath = getEndpointFilePath();
+function writeEndpoint(wsEndpoint: string, instance = 'default'): void {
+  const filePath = getEndpointFilePath(instance);
   const dir = path.dirname(filePath);
   if (!existsSync(dir)) {
     mkdirSync(dir, { recursive: true });
@@ -29,9 +34,25 @@ function writeEndpoint(wsEndpoint: string): void {
   writeFileSync(filePath, wsEndpoint, 'utf8');
 }
 
-function removeEndpointFile(): void {
-  const filePath = getEndpointFilePath();
+function removeEndpointFile(instance = 'default'): void {
+  const filePath = getEndpointFilePath(instance);
   if (existsSync(filePath)) unlinkSync(filePath);
+}
+
+function listInstances(): Array<{ name: string; endpoint: string }> {
+  const dir = path.dirname(getEndpointFilePath());
+  if (!existsSync(dir)) return [];
+
+  const instances: Array<{ name: string; endpoint: string }> = [];
+  for (const fileName of readdirSync(dir)) {
+    if (!fileName.startsWith(ENDPOINT_FILENAME)) continue;
+    const suffix = fileName.slice(ENDPOINT_FILENAME.length);
+    if (suffix && !suffix.startsWith('-')) continue;
+    const name = suffix.slice(1) || 'default';
+    if (!INSTANCE_NAME_PATTERN.test(name)) continue;
+    instances.push({ name, endpoint: readFileSync(path.join(dir, fileName), 'utf8').trim() });
+  }
+  return instances;
 }
 
 async function isServerRunning(wsEndpoint: string): Promise<boolean> {
@@ -46,7 +67,7 @@ async function isServerRunning(wsEndpoint: string): Promise<boolean> {
 
 const BROWSER_LAUNCHERS = { chromium, firefox, webkit } as const;
 
-async function launchServer(opts: { browser?: string; show?: boolean }): Promise<any> {
+async function launchServer(opts: { browser?: string; show?: boolean }, instance = 'default'): Promise<any> {
   const browserName = (opts.browser || 'chromium') as keyof typeof BROWSER_LAUNCHERS;
   const launcher = BROWSER_LAUNCHERS[browserName];
   if (!launcher) throw new Error(`Unsupported browser: ${browserName}`);
@@ -56,19 +77,21 @@ async function launchServer(opts: { browser?: string; show?: boolean }): Promise
   });
 
   const wsEndpoint = server.wsEndpoint();
-  writeEndpoint(wsEndpoint);
+  writeEndpoint(wsEndpoint, instance);
 
   log(`Browser server started: ${browserName} (${opts.show ? 'headed' : 'headless'})`);
 
   const cli = getCliName();
+  let instanceFlag = '';
+  if (instance !== 'default') instanceFlag = ` --instance ${instance}`;
   const sections: NextStepSection[] = [
     {
       label: 'Browser server',
-      path: getEndpointFilePath(),
+      path: getEndpointFilePath(instance),
       commands: [
         { label: 'Endpoint', command: wsEndpoint },
-        { label: 'Status', command: `${cli} browser status` },
-        { label: 'Stop', command: `${cli} browser stop` },
+        { label: 'Status', command: `${cli} browser status${instanceFlag}` },
+        { label: 'Stop', command: `${cli} browser stop${instanceFlag}` },
       ],
     },
   ];
@@ -77,12 +100,12 @@ async function launchServer(opts: { browser?: string; show?: boolean }): Promise
   return server;
 }
 
-async function getAliveEndpoint(): Promise<string | null> {
-  const endpoint = readEndpoint();
+async function getAliveEndpoint(instance = 'default'): Promise<string | null> {
+  const endpoint = readEndpoint(instance);
   if (!endpoint) return null;
   if (await isServerRunning(endpoint)) return endpoint;
-  removeEndpointFile();
+  removeEndpointFile(instance);
   return null;
 }
 
-export { readEndpoint, removeEndpointFile, isServerRunning, launchServer, getEndpointFilePath, getAliveEndpoint };
+export { readEndpoint, removeEndpointFile, isServerRunning, launchServer, getEndpointFilePath, getAliveEndpoint, listInstances };

--- a/src/browser-server.ts
+++ b/src/browser-server.ts
@@ -115,7 +115,7 @@ async function stopServer(instance = 'default'): Promise<boolean> {
   return true;
 }
 
-function keepServerRunning(stop: () => void | Promise<void>): void {
+function keepServerRunning(stop: () => unknown): Promise<never> {
   console.log('Browser server is running. Press Ctrl+C to stop.');
   const heartbeat = setInterval(() => {}, KEEP_ALIVE_INTERVAL);
 
@@ -128,6 +128,8 @@ function keepServerRunning(stop: () => void | Promise<void>): void {
 
   process.on('SIGINT', cleanup);
   process.on('SIGTERM', cleanup);
+
+  return new Promise<never>(() => {});
 }
 
 async function getAliveEndpoint(instance = 'default'): Promise<string | null> {

--- a/src/browser-server.ts
+++ b/src/browser-server.ts
@@ -8,6 +8,7 @@ import { type NextStepSection, printNextSteps } from './utils/next-steps.ts';
 
 const ENDPOINT_FILENAME = '.browser-endpoint';
 const INSTANCE_NAME_PATTERN = /^[a-z0-9-]+$/;
+const KEEP_ALIVE_INTERVAL = 1 << 30;
 
 function getEndpointFilePath(instance = 'default'): string {
   if (!INSTANCE_NAME_PATTERN.test(instance)) {
@@ -114,6 +115,21 @@ async function stopServer(instance = 'default'): Promise<boolean> {
   return true;
 }
 
+function keepServerRunning(stop: () => void | Promise<void>): void {
+  console.log('Browser server is running. Press Ctrl+C to stop.');
+  const heartbeat = setInterval(() => {}, KEEP_ALIVE_INTERVAL);
+
+  const cleanup = async () => {
+    console.log('\nStopping browser server...');
+    clearInterval(heartbeat);
+    await stop();
+    process.exit(0);
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+}
+
 async function getAliveEndpoint(instance = 'default'): Promise<string | null> {
   const endpoint = readEndpoint(instance);
   if (!endpoint) return null;
@@ -122,4 +138,4 @@ async function getAliveEndpoint(instance = 'default'): Promise<string | null> {
   return null;
 }
 
-export { readEndpoint, removeEndpointFile, isServerRunning, launchServer, stopServer, getEndpointFilePath, getAliveEndpoint, listInstances };
+export { readEndpoint, removeEndpointFile, isServerRunning, launchServer, stopServer, getEndpointFilePath, getAliveEndpoint, listInstances, keepServerRunning };

--- a/src/config.ts
+++ b/src/config.ts
@@ -709,7 +709,7 @@ export function resolveStateRoot(baseUrl: string, ephemeral?: boolean): string {
   const host = URL.parse(baseUrl)?.host;
   if (ephemeral || !host) return mkdtempSync(join(tmpdir(), 'explorbot-'));
 
-  const stateRoot = join(globalDir(), 'state', host);
+  const stateRoot = join(globalDir(), 'state', host.replaceAll(':', '_'));
   mkdirSync(stateRoot, { recursive: true, mode: 0o700 });
   return stateRoot;
 }
@@ -723,8 +723,10 @@ export function materializeKnowledge(outputRoot: string): void {
   const knowledgeFile = process.env.EXPLORBOT_KNOWLEDGE_FILE;
   const knowledgeDir = join(outputRoot, 'knowledge');
   const globalFile = join(knowledgeDir, 'global.md');
+  const envDir = join(knowledgeDir, 'env');
 
   if (!inline) rmSync(globalFile, { force: true });
+  rmSync(envDir, { recursive: true, force: true });
   if (!inline && !knowledgeFile) return;
 
   mkdirSync(knowledgeDir, { recursive: true });
@@ -739,7 +741,8 @@ export function materializeKnowledge(outputRoot: string): void {
   if (!existsSync(source)) {
     throw new Error(`Knowledge file from EXPLORBOT_KNOWLEDGE_FILE not found: ${source}`);
   }
-  copyFileSync(source, join(knowledgeDir, basename(source)));
+  mkdirSync(envDir, { recursive: true });
+  copyFileSync(source, join(envDir, basename(source)));
 }
 
 export async function createModel(provider: string, modelId: string): Promise<any> {

--- a/src/config.ts
+++ b/src/config.ts
@@ -542,7 +542,7 @@ export class ConfigParser {
       playwright: { browser: 'chromium', url, show: false },
       ai,
       dirs: { knowledge: 'knowledge', experience: 'experience', output: '.' },
-      experience: { disabled: true },
+      experience: { disabled: !!process.env.EXPLORBOT_EPHEMERAL },
     };
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -705,10 +705,11 @@ export function resolveOutputRoot(baseUrl?: string): string {
 }
 
 export function resolveStateRoot(baseUrl: string, ephemeral?: boolean): string {
-  if (ephemeral) return mkdtempSync(join(tmpdir(), 'explorbot-'));
+  const host = URL.parse(baseUrl)?.host;
+  if (ephemeral || !host) return mkdtempSync(join(tmpdir(), 'explorbot-'));
 
-  const stateRoot = join(globalDir(), 'state', new URL(baseUrl).host);
-  mkdirSync(stateRoot, { recursive: true });
+  const stateRoot = join(globalDir(), 'state', host);
+  mkdirSync(stateRoot, { recursive: true, mode: 0o700 });
   return stateRoot;
 }
 
@@ -719,13 +720,16 @@ export function globalDir(): string {
 export function materializeKnowledge(outputRoot: string): void {
   const inline = process.env.EXPLORBOT_KNOWLEDGE;
   const knowledgeFile = process.env.EXPLORBOT_KNOWLEDGE_FILE;
+  const knowledgeDir = join(outputRoot, 'knowledge');
+  const globalFile = join(knowledgeDir, 'global.md');
+
+  if (!inline) rmSync(globalFile, { force: true });
   if (!inline && !knowledgeFile) return;
 
-  const knowledgeDir = join(outputRoot, 'knowledge');
   mkdirSync(knowledgeDir, { recursive: true });
 
   if (inline) {
-    writeFileSync(join(knowledgeDir, 'global.md'), matter.stringify(inline, { url: '*', endpoint: '*' }));
+    writeFileSync(globalFile, matter.stringify(inline, { url: '*', endpoint: '*' }));
   }
 
   if (!knowledgeFile) return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import os, { tmpdir } from 'node:os';
 import path, { basename, dirname, join, resolve } from 'node:path';
 import { parseEnv } from 'node:util';
 import matter from 'gray-matter';
@@ -254,13 +254,16 @@ type RuleEntry = string | Record<string, string>;
 
 export const EXPLORBOT_CONFIG_PATHS = ['explorbot.config.js', 'explorbot.config.mjs', 'explorbot.config.ts'];
 
+export const GLOBAL_CONFIG_NAMES = ['config.js', 'config.mjs', 'config.ts'];
+
 export const EXPLORBOT_ENV_VARS: EnvVar[] = [
   { name: 'EXPLORBOT_AI_PROVIDER', required: true, description: 'Provider name; fills every model role from its recommended models. Turns on config-free mode' },
   { name: 'EXPLORBOT_AI_MODEL', description: 'Pins the main model — a model id for the provider, or a standalone provider/model-id' },
   { name: 'EXPLORBOT_URL', required: true, description: 'Base URL to test; the API boat reads it as the base endpoint' },
   { name: 'EXPLORBOT_VISION_MODEL', description: 'Screenshot analysis; overrides the provider recommendation' },
   { name: 'EXPLORBOT_AGENTIC_MODEL', description: 'Captain and Pilot decisions; overrides the provider recommendation' },
-  { name: 'EXPLORBOT_OUTPUT', description: 'Output root for states, plans, research, and reports. Defaults to a fresh temp directory' },
+  { name: 'EXPLORBOT_OUTPUT', description: 'Output root for states, plans, research, and reports. Defaults to the per-host state dir under ~/.explorbot/state' },
+  { name: 'EXPLORBOT_EPHEMERAL', description: 'Keep no state between runs — output goes to a fresh temp directory instead of the per-host state dir' },
   { name: 'EXPLORBOT_KNOWLEDGE', description: 'Inline knowledge text, applied to every page' },
   { name: 'EXPLORBOT_KNOWLEDGE_FILE', description: 'Path to a knowledge markdown file' },
   { name: 'EXPLORBOT_API_SPEC', description: 'OpenAPI spec path for the API boat' },
@@ -303,10 +306,20 @@ export class ConfigParser {
 
   private constructor() {}
 
-  public static loadEnv(filePath: string): void {
+  public static loadEnv(filePath: string, keepExisting = false): void {
     const resolved = resolve(filePath);
     if (!existsSync(resolved)) return;
-    Object.assign(process.env, parseEnv(readFileSync(resolved, 'utf8')));
+
+    const parsed = parseEnv(readFileSync(resolved, 'utf8'));
+    if (!keepExisting) {
+      Object.assign(process.env, parsed);
+      return;
+    }
+
+    for (const [key, value] of Object.entries(parsed)) {
+      if (key in process.env) continue;
+      process.env[key] = value as string;
+    }
   }
 
   public static recommendedModels(): Record<string, Record<string, string>> {
@@ -342,6 +355,7 @@ export class ConfigParser {
     }
 
     ConfigParser.loadEnv('.env');
+    ConfigParser.loadEnv(join(globalDir(), '.env'), true);
 
     try {
       const resolvedPath = options?.config || this.findConfigFile();
@@ -361,7 +375,7 @@ export class ConfigParser {
       }
 
       if (!resolvedPath) {
-        const outputRoot = resolveOutputRoot();
+        const outputRoot = resolveOutputRoot(process.env.EXPLORBOT_URL || options?.baseUrl);
         loadedConfig = await this.buildEnvConfig(options?.baseUrl, outputRoot);
         sourcePath = join(outputRoot, 'explorbot.config.js');
 
@@ -542,6 +556,13 @@ export class ConfigParser {
       }
     }
 
+    for (const name of GLOBAL_CONFIG_NAMES) {
+      const globalPath = join(globalDir(), name);
+      if (existsSync(globalPath)) {
+        return globalPath;
+      }
+    }
+
     return null;
   }
 
@@ -664,18 +685,35 @@ export async function resolveModel(spec: string, role: ModelRole = 'model'): Pro
   return createModel(spec, modelId);
 }
 
-export function resolveOutputRoot(): string {
+export function resolveOutputRoot(baseUrl?: string): string {
   if (cachedOutputRoot) return cachedOutputRoot;
 
   const configured = process.env.EXPLORBOT_OUTPUT;
-  if (!configured) {
-    cachedOutputRoot = mkdtempSync(join(tmpdir(), 'explorbot-'));
+  if (configured) {
+    cachedOutputRoot = resolve(configured);
+    mkdirSync(cachedOutputRoot, { recursive: true });
     return cachedOutputRoot;
   }
 
-  cachedOutputRoot = resolve(configured);
-  mkdirSync(cachedOutputRoot, { recursive: true });
+  if (baseUrl) {
+    cachedOutputRoot = resolveStateRoot(baseUrl, !!process.env.EXPLORBOT_EPHEMERAL);
+    return cachedOutputRoot;
+  }
+
+  cachedOutputRoot = mkdtempSync(join(tmpdir(), 'explorbot-'));
   return cachedOutputRoot;
+}
+
+export function resolveStateRoot(baseUrl: string, ephemeral?: boolean): string {
+  if (ephemeral) return mkdtempSync(join(tmpdir(), 'explorbot-'));
+
+  const stateRoot = join(globalDir(), 'state', new URL(baseUrl).host);
+  mkdirSync(stateRoot, { recursive: true });
+  return stateRoot;
+}
+
+export function globalDir(): string {
+  return join(os.homedir(), '.explorbot');
 }
 
 export function materializeKnowledge(outputRoot: string): void {

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -47,6 +47,7 @@ export interface ExplorBotOptions {
   incognito?: boolean;
   session?: string | boolean;
   instance?: string;
+  optionalAi?: boolean;
 }
 
 export type UserResolveFunction = (error?: Error, showWelcome?: boolean) => Promise<string | null>;
@@ -62,6 +63,7 @@ export class ExplorBot {
   private planFeature?: string;
   lastPlanError: Error | null = null;
   lastSavedPlanPath: string | null = null;
+  private aiFailure: string | null = null;
   private agents: Record<string, any> = {};
   private sessionPlans: Plan[] = [];
   private lastReportedTestCount = 0;
@@ -105,7 +107,7 @@ export class ExplorBot {
         playwrightRecorder: this.playwrightRecorder(),
       });
       await this.explorer.start();
-      if (!this.options.incognito) {
+      if (!this.options.incognito && this.provider) {
         await this.agentExperienceCompactor().autocompact();
       }
     } catch (error) {
@@ -119,8 +121,13 @@ export class ExplorBot {
     if (this.provider) return;
     this.config = await this.configParser.loadConfig(this.options);
     if (this.options.session === true) this.options.session = path.join(this.configParser.getOutputDir(), 'session.json');
+    if (this.options.optionalAi) return this.bootstrapOptionalProvider();
     this.provider = new AIProvider(this.config.ai);
     await this.provider.validateConnection();
+  }
+
+  aiFailureReason(): string | null {
+    return this.aiFailure;
   }
 
   async stop(): Promise<void> {
@@ -518,5 +525,16 @@ export class ExplorBot {
 
   private isHistorianEnabled(): boolean {
     return this.config.ai?.agents?.historian?.enabled !== false;
+  }
+
+  private async bootstrapOptionalProvider(): Promise<void> {
+    try {
+      const provider = new AIProvider(this.config.ai);
+      await provider.validateConnection();
+      this.provider = provider;
+    } catch (error) {
+      this.aiFailure = browserErrorMessage(error);
+      tag('debug').log(`AI provider unavailable: ${this.aiFailure}`);
+    }
   }
 }

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -46,6 +46,7 @@ export interface ExplorBotOptions {
   headless?: boolean;
   incognito?: boolean;
   session?: string | boolean;
+  instance?: string;
 }
 
 export type UserResolveFunction = (error?: Error, showWelcome?: boolean) => Promise<string | null>;

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
+import type { Browser } from 'playwright';
 import type { AgentDeps } from './ai/agent.ts';
 import { Captain } from './ai/captain.ts';
 import { Driller } from './ai/driller.ts';
@@ -48,6 +49,7 @@ export interface ExplorBotOptions {
   session?: string | boolean;
   instance?: string;
   optionalAi?: boolean;
+  attachedBrowser?: Browser;
 }
 
 export type UserResolveFunction = (error?: Error, showWelcome?: boolean) => Promise<string | null>;
@@ -89,6 +91,10 @@ export class ExplorBot {
 
   setUserResolve(fn: UserResolveFunction): void {
     this.userResolveFn = fn;
+  }
+
+  attachBrowser(browser: Browser): void {
+    this.options.attachedBrowser = browser;
   }
 
   async start(): Promise<void> {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -310,7 +310,7 @@ class Explorer {
 
   private async connectOrLaunchBrowser(): Promise<void> {
     const { getAliveEndpoint } = await import('./browser-server.js');
-    const endpoint = await getAliveEndpoint();
+    const endpoint = await getAliveEndpoint(this.options?.instance);
 
     if (endpoint) {
       const browserName = this.config.playwright.browser || 'chromium';
@@ -733,6 +733,7 @@ export interface ExplorerOptions {
   headless?: boolean;
   incognito?: boolean;
   session?: string;
+  instance?: string;
 }
 
 export interface ExplorerDeps {

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -6,7 +6,7 @@ import stepsListener from 'codeceptjs/lib/listener/steps';
 import storeListener from 'codeceptjs/lib/listener/store';
 import { createTest } from 'codeceptjs/lib/mocha/test';
 import dedent from 'dedent';
-import type { BrowserContextOptions, Page } from 'playwright';
+import type { Browser, BrowserContextOptions, Page } from 'playwright';
 import { ActionResult } from './action-result.ts';
 import Action from './action.js';
 import type { RequestStore } from './api/request-store.ts';
@@ -103,8 +103,8 @@ class Explorer {
       throw new Error('Playwright helper not available');
     }
     await this.connectOrLaunchBrowser();
-    const hasSession = this.options?.session && existsSync(this.options.session);
-    await this.playwrightHelper._createContextPage(this.createBrowserContextOptions());
+    const hasSession = !this.options?.attachedBrowser && this.options?.session && existsSync(this.options.session);
+    await this.openContextPage();
     await this.playwrightRecorder.start(this.playwrightHelper.browserContext);
     this.attachXhrCapture();
     if (hasSession) {
@@ -123,10 +123,11 @@ class Explorer {
   async stop(): Promise<void> {
     if (!this.started) return;
     this.started = false;
+    const attached = !!this.options?.attachedBrowser;
 
     await this.stopCaptures();
 
-    if (this.options?.session && this.playwrightHelper?.browserContext) {
+    if (!attached && this.options?.session && this.playwrightHelper?.browserContext) {
       const dir = path.dirname(this.options.session);
       if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
       await this.playwrightHelper.browserContext.storageState({ path: this.options.session });
@@ -141,7 +142,14 @@ class Explorer {
       return;
     }
 
-    tag('info').log('Closing browser context (persistent browser stays running)');
+    if (attached) {
+      tag('info').log('Disconnecting from attached browser (its pages stay open)');
+      await this.playwrightHelper.browser?.close().catch((err: unknown) => {
+        debugLog('Failed to disconnect from attached browser:', err);
+      });
+    }
+
+    if (!attached) tag('info').log('Closing browser context (persistent browser stays running)');
     await this.closeBrowserContext();
     this.playwrightHelper.browser = null;
     this.playwrightHelper.isRunning = false;
@@ -309,6 +317,14 @@ class Explorer {
   }
 
   private async connectOrLaunchBrowser(): Promise<void> {
+    if (this.options?.attachedBrowser) {
+      this.playwrightHelper.browser = this.options.attachedBrowser;
+      this.playwrightHelper.isRunning = true;
+      this.isSharedBrowser = true;
+      tag('success').log('Attached to a browser opened by another tool');
+      return;
+    }
+
     const { getAliveEndpoint } = await import('./browser-server.js');
     const endpoint = await getAliveEndpoint(this.options?.instance);
 
@@ -324,6 +340,21 @@ class Explorer {
     }
 
     await this.playwrightHelper._startBrowser();
+  }
+
+  private async openContextPage(): Promise<void> {
+    const attached = this.options?.attachedBrowser;
+    if (!attached) {
+      await this.playwrightHelper._createContextPage(this.createBrowserContextOptions());
+      return;
+    }
+
+    const context = attached.contexts()[0] || (await attached.newContext());
+    const pages = context.pages();
+    const page = pages[pages.length - 1] || (await context.newPage());
+    this.playwrightHelper.browserContext = context;
+    await this.playwrightHelper._setPage(page);
+    debugLog(`Adopted attached browser page: ${page.url()}`);
   }
 
   private createBrowserContextOptions(): BrowserContextOptions {
@@ -506,6 +537,10 @@ class Explorer {
   }
 
   private async closeBrowserContext(): Promise<void> {
+    if (this.options?.attachedBrowser) {
+      this.playwrightHelper.browserContext = null;
+      return;
+    }
     if (!this.playwrightHelper.browserContext) return;
     await this.playwrightHelper.browserContext.close().catch((err: unknown) => {
       debugLog('Failed to close browser context:', err);
@@ -529,7 +564,7 @@ class Explorer {
       }
 
       await this.connectOrLaunchBrowser();
-      await this.playwrightHelper._createContextPage(this.createBrowserContextOptions());
+      await this.openContextPage();
       await this.playwrightRecorder.start(this.playwrightHelper.browserContext);
       this.attachXhrCapture();
       this.listenToStateChanged();
@@ -631,6 +666,7 @@ class Explorer {
 
   private async closeOtherTabs(): Promise<void> {
     if (!this.playwrightHelper) return;
+    if (this.options?.attachedBrowser) return;
 
     const context = this.playwrightHelper.page.context();
     const pages = context.pages();
@@ -734,6 +770,7 @@ export interface ExplorerOptions {
   incognito?: boolean;
   session?: string;
   instance?: string;
+  attachedBrowser?: Browser;
 }
 
 export interface ExplorerDeps {

--- a/tests/integration/prima-do.test.ts
+++ b/tests/integration/prima-do.test.ts
@@ -1,0 +1,142 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createOpenAI } from '@ai-sdk/openai';
+import { LLMock } from '@copilotkit/aimock';
+import { Prima } from '../../boat/prima/src/prima.ts';
+import { Provider } from '../../src/ai/provider.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+const boardState = {
+  url: '/tasks/board',
+  title: 'Task Board - Task Tracker',
+  hash: 'board_h1_task_board',
+  html: '<html><body><h1>Task Board</h1><button class="account-menu">Account</button><a href="/settings">Settings</a></body></html>',
+  ariaSnapshot: '- heading "Task Board" [level=1]\n- button "Account"\n- link "Settings"',
+};
+
+function clickCall(id: string, commands: string[], explanation: string) {
+  return { id, name: 'click', arguments: JSON.stringify({ commands, explanation }) };
+}
+
+function extractPromptText(entry: any): string {
+  if (!entry?.body?.messages) return '';
+  return entry.body.messages
+    .map((message: any) => {
+      if (typeof message.content === 'string') return message.content;
+      if (Array.isArray(message.content)) {
+        return message.content
+          .filter((part: any) => part.type === 'text')
+          .map((part: any) => part.text || '')
+          .join('\n');
+      }
+      return '';
+    })
+    .join('\n');
+}
+
+describe('Prima.do with aimock', () => {
+  let mock: LLMock;
+  let provider: Provider;
+  let prima: Prima;
+  let executed: string[];
+  let artifacts: string;
+
+  beforeAll(async () => {
+    mock = new LLMock({ port: 0, logLevel: 'silent' });
+    await mock.start();
+
+    const openai = createOpenAI({
+      baseURL: `${mock.url}/v1`,
+      apiKey: 'test-key',
+      compatibility: 'compatible',
+    });
+
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+    provider = new Provider({ model: openai.chat('test-model'), config: {} });
+    artifacts = mkdtempSync(path.join(tmpdir(), 'prima-do-'));
+  });
+
+  beforeEach(() => {
+    mock.clearRequests();
+    mock.resetMatchCounts();
+    mock.clearFixtures();
+
+    executed = [];
+    const action = {
+      lastError: null,
+      actionResult: null,
+      exitIframe: async () => {},
+      attempt: async (code: string) => {
+        executed.push(code);
+        return true;
+      },
+      saveScreenshot: async () => null,
+    };
+
+    prima = new Prima({ instance: 'default' });
+    (prima as any).artifactsDir = artifacts;
+    (prima as any).bot = {
+      getExplorer: () => ({ action: () => action, capture: async () => null }),
+      stateManager: () => ({ getCurrentState: () => boardState, getVisitCount: () => 1 }),
+      getCurrentState: () => boardState,
+      requestStore: () => ({ getRequests: () => [] }),
+      getProvider: () => provider,
+      experienceTracker: () => ({ renderExperienceTocFor: () => '' }),
+    };
+  });
+
+  afterAll(async () => {
+    await mock.stop();
+    rmSync(artifacts, { recursive: true, force: true });
+    ConfigParser.cleanupAllTestDirectories();
+  });
+
+  it('runs both instructions and collects the executed code', async () => {
+    mock.on({ sequenceIndex: 0 }, { toolCalls: [clickCall('call-1', ['I.click("Account")'], 'open the account menu')] });
+    mock.on({ sequenceIndex: 1 }, { toolCalls: [clickCall('call-2', ['I.click("Settings")'], 'choose the settings entry')] });
+    mock.on({}, { content: 'Both instructions are done.' });
+
+    const envelope = await prima.do(['open the account menu', 'choose the settings entry']);
+
+    expect(envelope.ok).toBe(true);
+    expect(envelope.used).toEqual(['I.click("Account")', 'I.click("Settings")']);
+    expect(executed).toEqual(['I.click("Account")', 'I.click("Settings")']);
+    expect(envelope.command).toContain('open the account menu');
+  });
+
+  it('sends every instruction and the page context in one prompt', async () => {
+    mock.on({ sequenceIndex: 0 }, { toolCalls: [clickCall('call-1', ['I.click("Account")'], 'open the account menu')] });
+    mock.on({}, { content: 'Both instructions are done.' });
+
+    await prima.do(['open the account menu', 'choose the settings entry']);
+
+    const prompt = extractPromptText(mock.getRequests()[0]);
+    expect(prompt).toContain('1. open the account menu');
+    expect(prompt).toContain('2. choose the settings entry');
+    expect(prompt).toContain('<page url="/tasks/board"');
+    expect(prompt).toContain('button "Account"');
+  });
+
+  it('offers the page interaction tools to the model', async () => {
+    mock.on({}, { content: 'Nothing to do here.' });
+
+    await prima.do(['open the account menu']);
+
+    const tools = (mock.getRequests()[0] as any).body.tools.map((entry: any) => entry.function.name);
+    expect(tools).toContain('click');
+    expect(tools).toContain('form');
+  });
+
+  it('reports a failure when the model performs no action', async () => {
+    mock.on({}, { content: 'This board has no account menu.' });
+
+    const envelope = await prima.do(['open the account menu']);
+
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain('No action was performed');
+    expect(envelope.failure?.error).toContain('This board has no account menu.');
+  });
+});

--- a/tests/integration/prima-heal.test.ts
+++ b/tests/integration/prima-heal.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createOpenAI } from '@ai-sdk/openai';
+import { LLMock } from '@copilotkit/aimock';
+import { Prima } from '../../boat/prima/src/prima.ts';
+import { ActionResult } from '../../src/action-result.ts';
+import { Navigator } from '../../src/ai/navigator.ts';
+import { Provider } from '../../src/ai/provider.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+const checkoutState = {
+  url: '/checkout',
+  title: 'Checkout - Widget Depot',
+  hash: 'checkout_h1_checkout',
+  html: '<html><body><h1>Checkout</h1><button id="place-order">Place order</button></body></html>',
+  ariaSnapshot: '- heading "Checkout" [level=1]\n- button "Place order"',
+};
+
+const recovery = ['Both routes below reach the same outcome.', '', "```js\nI.click('Confirm purchase')\n```", '', "```js\nI.click('#place-order')\n```"].join('\n');
+
+function extractPromptText(entry: any): string {
+  if (!entry?.body?.messages) return '';
+  return entry.body.messages
+    .map((message: any) => {
+      if (typeof message.content === 'string') return message.content;
+      if (Array.isArray(message.content)) {
+        return message.content
+          .filter((part: any) => part.type === 'text')
+          .map((part: any) => part.text || '')
+          .join('\n');
+      }
+      return '';
+    })
+    .join('\n');
+}
+
+describe('Prima heal with aimock', () => {
+  let mock: LLMock;
+  let provider: Provider;
+  let prima: Prima;
+  let attempted: string[];
+  let artifacts: string;
+
+  function buildNavigator(succeedsWith: string): Navigator {
+    const action: any = {
+      lastError: null,
+      actionResult: null,
+      exitIframe: async () => {},
+      attempt: async (code: string) => {
+        attempted.push(code);
+        if (code.includes(succeedsWith)) {
+          action.lastError = null;
+          return true;
+        }
+        action.lastError = new Error('element not visible');
+        return false;
+      },
+      getActor: () => ({ wait: async () => {} }),
+      stateManager: { getCurrentState: () => checkoutState },
+    };
+
+    const experienceTracker = { getSuccessfulExperience: () => [], writeFlow: () => {} };
+    return new Navigator({
+      explorer: { action: () => action, capture: async () => ActionResult.fromState(checkoutState as any) } as any,
+      ai: provider,
+      config: ConfigParser.getInstance().getConfig(),
+      stateManager: { getCurrentState: () => checkoutState, getVisitCount: () => 1, getExperienceTracker: () => experienceTracker } as any,
+      knowledgeTracker: { renderRelevantKnowledge: () => '', getRelevantKnowledge: () => [] } as any,
+      requestStore: {} as any,
+      playwrightRecorder: {} as any,
+    });
+  }
+
+  beforeAll(async () => {
+    mock = new LLMock({ port: 0, logLevel: 'silent' });
+    await mock.start();
+
+    const openai = createOpenAI({
+      baseURL: `${mock.url}/v1`,
+      apiKey: 'test-key',
+      compatibility: 'compatible',
+    });
+
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+    provider = new Provider({ model: openai.chat('test-model'), config: {} });
+    artifacts = mkdtempSync(path.join(tmpdir(), 'prima-heal-'));
+  });
+
+  beforeEach(() => {
+    mock.clearRequests();
+    mock.resetMatchCounts();
+    mock.clearFixtures();
+
+    attempted = [];
+    prima = new Prima({ instance: 'default' });
+    (prima as any).artifactsDir = artifacts;
+    (prima as any).bot = {
+      getExplorer: () => ({
+        action: () => ({
+          execute: async () => {
+            throw new Error("locator 'text=Confirm' not found");
+          },
+        }),
+        capture: async () => ActionResult.fromState(checkoutState as any),
+      }),
+      stateManager: () => ({ getCurrentState: () => checkoutState, getVisitCount: () => 1 }),
+      getCurrentState: () => checkoutState,
+      requestStore: () => ({ getRequests: () => [] }),
+      getProvider: () => provider,
+    };
+  });
+
+  afterAll(async () => {
+    await mock.stop();
+    rmSync(artifacts, { recursive: true, force: true });
+    ConfigParser.cleanupAllTestDirectories();
+  });
+
+  it('recovers a failed pw along another route and reports the code that worked', async () => {
+    mock.on({}, { content: recovery });
+    (prima as any).bot.agentNavigator = () => buildNavigator('#place-order');
+
+    const envelope = await prima.pw("({ page }) => page.click('text=Confirm')");
+
+    expect(envelope.ok).toBe(true);
+    expect(envelope.healed).toBe(true);
+    expect(envelope.healNote).toContain('2 attempts');
+    expect(envelope.used).toEqual(["I.click('#place-order')"]);
+    expect(attempted).toEqual(["I.click('Confirm purchase')", "I.click('#place-order')"]);
+  });
+
+  it('asks the model to reach the same outcome another way', async () => {
+    mock.on({}, { content: recovery });
+    (prima as any).bot.agentNavigator = () => buildNavigator('#place-order');
+
+    await prima.pw("({ page }) => page.click('text=Confirm')");
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain("({ page }) => page.click('text=Confirm')");
+    expect(prompt).toContain("locator 'text=Confirm' not found");
+    expect(prompt).toContain('Reach the same outcome on the current page in a different way.');
+    expect(prompt).toContain('button "Place order"');
+  });
+
+  it('reports every attempt and its outcome when recovery does not work', async () => {
+    mock.on({}, { content: recovery });
+    (prima as any).bot.agentNavigator = () => buildNavigator('nothing-matches-this');
+
+    const envelope = await prima.pw("({ page }) => page.click('text=Confirm')");
+
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toContain("locator 'text=Confirm' not found");
+    expect(envelope.failure?.attempts.map((attempt) => attempt.code)).toContain("I.click('#place-order')");
+    expect(envelope.failure?.attempts.every((attempt) => attempt.outcome.includes('element not visible'))).toBe(true);
+    expect(envelope.failure?.compactAria).toContain('button "Place order"');
+  });
+});

--- a/tests/integration/prima-heal.test.ts
+++ b/tests/integration/prima-heal.test.ts
@@ -67,7 +67,7 @@ describe('Prima heal with aimock', () => {
       ai: provider,
       config: ConfigParser.getInstance().getConfig(),
       stateManager: { getCurrentState: () => checkoutState, getVisitCount: () => 1, getExperienceTracker: () => experienceTracker } as any,
-      knowledgeTracker: { renderRelevantKnowledge: () => '', getRelevantKnowledge: () => [] } as any,
+      knowledgeTracker: { renderRelevantKnowledge: () => '', renderRelevantContext: () => '', getRelevantKnowledge: () => [] } as any,
       requestStore: {} as any,
       playwrightRecorder: {} as any,
     });

--- a/tests/integration/prima-smoke.test.ts
+++ b/tests/integration/prima-smoke.test.ts
@@ -117,6 +117,16 @@ describe('Prima drives a real page', () => {
     expect(rendered).toContain('### Instance');
   });
 
+  test('pw runs a multi-line function without losing any of its lines', async () => {
+    const expression = ['async ({ page }) => {', "  await page.fill('#note', 'the hinge arrived bent');", "  await page.click('text=Submit');", '}'].join('\n');
+
+    const envelope = await prima.pw(expression);
+
+    expect(envelope.ok).toBe(true);
+    expect(envelope.page.title).toBe('Widget Depot Thanks');
+    expect(envelope.page.url).toContain('note=the+hinge+arrived+bent');
+  });
+
   test('pw writes the aria, html and network artifacts to disk', async () => {
     const envelope = await prima.pw("({ page }) => page.click('text=Submit')");
 

--- a/tests/integration/prima-smoke.test.ts
+++ b/tests/integration/prima-smoke.test.ts
@@ -197,6 +197,47 @@ describe('Prima without a browser session', () => {
   }, 60000);
 });
 
+describe('Prima without a config file', () => {
+  let workspace: string;
+  let home: string;
+
+  beforeAll(() => {
+    workspace = mkdtempSync(path.join(tmpdir(), 'prima-config-free-'));
+    home = path.join(workspace, 'home');
+    mkdirSync(path.join(home, '.cache'), { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  function runCli(args: string[]) {
+    const env: Record<string, string> = { ...process.env, HOME: home, XDG_CACHE_HOME: path.join(home, '.cache'), EXPLORBOT_AI_PROVIDER: 'groq' };
+    for (const key of ['EXPLORBOT_URL', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_EPHEMERAL']) delete env[key];
+
+    const run = Bun.spawnSync(['bun', PRIMA_CLI, ...args], { cwd: workspace, env });
+    return { exitCode: run.exitCode, stdout: run.stdout.toString() };
+  }
+
+  test('the go target is the url the configuration is built around', () => {
+    const run = runCli(['go', 'https://app.example.com/login']);
+
+    expect(run.stdout).not.toContain('No URL to explore');
+    expect(run.stdout).toContain('playwright-cli open');
+    expect(run.exitCode).toBe(1);
+    expect(existsSync(path.join(home, '.explorbot', 'state', 'app.example.com'))).toBe(true);
+  }, 60000);
+
+  test('--url is the url the configuration is built around', () => {
+    const run = runCli(['pw', "({ page }) => page.click('text=Submit')", '--url', 'https://shop.example.com']);
+
+    expect(run.stdout).not.toContain('No URL to explore');
+    expect(run.stdout).toContain('playwright-cli open');
+    expect(run.exitCode).toBe(1);
+    expect(existsSync(path.join(home, '.explorbot', 'state', 'shop.example.com'))).toBe(true);
+  }, 60000);
+});
+
 describe('Prima attaches to a live playwright-cli session', () => {
   test.skipIf(!liveSession)(
     'reports the playwright-cli session it is driving — skipped unless a playwright-cli session is open for this workspace',

--- a/tests/integration/prima-smoke.test.ts
+++ b/tests/integration/prima-smoke.test.ts
@@ -1,0 +1,212 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { type Browser, chromium } from 'playwright';
+import { renderEnvelope } from '../../boat/prima/src/envelope.ts';
+import { Prima } from '../../boat/prima/src/prima.ts';
+import { readDescriptors, registryDir, selectDescriptor } from '../../boat/prima/src/pw-registry.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+const PRIMA_CLI = path.join(process.cwd(), 'boat', 'prima', 'bin', 'prima-cli.ts');
+
+const FEEDBACK_PAGE = `<!doctype html>
+<html>
+  <head><title>Widget Depot Feedback</title></head>
+  <body>
+    <h1>Send feedback</h1>
+    <form action="/thanks" method="get">
+      <label for="note">Your message</label>
+      <input id="note" name="note" type="text" />
+      <button type="submit">Submit</button>
+    </form>
+  </body>
+</html>`;
+
+const THANKS_PAGE = `<!doctype html>
+<html>
+  <head><title>Widget Depot Thanks</title></head>
+  <body><h1>Thanks for the note</h1></body>
+</html>`;
+
+function startFixtureServer() {
+  return Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === '/thanks') return new Response(THANKS_PAGE, { headers: { 'content-type': 'text/html' } });
+      return new Response(FEEDBACK_PAGE, { headers: { 'content-type': 'text/html' } });
+    },
+  });
+}
+
+function writeDescriptor(dir: string, title: string) {
+  mkdirSync(dir, { recursive: true });
+  const descriptor = {
+    playwrightVersion: '1.62.0',
+    playwrightLib: '',
+    title,
+    endpoint: 'ws://127.0.0.1:1/smoke-session',
+    workspaceDir: process.cwd(),
+    browser: { browserName: 'chromium', guid: 'smoke-guid' },
+  };
+  writeFileSync(path.join(dir, 'smoke-guid'), JSON.stringify(descriptor), 'utf8');
+}
+
+const liveSession = selectDescriptor(readDescriptors(), { workspaceDir: process.cwd() }).match;
+
+describe('Prima drives a real page', () => {
+  let server: ReturnType<typeof startFixtureServer>;
+  let browser: Browser;
+  let prima: Prima;
+  let home: string;
+  let base: string;
+  const realHome = process.env.HOME;
+  const realCache = process.env.XDG_CACHE_HOME;
+
+  beforeAll(async () => {
+    server = startFixtureServer();
+    base = `http://127.0.0.1:${server.port}`;
+
+    home = mkdtempSync(path.join(tmpdir(), 'prima-smoke-'));
+    process.env.HOME = home;
+    process.env.XDG_CACHE_HOME = path.join(home, '.cache');
+    writeDescriptor(registryDir(), 'default');
+
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+
+    browser = await chromium.launch({ headless: true });
+    prima = new Prima({ instance: 'default' });
+    (prima as any).connectDescriptor = async () => browser;
+    await prima.start();
+  });
+
+  beforeEach(async () => {
+    await prima.go(`${base}/`);
+  });
+
+  afterAll(async () => {
+    await prima?.stop().catch(() => {});
+    await browser?.close().catch(() => {});
+    server?.stop(true);
+    process.env.HOME = realHome;
+    process.env.XDG_CACHE_HOME = realCache;
+    rmSync(home, { recursive: true, force: true });
+    ConfigParser.cleanupAllTestDirectories();
+  });
+
+  test('attaches to the workspace session instead of launching a browser', async () => {
+    const info = await prima.instanceInfo();
+    expect(info.attached).toContain('default');
+    expect(info.attached).toContain(process.cwd());
+    expect(existsSync(path.join(home, '.explorbot'))).toBe(false);
+  });
+
+  test('pw clicks the fixture form and reports the page change', async () => {
+    const envelope = await prima.pw("({ page }) => page.click('text=Submit')");
+
+    expect(envelope.ok).toBe(true);
+    expect(envelope.used).toEqual(["({ page }) => page.click('text=Submit')"]);
+    expect(envelope.page.title).toBe('Widget Depot Thanks');
+    expect(envelope.page.previousUrl).not.toBe(envelope.page.url);
+    expect(envelope.changes).toContain('Submit');
+
+    const rendered = renderEnvelope(envelope);
+    expect(rendered).toContain('### Changes');
+    expect(rendered).toContain('### Instance');
+  });
+
+  test('pw writes the aria, html and network artifacts to disk', async () => {
+    const envelope = await prima.pw("({ page }) => page.click('text=Submit')");
+
+    expect(existsSync(envelope.artifacts!.aria)).toBe(true);
+    expect(existsSync(envelope.artifacts!.html)).toBe(true);
+    expect(existsSync(envelope.artifacts!.network)).toBe(true);
+    expect(await Bun.file(envelope.artifacts!.aria).text()).toContain('Thanks for the note');
+    expect(await Bun.file(envelope.artifacts!.html).text()).toContain('Thanks for the note');
+  });
+
+  test('a non-function argument is a tool error and leaves the page alone', async () => {
+    const envelope = await prima.pw("page.click('text=Submit')");
+
+    expect(envelope.ok).toBe(false);
+    expect(envelope.failure?.error).toStartWith('tool:');
+    expect(envelope.failure?.compactAria).toContain('button "Submit"');
+    expect(envelope.artifacts).toBeUndefined();
+
+    const page = browser.contexts()[0].pages().at(-1)!;
+    expect(await page.title()).toBe('Widget Depot Feedback');
+  });
+
+  test('a failing pw without a usable AI model reports healing as unavailable', async () => {
+    const envelope = await prima.pw("({ page }) => page.click('text=Ship the order')");
+
+    expect(envelope.ok).toBe(false);
+    expect(envelope.healed).toBe(false);
+    expect(envelope.healNote).toContain('ai unavailable');
+    expect(envelope.failure?.compactAria).toContain('button "Submit"');
+  });
+});
+
+describe('Prima without a browser session', () => {
+  let workspace: string;
+
+  beforeAll(() => {
+    workspace = mkdtempSync(path.join(tmpdir(), 'prima-workspace-'));
+    mkdirSync(path.join(workspace, 'home', '.cache'), { recursive: true });
+    writeFileSync(
+      path.join(workspace, 'explorbot.config.js'),
+      `export default {
+  playwright: { browser: 'chromium', url: 'http://127.0.0.1:9', show: false },
+  ai: { model: null },
+  dirs: { output: 'output' },
+};
+`,
+      'utf8'
+    );
+  });
+
+  afterAll(() => {
+    rmSync(workspace, { recursive: true, force: true });
+  });
+
+  test('the cli fails with session guidance, exits 1 and creates no endpoint', async () => {
+    const home = path.join(workspace, 'home');
+    const run = Bun.spawnSync(['bun', PRIMA_CLI, 'pw', "({ page }) => page.click('text=Submit')"], {
+      cwd: workspace,
+      env: { ...process.env, HOME: home, XDG_CACHE_HOME: path.join(home, '.cache') },
+    });
+
+    const stdout = run.stdout.toString();
+    expect(run.exitCode).toBe(1);
+    expect(stdout).toContain('ok: false');
+    expect(stdout).toContain('playwright-cli open');
+    expect(stdout).toContain('prima browser start');
+    expect(existsSync(path.join(workspace, 'output', '.browser-endpoint'))).toBe(false);
+  }, 60000);
+});
+
+describe('Prima attaches to a live playwright-cli session', () => {
+  test.skipIf(!liveSession)(
+    'reports the playwright-cli session it is driving — skipped unless a playwright-cli session is open for this workspace',
+    async () => {
+      ConfigParser.resetForTesting();
+      ConfigParser.setupTestConfig();
+
+      const prima = new Prima({ instance: 'default' });
+      await prima.start();
+
+      const info = await prima.instanceInfo();
+      expect(info.attached).toContain(liveSession!.title);
+      expect(info.tabs).toBeGreaterThan(0);
+
+      await prima.stop();
+      expect(readDescriptors().some((descriptor) => descriptor.endpoint === liveSession!.endpoint)).toBe(true);
+      expect(await prima.browserStop()).toBe(false);
+
+      ConfigParser.cleanupAllTestDirectories();
+    },
+    60000
+  );
+});

--- a/tests/node/build.test.mjs
+++ b/tests/node/build.test.mjs
@@ -26,6 +26,21 @@ describe('npm build', () => {
     assert.ok(output.includes('explorbot'), 'CLI help output missing explorbot');
   });
 
+  it('every bin of the package is built with a node shebang', () => {
+    const bins = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).bin;
+    for (const [name, relative] of Object.entries(bins)) {
+      const file = join(root, relative);
+      assert.ok(existsSync(file), `${name} bin not found at ${relative}`);
+      assert.strictEqual(readFileSync(file, 'utf8').split('\n')[0], '#!/usr/bin/env node', `${name} bin missing node shebang`);
+    }
+  });
+
+  it('prima CLI --help runs on Node.js', () => {
+    const output = execSync(`node ${join(dist, 'boat/prima/bin/prima-cli.js')} --help`, { encoding: 'utf8' });
+    assert.ok(output.includes('Usage: prima'), 'prima help output missing Usage: prima');
+    assert.ok(output.includes('pw'), 'prima help output missing the pw command');
+  });
+
   it('fingerprint worker resolves to .js in compiled output', () => {
     const cacheFile = join(dist, 'src/ai/researcher/cache.js');
     assert.ok(existsSync(cacheFile), 'compiled cache.js not found');

--- a/tests/unit/browser-server-instances.test.ts
+++ b/tests/unit/browser-server-instances.test.ts
@@ -46,6 +46,17 @@ describe('named instances', () => {
     ]);
   });
 
+  test('skips malformed endpoint filenames instead of naming them default', () => {
+    const dir = path.dirname(getEndpointFilePath());
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(getEndpointFilePath(), 'ws://localhost:1111/default\n', 'utf8');
+    writeFileSync(path.join(dir, '.browser-endpoint-'), 'ws://localhost:3333/malformed\n', 'utf8');
+    writeFileSync(path.join(dir, '.browser-endpointX'), 'ws://localhost:4444/malformed\n', 'utf8');
+    writeFileSync(path.join(dir, '.browser-endpoint-Staging'), 'ws://localhost:5555/malformed\n', 'utf8');
+
+    expect(listInstances()).toEqual([{ name: 'default', endpoint: 'ws://localhost:1111/default' }]);
+  });
+
   test('lists nothing when endpoint dir is missing', () => {
     expect(listInstances()).toEqual([]);
   });

--- a/tests/unit/browser-server-instances.test.ts
+++ b/tests/unit/browser-server-instances.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { getEndpointFilePath, listInstances } from '../../src/browser-server.ts';
+import { getEndpointFilePath, listInstances, stopServer } from '../../src/browser-server.ts';
 import { ConfigParser } from '../../src/config.ts';
 
 describe('named instances', () => {
@@ -58,6 +58,15 @@ describe('named instances', () => {
   });
 
   test('lists nothing when endpoint dir is missing', () => {
+    expect(listInstances()).toEqual([]);
+  });
+
+  test('stopping an instance with a dead endpoint reports nothing was running and clears it', async () => {
+    const dir = path.dirname(getEndpointFilePath());
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(getEndpointFilePath('staging'), 'ws://127.0.0.1:1/staging', 'utf8');
+
+    expect(await stopServer('staging')).toBe(false);
     expect(listInstances()).toEqual([]);
   });
 });

--- a/tests/unit/browser-server-instances.test.ts
+++ b/tests/unit/browser-server-instances.test.ts
@@ -1,0 +1,52 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { getEndpointFilePath, listInstances } from '../../src/browser-server.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+describe('named instances', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  afterEach(() => {
+    const dir = path.dirname(getEndpointFilePath());
+    rmSync(dir, { recursive: true, force: true });
+    ConfigParser.resetForTesting();
+  });
+
+  test('default instance keeps legacy filename', () => {
+    expect(path.basename(getEndpointFilePath())).toBe('.browser-endpoint');
+    expect(path.basename(getEndpointFilePath('default'))).toBe('.browser-endpoint');
+  });
+
+  test('named instance gets suffixed filename', () => {
+    expect(path.basename(getEndpointFilePath('staging'))).toBe('.browser-endpoint-staging');
+  });
+
+  test('instance name with unsupported characters is rejected', () => {
+    expect(() => getEndpointFilePath('Staging')).toThrow();
+    expect(() => getEndpointFilePath('../escape')).toThrow();
+    expect(() => getEndpointFilePath('')).toThrow();
+  });
+
+  test('lists instances from endpoint files', () => {
+    const dir = path.dirname(getEndpointFilePath());
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(getEndpointFilePath(), 'ws://localhost:1111/default\n', 'utf8');
+    writeFileSync(getEndpointFilePath('staging'), 'ws://localhost:2222/staging\n', 'utf8');
+    writeFileSync(path.join(dir, 'other-file.txt'), 'ignored', 'utf8');
+
+    const instances = listInstances().sort((a, b) => a.name.localeCompare(b.name));
+
+    expect(instances).toEqual([
+      { name: 'default', endpoint: 'ws://localhost:1111/default' },
+      { name: 'staging', endpoint: 'ws://localhost:2222/staging' },
+    ]);
+  });
+
+  test('lists nothing when endpoint dir is missing', () => {
+    expect(listInstances()).toEqual([]);
+  });
+});

--- a/tests/unit/config-ladder.test.ts
+++ b/tests/unit/config-ladder.test.ts
@@ -4,7 +4,9 @@ import os from 'node:os';
 import path from 'node:path';
 import { ConfigParser, resolveStateRoot } from '../../src/config.ts';
 
-const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_EPHEMERAL', 'EXPLORBOT_KNOWLEDGE', 'EXPLORBOT_KNOWLEDGE_FILE', 'LADDER_SHARED_KEY', 'LADDER_GLOBAL_KEY', 'LADDER_PRESET_KEY'];
+const KNOWLEDGE_ENV = 'EXPLORBOT_KNOWLEDGE';
+const KNOWLEDGE_FILE_ENV = 'EXPLORBOT_KNOWLEDGE_FILE';
+const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_EPHEMERAL', KNOWLEDGE_ENV, KNOWLEDGE_FILE_ENV, 'LADDER_SHARED_KEY', 'LADDER_GLOBAL_KEY', 'LADDER_PRESET_KEY'];
 
 const CONFIG_MODULE = (url: string) => `export default {\n  playwright: { url: '${url}', browser: 'chromium' },\n  ai: { model: { modelId: 'ladder-model', provider: 'test' } },\n};\n`;
 
@@ -53,8 +55,15 @@ describe('resolveStateRoot', () => {
     expect(existsSync(dir)).toBe(true);
   });
 
-  test('keeps the port as part of the host', () => {
-    expect(resolveStateRoot('http://localhost:3000/')).toBe(path.join(home, '.explorbot', 'state', 'localhost:3000'));
+  test('keeps the port as part of the host, in a name every filesystem accepts', () => {
+    const dir = resolveStateRoot('http://localhost:3000/');
+
+    expect(dir).toBe(path.join(home, '.explorbot', 'state', 'localhost_3000'));
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  test('separates hosts that differ only by port', () => {
+    expect(resolveStateRoot('http://localhost:3000/')).not.toBe(resolveStateRoot('http://localhost:4000/'));
   });
 
   test('falls back to a temp dir when the url has no scheme', () => {
@@ -208,7 +217,7 @@ describe('config-free state root', () => {
   test('keeps env knowledge per run and leaves authored files alone', async () => {
     process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
     process.env.EXPLORBOT_URL = 'https://app.example.com';
-    process.env.EXPLORBOT_KNOWLEDGE = 'Credentials: admin/admin123';
+    process.env[KNOWLEDGE_ENV] = 'Credentials: admin/admin123';
 
     const parser = ConfigParser.getInstance();
     await parser.loadConfig({ path: project });
@@ -220,11 +229,46 @@ describe('config-free state root', () => {
     const authored = path.join(knowledgeDir, 'login.md');
     writeFileSync(authored, '---\nurl: /login\n---\n\nAuthored by hand\n');
 
-    delete process.env.EXPLORBOT_KNOWLEDGE;
+    delete process.env[KNOWLEDGE_ENV];
     ConfigParser.resetForTesting();
     await ConfigParser.getInstance().loadConfig({ path: project });
 
     expect(existsSync(globalFile)).toBe(false);
+    expect(existsSync(authored)).toBe(true);
+  });
+
+  test('drops a knowledge file of an earlier run and leaves authored files alone', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+
+    const first = path.join(project, 'staging.md');
+    writeFileSync(first, '---\nurl: /login\n---\n\nCredentials: admin/admin123\n');
+    process.env[KNOWLEDGE_FILE_ENV] = first;
+
+    const parser = ConfigParser.getInstance();
+    await parser.loadConfig({ path: project });
+
+    const knowledgeDir = path.join(home, '.explorbot', 'state', 'app.example.com', 'knowledge');
+    expect(existsSync(path.join(knowledgeDir, 'env', 'staging.md'))).toBe(true);
+
+    const authored = path.join(knowledgeDir, 'checkout.md');
+    writeFileSync(authored, '---\nurl: /checkout\n---\n\nAuthored by hand\n');
+
+    const second = path.join(project, 'production.md');
+    writeFileSync(second, '---\nurl: /login\n---\n\nCredentials: guest/guest\n');
+    process.env[KNOWLEDGE_FILE_ENV] = second;
+    ConfigParser.resetForTesting();
+    await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(existsSync(path.join(knowledgeDir, 'env', 'staging.md'))).toBe(false);
+    expect(existsSync(path.join(knowledgeDir, 'env', 'production.md'))).toBe(true);
+    expect(existsSync(authored)).toBe(true);
+
+    delete process.env[KNOWLEDGE_FILE_ENV];
+    ConfigParser.resetForTesting();
+    await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(existsSync(path.join(knowledgeDir, 'env'))).toBe(false);
     expect(existsSync(authored)).toBe(true);
   });
 });

--- a/tests/unit/config-ladder.test.ts
+++ b/tests/unit/config-ladder.test.ts
@@ -164,6 +164,25 @@ describe('config-free state root', () => {
     expect(parser.getOutputDir()).toContain('explorbot');
   });
 
+  test('records experience while the state root is persistent', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+
+    const config = await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(config.experience?.disabled).toBe(false);
+  });
+
+  test('records no experience when the state root is ephemeral', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+    process.env.EXPLORBOT_EPHEMERAL = '1';
+
+    const config = await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(config.experience?.disabled).toBe(true);
+  });
+
   test('leaves an unparseable url to config validation', async () => {
     process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
     process.env.EXPLORBOT_URL = 'example.com';

--- a/tests/unit/config-ladder.test.ts
+++ b/tests/unit/config-ladder.test.ts
@@ -57,6 +57,21 @@ describe('resolveStateRoot', () => {
     expect(resolveStateRoot('http://localhost:3000/')).toBe(path.join(home, '.explorbot', 'state', 'localhost:3000'));
   });
 
+  test('falls back to a temp dir when the url has no scheme', () => {
+    const dir = resolveStateRoot('example.com');
+
+    expect(dir.startsWith(home)).toBe(false);
+    expect(existsSync(dir)).toBe(true);
+    expect(existsSync(path.join(home, '.explorbot', 'state'))).toBe(false);
+  });
+
+  test('falls back to a temp dir when the url has no host', () => {
+    const dir = resolveStateRoot('localhost:3000');
+
+    expect(dir.startsWith(home)).toBe(false);
+    expect(existsSync(path.join(home, '.explorbot', 'state'))).toBe(false);
+  });
+
   test('ephemeral returns fresh temp dir', () => {
     const a = resolveStateRoot('https://app.example.com', true);
     const b = resolveStateRoot('https://app.example.com', true);
@@ -149,6 +164,17 @@ describe('config-free state root', () => {
     expect(parser.getOutputDir()).toContain('explorbot');
   });
 
+  test('leaves an unparseable url to config validation', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'example.com';
+
+    const parser = ConfigParser.getInstance();
+    const config = await parser.loadConfig({ path: project });
+
+    expect(parser.getOutputDir().startsWith(home)).toBe(false);
+    expect(() => parser.validateConfig(config)).toThrow(/Invalid URL in configuration: example.com/);
+  });
+
   test('keeps EXPLORBOT_OUTPUT ahead of the state dir', async () => {
     process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
     process.env.EXPLORBOT_URL = 'https://app.example.com';
@@ -158,5 +184,28 @@ describe('config-free state root', () => {
     await parser.loadConfig({ path: project });
 
     expect(parser.getOutputDir()).toBe(project);
+  });
+
+  test('keeps env knowledge per run and leaves authored files alone', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+    process.env.EXPLORBOT_KNOWLEDGE = 'Credentials: admin/admin123';
+
+    const parser = ConfigParser.getInstance();
+    await parser.loadConfig({ path: project });
+
+    const knowledgeDir = path.join(home, '.explorbot', 'state', 'app.example.com', 'knowledge');
+    const globalFile = path.join(knowledgeDir, 'global.md');
+    expect(existsSync(globalFile)).toBe(true);
+
+    const authored = path.join(knowledgeDir, 'login.md');
+    writeFileSync(authored, '---\nurl: /login\n---\n\nAuthored by hand\n');
+
+    delete process.env.EXPLORBOT_KNOWLEDGE;
+    ConfigParser.resetForTesting();
+    await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(existsSync(globalFile)).toBe(false);
+    expect(existsSync(authored)).toBe(true);
   });
 });

--- a/tests/unit/config-ladder.test.ts
+++ b/tests/unit/config-ladder.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { ConfigParser, resolveStateRoot } from '../../src/config.ts';
+
+const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_EPHEMERAL', 'EXPLORBOT_KNOWLEDGE', 'EXPLORBOT_KNOWLEDGE_FILE', 'LADDER_SHARED_KEY', 'LADDER_GLOBAL_KEY', 'LADDER_PRESET_KEY'];
+
+const CONFIG_MODULE = (url: string) => `export default {\n  playwright: { url: '${url}', browser: 'chromium' },\n  ai: { model: { modelId: 'ladder-model', provider: 'test' } },\n};\n`;
+
+let home: string;
+let project: string;
+let savedEnv: Record<string, string | undefined>;
+let homedirSpy: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+  home = mkdtempSync(path.join(os.tmpdir(), 'explorbot-home-'));
+  project = mkdtempSync(path.join(os.tmpdir(), 'explorbot-project-'));
+  homedirSpy = spyOn(os, 'homedir').mockReturnValue(home);
+
+  savedEnv = {};
+  for (const key of ENV_KEYS) {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  ConfigParser.resetForTesting();
+});
+
+afterEach(() => {
+  homedirSpy.mockRestore();
+  for (const key of ENV_KEYS) {
+    if (savedEnv[key] === undefined) delete process.env[key];
+    else process.env[key] = savedEnv[key];
+  }
+  rmSync(home, { recursive: true, force: true });
+  rmSync(project, { recursive: true, force: true });
+  ConfigParser.resetForTesting();
+});
+
+function writeGlobalFile(name: string, content: string): string {
+  const dir = path.join(home, '.explorbot');
+  mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  writeFileSync(file, content);
+  return file;
+}
+
+describe('resolveStateRoot', () => {
+  test('derives persistent per-host dir', () => {
+    const dir = resolveStateRoot('https://app.example.com/login');
+    expect(dir).toBe(path.join(os.homedir(), '.explorbot', 'state', 'app.example.com'));
+    expect(existsSync(dir)).toBe(true);
+  });
+
+  test('keeps the port as part of the host', () => {
+    expect(resolveStateRoot('http://localhost:3000/')).toBe(path.join(home, '.explorbot', 'state', 'localhost:3000'));
+  });
+
+  test('ephemeral returns fresh temp dir', () => {
+    const a = resolveStateRoot('https://app.example.com', true);
+    const b = resolveStateRoot('https://app.example.com', true);
+    expect(a).not.toBe(b);
+    expect(a).toContain('explorbot');
+    expect(a.startsWith(home)).toBe(false);
+    expect(existsSync(a)).toBe(true);
+  });
+});
+
+describe('config ladder', () => {
+  test('loads the global config when the project has none', async () => {
+    writeGlobalFile('config.js', CONFIG_MODULE('https://global.example.com'));
+
+    const parser = ConfigParser.getInstance();
+    const config = await parser.loadConfig({ path: project });
+
+    expect(config.playwright.url).toBe('https://global.example.com');
+    expect(parser.getConfigPath()).toBe(path.join(home, '.explorbot', 'config.js'));
+  });
+
+  test('loads a global typescript config', async () => {
+    writeGlobalFile('config.ts', CONFIG_MODULE('https://global-ts.example.com'));
+
+    const config = await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(config.playwright.url).toBe('https://global-ts.example.com');
+  });
+
+  test('prefers the project config over the global one', async () => {
+    writeGlobalFile('config.js', CONFIG_MODULE('https://global.example.com'));
+    writeFileSync(path.join(project, 'explorbot.config.js'), CONFIG_MODULE('https://project.example.com'));
+
+    const parser = ConfigParser.getInstance();
+    const config = await parser.loadConfig({ path: project });
+
+    expect(config.playwright.url).toBe('https://project.example.com');
+    expect(parser.getConfigPath()).toBe(path.join(project, 'explorbot.config.js'));
+  });
+
+  test('prefers an explicit config path over the global one', async () => {
+    writeGlobalFile('config.js', CONFIG_MODULE('https://global.example.com'));
+    const explicit = path.join(project, 'custom.config.js');
+    writeFileSync(explicit, CONFIG_MODULE('https://explicit.example.com'));
+
+    const config = await ConfigParser.getInstance().loadConfig({ config: explicit });
+
+    expect(config.playwright.url).toBe('https://explicit.example.com');
+  });
+});
+
+describe('global .env', () => {
+  test('fills keys the project .env and the environment leave unset', async () => {
+    writeGlobalFile('config.js', CONFIG_MODULE('https://global.example.com'));
+    writeGlobalFile('.env', 'LADDER_GLOBAL_KEY=from-global\nLADDER_SHARED_KEY=from-global\nLADDER_PRESET_KEY=from-global\n');
+    writeFileSync(path.join(project, '.env'), 'LADDER_SHARED_KEY=from-project\n');
+    process.env.LADDER_PRESET_KEY = 'from-environment';
+
+    await ConfigParser.getInstance().loadConfig({ path: project });
+
+    expect(process.env.LADDER_GLOBAL_KEY).toBe('from-global');
+    expect(process.env.LADDER_SHARED_KEY).toBe('from-project');
+    expect(process.env.LADDER_PRESET_KEY).toBe('from-environment');
+  });
+});
+
+describe('config-free state root', () => {
+  test('roots knowledge, experience and output under the per-host state dir', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+
+    const parser = ConfigParser.getInstance();
+    const config = await parser.loadConfig({ path: project });
+    const stateRoot = path.join(home, '.explorbot', 'state', 'app.example.com');
+
+    expect(parser.getOutputDir()).toBe(stateRoot);
+    expect(parser.resolveProjectDir(config.dirs!.knowledge)).toBe(path.join(stateRoot, 'knowledge'));
+    expect(parser.resolveProjectDir(config.dirs!.experience)).toBe(path.join(stateRoot, 'experience'));
+  });
+
+  test('uses a temp state root when EXPLORBOT_EPHEMERAL is set', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+    process.env.EXPLORBOT_EPHEMERAL = '1';
+
+    const parser = ConfigParser.getInstance();
+    await parser.loadConfig({ path: project });
+
+    expect(parser.getOutputDir().startsWith(home)).toBe(false);
+    expect(parser.getOutputDir()).toContain('explorbot');
+  });
+
+  test('keeps EXPLORBOT_OUTPUT ahead of the state dir', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://app.example.com';
+    process.env.EXPLORBOT_OUTPUT = project;
+
+    const parser = ConfigParser.getInstance();
+    await parser.loadConfig({ path: project });
+
+    expect(parser.getOutputDir()).toBe(project);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -253,7 +253,7 @@ describe('ConfigParser environment mode', () => {
 
     materializeKnowledge(scratchDir);
 
-    expect(readFileSync(join(scratchDir, 'knowledge', 'login.md'), 'utf8')).toContain('url: /login');
+    expect(readFileSync(join(scratchDir, 'knowledge', 'env', 'login.md'), 'utf8')).toContain('url: /login');
   });
 
   it('throws when EXPLORBOT_KNOWLEDGE_FILE does not exist', () => {
@@ -270,7 +270,7 @@ describe('ConfigParser environment mode', () => {
     materializeKnowledge(scratchDir);
 
     expect(existsSync(join(scratchDir, 'knowledge', 'global.md'))).toBe(true);
-    expect(existsSync(join(scratchDir, 'knowledge', 'checkout.md'))).toBe(true);
+    expect(existsSync(join(scratchDir, 'knowledge', 'env', 'checkout.md'))).toBe(true);
   });
 
   it('writes no knowledge dir when neither knowledge var is set', () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -44,7 +44,7 @@ describe('ConfigParser runtime baseUrl overrides', () => {
   });
 });
 
-const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_VISION_MODEL', 'EXPLORBOT_AGENTIC_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_KNOWLEDGE', 'EXPLORBOT_KNOWLEDGE_FILE'];
+const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_VISION_MODEL', 'EXPLORBOT_AGENTIC_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_EPHEMERAL', 'EXPLORBOT_KNOWLEDGE', 'EXPLORBOT_KNOWLEDGE_FILE'];
 
 let savedEnv: Record<string, string | undefined> = {};
 let scratchDir: string;
@@ -209,7 +209,7 @@ describe('ConfigParser environment mode', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('disables experience and historian and keeps output at the config root', async () => {
+  it('keeps experience, disables historian and keeps output at the config root', async () => {
     process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
     process.env.EXPLORBOT_URL = 'https://example.com';
     process.env.EXPLORBOT_OUTPUT = scratchDir;
@@ -217,7 +217,7 @@ describe('ConfigParser environment mode', () => {
     const config = await parser.loadConfig();
 
     expect(config.dirs?.output).toBe('.');
-    expect(config.experience?.disabled).toBe(true);
+    expect(config.experience?.disabled).toBe(false);
     expect(config.ai.agents?.historian?.enabled).toBe(false);
     expect(parser.getOutputDir()).toBe(scratchDir);
   });

--- a/tests/unit/explorbot-optional-ai.test.ts
+++ b/tests/unit/explorbot-optional-ai.test.ts
@@ -1,0 +1,24 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { ConfigParser } from '../../src/config.ts';
+import { ExplorBot } from '../../src/explorbot.ts';
+
+beforeAll(() => {
+  ConfigParser.resetForTesting();
+  ConfigParser.setupTestConfig();
+});
+
+describe('ExplorBot provider bootstrap', () => {
+  test('provider failure stays fatal for regular callers', async () => {
+    const bot = new ExplorBot({});
+    await expect(bot.startProviderOnly()).rejects.toThrow();
+    expect(bot.aiFailureReason()).toBeNull();
+  });
+
+  test('optionalAi records the reason instead of failing the start', async () => {
+    const bot = new ExplorBot({ optionalAi: true });
+    await bot.startProviderOnly();
+    expect(bot.getProvider()).toBeUndefined();
+    expect(bot.aiFailureReason()).toBeTruthy();
+    expect(bot.getConfig()).toBeTruthy();
+  });
+});

--- a/tests/unit/explorbot-optional-ai.test.ts
+++ b/tests/unit/explorbot-optional-ai.test.ts
@@ -1,11 +1,42 @@
-import { beforeAll, describe, expect, test } from 'bun:test';
+import { afterEach, beforeAll, describe, expect, spyOn, test } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { ConfigParser } from '../../src/config.ts';
 import { ExplorBot } from '../../src/explorbot.ts';
+import Explorer from '../../src/explorer.ts';
 
 beforeAll(() => {
   ConfigParser.resetForTesting();
   ConfigParser.setupTestConfig();
 });
+
+const spies: Array<{ mockRestore: () => void }> = [];
+
+afterEach(() => {
+  for (const spy of spies.splice(0)) spy.mockRestore();
+  rmSync(join(process.cwd(), 'test-dirs'), { recursive: true, force: true });
+});
+
+function stubBrowser() {
+  spies.push(spyOn(Explorer.prototype as any, 'initializeContainer').mockImplementation(() => {}));
+  spies.push(spyOn(Explorer.prototype, 'start').mockImplementation(async () => {}));
+}
+
+function seedDynamicExperience() {
+  const parser = ConfigParser.getInstance();
+  const dir = parser.resolveProjectDir(parser.getConfig().dirs!.experience!);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'users_123.md'), '---\nurl: /users/123\n---\n\n## ACTION: open the user page\n', 'utf-8');
+  writeFileSync(join(dir, 'users_456.md'), '---\nurl: /users/456\n---\n\n## ACTION: open the user page\n', 'utf-8');
+}
+
+function forbidExit() {
+  spies.push(
+    spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code}) was called`);
+    }) as any)
+  );
+}
 
 describe('ExplorBot provider bootstrap', () => {
   test('provider failure stays fatal for regular callers', async () => {
@@ -20,5 +51,18 @@ describe('ExplorBot provider bootstrap', () => {
     expect(bot.getProvider()).toBeUndefined();
     expect(bot.aiFailureReason()).toBeTruthy();
     expect(bot.getConfig()).toBeTruthy();
+  });
+
+  test('start survives a failing provider bootstrap without exiting', async () => {
+    stubBrowser();
+    forbidExit();
+    seedDynamicExperience();
+
+    const bot = new ExplorBot({ optionalAi: true });
+    await bot.start();
+
+    expect(bot.isExploring).toBe(true);
+    expect(bot.getProvider()).toBeUndefined();
+    expect(bot.aiFailureReason()).toBeTruthy();
   });
 });

--- a/tests/unit/explorer-attached-browser.test.ts
+++ b/tests/unit/explorer-attached-browser.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'bun:test';
+import Explorer from '../../src/explorer.ts';
+
+function fakePage(url: string, events: string[]) {
+  return {
+    url: () => url,
+    isClosed: () => false,
+    on: () => {},
+    bringToFront: async () => {},
+    setDefaultNavigationTimeout: () => {},
+    setDefaultTimeout: () => {},
+    close: async () => {
+      events.push(`page.close:${url}`);
+    },
+  };
+}
+
+function buildAttachedExplorer() {
+  const events: string[] = [];
+  const lastPage = fakePage('https://app.example.com/dashboard', events);
+  const firstPage = fakePage('https://app.example.com/', events);
+  const context = {
+    pages: () => [firstPage, lastPage],
+    newPage: async () => {
+      events.push('context.newPage');
+      return lastPage;
+    },
+    close: async () => {
+      events.push('context.close');
+    },
+    storageState: async () => {
+      events.push('context.storageState');
+    },
+    setDefaultTimeout: () => {},
+  };
+  const browser = {
+    contexts: () => [context],
+    newContext: async () => {
+      events.push('browser.newContext');
+      return context;
+    },
+    close: async () => {
+      events.push('browser.close');
+    },
+  };
+  const playwrightHelper: any = {
+    options: {},
+    page: null,
+    browser,
+    browserContext: null,
+    isRunning: true,
+    _createContextPage: async () => {
+      events.push('helper._createContextPage');
+    },
+    _setPage: async (page: unknown) => {
+      events.push('helper._setPage');
+      playwrightHelper.page = page;
+    },
+    _stopBrowser: async () => {
+      events.push('helper._stopBrowser');
+    },
+  };
+
+  const explorer = Object.assign(Object.create(Explorer.prototype), {
+    config: { playwright: {} },
+    options: { attachedBrowser: browser, session: 'output/session.json' },
+    playwrightHelper,
+    playwrightRecorder: { start: async () => {}, stop: async () => {} },
+    reporter: { finishRun: async () => {} },
+    xhrCapture: null,
+    started: true,
+    isSharedBrowser: true,
+    observedTestPages: new Set(),
+  }) as Explorer;
+
+  return { explorer, events, playwrightHelper, context, lastPage };
+}
+
+describe('Explorer attached browser', () => {
+  it('adopts the existing context and its last page instead of creating one', async () => {
+    const { explorer, events, playwrightHelper, context, lastPage } = buildAttachedExplorer();
+
+    await (explorer as any).openContextPage();
+
+    expect(events).not.toContain('helper._createContextPage');
+    expect(events).not.toContain('browser.newContext');
+    expect(events).not.toContain('context.newPage');
+    expect(playwrightHelper.browserContext).toBe(context);
+    expect(playwrightHelper.page).toBe(lastPage);
+  });
+
+  it('creates a page only when the attached context has none', async () => {
+    const { explorer, events, playwrightHelper, context, lastPage } = buildAttachedExplorer();
+    context.pages = () => [];
+
+    await (explorer as any).openContextPage();
+
+    expect(events).toContain('context.newPage');
+    expect(playwrightHelper.page).toBe(lastPage);
+  });
+
+  it('stop disconnects without closing the attached browser or its context', async () => {
+    const { explorer, events } = buildAttachedExplorer();
+    await (explorer as any).openContextPage();
+
+    await explorer.stop();
+
+    expect(events).toContain('browser.close');
+    expect(events).not.toContain('helper._stopBrowser');
+    expect(events).not.toContain('context.close');
+  });
+
+  it('releases the adopted context without closing it when the browser restarts', async () => {
+    const { explorer, events, playwrightHelper } = buildAttachedExplorer();
+    await (explorer as any).openContextPage();
+
+    await (explorer as any).closeBrowserContext();
+
+    expect(events).not.toContain('context.close');
+    expect(playwrightHelper.browserContext).toBeNull();
+  });
+
+  it('stop skips saving the session of an attached browser', async () => {
+    const { explorer, events } = buildAttachedExplorer();
+    await (explorer as any).openContextPage();
+
+    await explorer.stop();
+
+    expect(events).not.toContain('context.storageState');
+  });
+
+  it('keeps the other tabs of an attached browser open', async () => {
+    const { explorer, events } = buildAttachedExplorer();
+    await (explorer as any).openContextPage();
+
+    await (explorer as any).closeOtherTabs();
+
+    expect(events.filter((event) => event.startsWith('page.close'))).toEqual([]);
+  });
+});

--- a/tests/unit/navigator-attempt-hook.test.ts
+++ b/tests/unit/navigator-attempt-hook.test.ts
@@ -6,7 +6,7 @@ describe('Navigator resolveState attempt hook', () => {
     const navigator = Object.create(Navigator.prototype) as any;
     navigator.MAX_ATTEMPTS = 5;
     navigator.config = { playwright: { url: 'http://localhost:3000' } };
-    navigator.knowledgeTracker = { renderRelevantKnowledge: () => '' };
+    navigator.knowledgeTracker = { renderRelevantKnowledge: () => '', renderRelevantContext: () => '' };
     navigator.experienceTracker = { getSuccessfulExperience: () => [], writeFlow: () => {} };
     navigator.provider = {
       startConversation: () => ({ addUserText: () => {} }),

--- a/tests/unit/navigator-attempt-hook.test.ts
+++ b/tests/unit/navigator-attempt-hook.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'bun:test';
+import { Navigator } from '../../src/ai/navigator.ts';
+
+describe('Navigator resolveState attempt hook', () => {
+  function createNavigator(response: string, succeedsWith: string) {
+    const navigator = Object.create(Navigator.prototype) as any;
+    navigator.MAX_ATTEMPTS = 5;
+    navigator.config = { playwright: { url: 'http://localhost:3000' } };
+    navigator.knowledgeTracker = { renderRelevantKnowledge: () => '' };
+    navigator.experienceTracker = { getSuccessfulExperience: () => [], writeFlow: () => {} };
+    navigator.provider = {
+      startConversation: () => ({ addUserText: () => {} }),
+      invokeConversation: async () => ({ response: { text: response } }),
+    };
+
+    const action: any = {
+      lastError: null,
+      actionResult: null,
+      exitIframe: async () => {},
+      attempt: async (code: string) => {
+        if (code.includes(succeedsWith)) {
+          action.lastError = null;
+          return true;
+        }
+        action.lastError = new Error('element not visible');
+        return false;
+      },
+      stateManager: { getCurrentState: () => ({ url: '/login', fullUrl: 'http://localhost:3000/login' }) },
+      getActor: () => ({ wait: async () => {} }),
+    };
+
+    navigator.explorer = { action: () => action };
+    navigator.stateManager = action.stateManager;
+    return navigator;
+  }
+
+  function fakeActionResult() {
+    return {
+      url: '/login',
+      isInsideIframe: false,
+      toAiContext: () => 'page context',
+      combinedHtml: async () => '<html></html>',
+      getStateHash: () => 'login_h1',
+    } as any;
+  }
+
+  it('reports every executed attempt with its code and error', async () => {
+    const response = "```js\nI.click('Login')\n```\n\n```js\nI.click('#login-btn')\n```";
+    const navigator = createNavigator(response, '#login-btn');
+    const attempts: Array<{ code: string; error?: string }> = [];
+
+    const resolved = await navigator.resolveState('click Login', fakeActionResult(), {
+      onAttempt: (attempt: { code: string; error?: string }) => attempts.push(attempt),
+    });
+
+    expect(resolved).toBe(true);
+    expect(attempts.map((attempt) => attempt.code)).toEqual(["I.click('Login')", "I.click('#login-btn')"]);
+    expect(attempts[0].error).toContain('element not visible');
+    expect(attempts[1].error).toBeUndefined();
+  });
+
+  it('resolves without a hook', async () => {
+    const response = "```js\nI.click('#login-btn')\n```";
+    const navigator = createNavigator(response, '#login-btn');
+
+    const resolved = await navigator.resolveState('click Login', fakeActionResult());
+
+    expect(resolved).toBe(true);
+  });
+});

--- a/tests/unit/navigator-attempt-hook.test.ts
+++ b/tests/unit/navigator-attempt-hook.test.ts
@@ -67,4 +67,11 @@ describe('Navigator resolveState attempt hook', () => {
 
     expect(resolved).toBe(true);
   });
+
+  it('says AI recovery is unavailable when no provider is configured', async () => {
+    const navigator = createNavigator('', '#login-btn');
+    navigator.provider = undefined;
+
+    await expect(navigator.resolveState('click Login', fakeActionResult())).rejects.toThrow(/AI-assisted recovery is unavailable/);
+  });
 });


### PR DESCRIPTION
## What

**prima** (`boat/prima`): an intent-level browser driver CLI that lets an orchestrating agent (Claude Code / Opus) drive a browser through explorbot's cheap-model perception layer. Spec + plan + full implementation (11 tasks, per-task adversarial reviews, whole-branch final review).

```
explorbot prima pw "({ page }) => page.click('text=Login')"   # precise, no AI
explorbot prima do "open the first invoice" "download its PDF" # tester-style NL
explorbot prima ask "what do I see?"                           # vision Q&A
explorbot prima research --data                                # verified UI map
explorbot prima verify "user is logged in"                     # AI assertion
explorbot prima go https://app.example.com                     # navigate
prima browser start|stop|status|list                           # owned instances
```

Every command returns a uniform envelope (result + `used:` executed code, page/state, ariaDiff, instance info, artifact file paths) — page data never enters the orchestrator's context. Failures heal via Navigator's cheap-model recovery with an attempt trace; exhaustion returns compact ARIA inline + full HTML/ARIA/network as files.

## Highlights

- **Attaches to playwright-cli's browser by default** via the Playwright-protocol registry (`~/.cache/ms-playwright/b/`, matched by workspaceDir + session title, probe-before-select); prima-owned named instances as fallback; **no implicit browser launch ever** (fails with create-a-session guidance)
- **AI-optional**: `pw` and URL-`go` work with no model (`optionalAi` bootstrap); NL commands fail cleanly suggesting playwright-cli fallback
- **Config-free operation**: `~/.explorbot/` global config + `.env`, per-host state dirs (`~/.explorbot/state/<host>/`) with experience memory; `--ephemeral` for throwaway runs
- **Core additions**: named browser-server instances, Navigator `onAttempt` hook, verbatim execution path for the generated pw wrapper, `~/.explorbot` config ladder
- **Ships to Node**: `npx explorbot prima ...` proven end-to-end (browser start → go → pw, no stubs); `prima` is a second bin of the package. Bun-from-source covers everything except Playwright `connect()` flows (documented caveat)
- 1055 tests pass (unit + aimock integration + real-browser smoke); docs + changelog included

## Found & fixed along the way

- `usePlaywrightTo` rejects non-async fns — every documented `pw` form failed (smoke caught it)
- Two undeclared `playwright-core@1.54` imports causing protocol skew vs `playwright@1.60` (one made the Node build's connect fail)
- `browser start` didn't hold Bun's event loop (latent in main CLI too)
- Config-load ordering + throwing failure-envelope path in Prima.start()

## Review fixes

- `go <absolute url>` double-navigation — fixed in 5078118. The url-shaped target is seeded into a dedicated `PrimaOptions.baseUrl`, which only feeds config resolution, so `options.url` keeps meaning "open this page at start". `go` navigates once, through the heal layer.
- Per-host state dir could be named `state/localhost:3000`, which Windows cannot create — the colon is replaced, so hosts differing only by port stay apart and IPv6 literals work.
- A file materialized from `EXPLORBOT_KNOWLEDGE_FILE` outlived its run now that config-free output is persistent — it goes to a machine-owned `knowledge/env/` directory cleared on every load, so no stale knowledge or credentials reach a later run. Hand-authored knowledge files are untouched.
- Lint is green (`noDelete` on a test env unset).

## Follow-ups (not in this PR)

- Investigate `connectOverCDP` under Bun to close the connect() gap
- Live playwright-cli (≥1.62) attach smoke before release tag — settles adopted-context disconnect semantics
- Declare `playwright-core` pinned to `playwright`'s version (playwright-recorder still resolves the hoisted copy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
