### PR TITLE
Make Docbot state diagram compact

### DIFF
--- a/boat/doc-collector/src/docs-renderer.ts
+++ b/boat/doc-collector/src/docs-renderer.ts
@@ -5,7 +5,7 @@ import { type WebPageState } from '../../../src/state-manager.ts';
 import { normalizeInlineText } from '../../../src/utils/strings.ts';
 import type { PageDocumentation, StateTransition } from './ai/documentarian.ts';
 import type { DocumentationScreenshot } from './screenshots.ts';
-import { type DocumentedPage, type SkippedPage, buildStateGraph, renderMermaidFromGraph, renderStateMapFromGraph } from './state-diagram.ts';
+import { type DocumentedPage, type SkippedPage, buildStateGraph, renderMermaidFromGraph, renderPageStateDiagram, renderStateMapFromGraph } from './state-diagram.ts';
 
 function renderPageDocumentation(state: WebPageState, documentation: PageDocumentation, screenshots: DocumentationScreenshot[] = []): string {
   const lines: string[] = [];
@@ -35,6 +35,13 @@ function renderPageDocumentation(state: WebPageState, documentation: PageDocumen
   }
 
   const interactions = documentation.interactions;
+  const pageStateDiagram = renderPageStateDiagram(state.title || state.url || 'page', state.url || '', interactions || []);
+  if (pageStateDiagram) {
+    lines.push('## State Map');
+    lines.push('');
+    lines.push(`\`\`\`mermaid\n${pageStateDiagram}\n\`\`\``);
+    lines.push('');
+  }
   if (interactions && interactions.length > 0) {
     lines.push('## State Transitions');
     lines.push('');
@@ -122,9 +129,10 @@ function renderSpecIndex(outputDir: string, startPath: string, pages: Documented
   lines.push(`Max pages: ${maxPages}`);
   lines.push('');
   const graph = buildStateGraph(outputDir, pages);
+  const mermaid = renderMermaidFromGraph(graph, true);
   lines.push('## State Transitions');
   lines.push('');
-  lines.push(`\`\`\`mermaid\n${renderMermaidFromGraph(graph)}\n\`\`\``);
+  lines.push(`\`\`\`mermaid\n${mermaid}\n\`\`\``);
   lines.push('');
   const stateMap = renderStateMapFromGraph(graph);
   if (stateMap) {

--- a/boat/doc-collector/src/state-diagram.ts
+++ b/boat/doc-collector/src/state-diagram.ts
@@ -254,13 +254,7 @@ function createsCycle(sourceId: string, targetId: string, adjacency: Map<string,
 }
 
 function escapeMermaidLabel(value: string): string {
-  return normalizeInlineText(value)
-    .replaceAll('&', '&amp;')
-    .replaceAll('"', '&quot;')
-    .replaceAll('#', '&#35;')
-    .replaceAll('<', '&#60;')
-    .replaceAll('>', '&#62;')
-    .replaceAll('|', '&#124;');
+  return normalizeInlineText(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('#', '&#35;').replaceAll('<', '&#60;').replaceAll('>', '&#62;').replaceAll('|', '&#124;');
 }
 
 function escapeTable(value: string): string {

--- a/boat/doc-collector/src/state-diagram.ts
+++ b/boat/doc-collector/src/state-diagram.ts
@@ -69,17 +69,17 @@ function buildStateGraph(outputDir: string, pages: DocumentedPage[]): StateGraph
         continue;
       }
 
-      const pairKey = `${sourceId}>${targetId}`;
-      if (adjacency.get(targetId)?.has(sourceId)) {
+      if (adjacency.get(sourceId)?.has(targetId)) {
+        continue;
+      }
+
+      if (createsCycle(sourceId, targetId, adjacency)) {
+        const pairKey = `${sourceId}>${targetId}`;
         if (drawnBack.has(pairKey)) {
           continue;
         }
         drawnBack.add(pairKey);
         edges.push({ source: sourceId, target: targetId, action: transition.action, isBack: true });
-        continue;
-      }
-
-      if (adjacency.get(sourceId)?.has(targetId) || createsCycle(sourceId, targetId, adjacency)) {
         continue;
       }
       adjacency.get(sourceId)?.add(targetId);
@@ -104,8 +104,8 @@ function renderMermaidBody(outputDir: string, pages: DocumentedPage[]): string {
   return renderMermaidFromGraph(buildStateGraph(outputDir, pages));
 }
 
-function renderMermaidFromGraph(graph: StateGraph): string {
-  const lines: string[] = ['flowchart TD'];
+function renderMermaidFromGraph(graph: StateGraph, compact = false): string {
+  const lines: string[] = [compact ? 'flowchart LR' : 'flowchart TD'];
   if (graph.pages.length === 0) {
     lines.push('  empty["No documented states"]');
     return lines.join('\n');
@@ -117,6 +117,12 @@ function renderMermaidFromGraph(graph: StateGraph): string {
     if (!children || children.length === 0) {
       continue;
     }
+    if (compact) {
+      for (const child of children) {
+        lines.push(`  ${renderNodeLine(child)}`);
+      }
+      continue;
+    }
     lines.push(`  subgraph sg_${page.id} ["${escapeMermaidLabel(page.label)} — transient states"]`);
     for (const child of children) {
       lines.push(`    ${renderNodeLine(child)}`);
@@ -125,11 +131,12 @@ function renderMermaidFromGraph(graph: StateGraph): string {
   }
 
   for (const edge of graph.edges) {
-    let arrow = '-->';
-    if (edge.isBack) {
-      arrow = '-.->';
+    const arrow = edge.isBack ? '-.->' : '-->';
+    if (compact) {
+      lines.push(`  ${edge.source} ${arrow} ${edge.target}`);
+    } else {
+      lines.push(`  ${edge.source} ${arrow}|"${escapeMermaidLabel(edge.action)}"| ${edge.target}`);
     }
-    lines.push(`  ${edge.source} ${arrow}|"${escapeMermaidLabel(edge.action)}"| ${edge.target}`);
   }
 
   lines.push('  classDef page fill:#dbeafe,stroke:#2563eb,color:#0f172a;');
@@ -174,6 +181,46 @@ function renderStateMapFromGraph(graph: StateGraph): string {
   return rows.join('\n');
 }
 
+function renderPageStateDiagram(label: string, url: string, interactions: StateTransition[]): string {
+  const targets = new Map<string, { node: StateNode; action: string; screenshot?: { title: string; relativePath: string } }>();
+  let index = 0;
+  for (const interaction of interactions) {
+    const targetState = interaction.targetState;
+    if (!targetState) {
+      continue;
+    }
+    const key = `${targetState.kind}:${targetState.label}:${normalizeUrl(targetState.url)}`;
+    if (targets.has(key)) {
+      continue;
+    }
+    targets.set(key, {
+      node: { id: `target${index++}`, kind: targetState.kind, label: targetState.label, subLabel: targetState.kind },
+      action: interaction.action,
+      screenshot: interaction.screenshot,
+    });
+  }
+
+  if (targets.size === 0) {
+    return '';
+  }
+
+  const lines: string[] = ['flowchart LR'];
+  lines.push(`  ${renderNodeLine({ id: 'self', kind: 'page', label, subLabel: url })}`);
+  for (const target of targets.values()) {
+    lines.push(`  ${renderNodeLine(target.node)}`);
+  }
+  for (const target of targets.values()) {
+    lines.push(`  self -->|"${escapeMermaidLabel(target.action)}"| ${target.node.id}`);
+  }
+  for (const target of targets.values()) {
+    if (target.screenshot) {
+      lines.push(`  click ${target.node.id} "${target.screenshot.relativePath}" "${escapeMermaidLabel(target.screenshot.title)}"`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 function renderNodeLine(node: StateNode): string {
   const label = `${escapeMermaidLabel(node.label)}<br/>${escapeMermaidLabel(node.subLabel)}`;
   if (node.kind === 'dialog' || node.kind === 'modal') {
@@ -207,7 +254,13 @@ function createsCycle(sourceId: string, targetId: string, adjacency: Map<string,
 }
 
 function escapeMermaidLabel(value: string): string {
-  return normalizeInlineText(value).replaceAll('&', '&amp;').replaceAll('"', '&quot;').replaceAll('|', '&#124;');
+  return normalizeInlineText(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('#', '&#35;')
+    .replaceAll('<', '&#60;')
+    .replaceAll('>', '&#62;')
+    .replaceAll('|', '&#124;');
 }
 
 function escapeTable(value: string): string {
@@ -277,5 +330,5 @@ interface StateGraph {
   classAssignment: Map<StateClass, string[]>;
 }
 
-export { buildStateGraph, renderMermaidBody, renderMermaidFromGraph, renderStateMapFromGraph };
+export { buildStateGraph, renderMermaidBody, renderMermaidFromGraph, renderPageStateDiagram, renderStateMapFromGraph };
 export type { DocumentedPage, SkippedPage, StateGraph, StateNode, StateEdge, StateClick };

--- a/tests/unit/doc-collector.test.ts
+++ b/tests/unit/doc-collector.test.ts
@@ -465,23 +465,20 @@ describe('doc-collector renderer', () => {
   });
 
   it('renders a focused per-page state map when interactions target a transient state', () => {
-    const markdown = renderPageDocumentation(
-      { url: '/suites', title: 'Suites' },
-      {
-        summary: 'Suites page',
-        can: [],
-        might: [],
-        interactions: [
-          {
-            action: 'Clicked button: Import tests',
-            before: 'Suites',
-            after: 'Import tests',
-            targetState: { kind: 'dialog', label: 'Import tests', url: '/suites' },
-            screenshot: { title: 'Import tests', relativePath: '../screenshots/suites_import.png' },
-          },
-        ],
-      } as any
-    );
+    const markdown = renderPageDocumentation({ url: '/suites', title: 'Suites' }, {
+      summary: 'Suites page',
+      can: [],
+      might: [],
+      interactions: [
+        {
+          action: 'Clicked button: Import tests',
+          before: 'Suites',
+          after: 'Import tests',
+          targetState: { kind: 'dialog', label: 'Import tests', url: '/suites' },
+          screenshot: { title: 'Import tests', relativePath: '../screenshots/suites_import.png' },
+        },
+      ],
+    } as any);
 
     expect(markdown).toContain('## State Map');
     expect(markdown).toContain('flowchart LR');
@@ -492,15 +489,12 @@ describe('doc-collector renderer', () => {
   });
 
   it('omits the per-page state map when no interaction targets a state', () => {
-    const markdown = renderPageDocumentation(
-      { url: '/x', title: 'X' },
-      {
-        summary: 'Static',
-        can: [],
-        might: [],
-        interactions: [{ action: 'Clicked button: Save', before: 'x', after: 'y', changes: { urlChanged: false, newElements: 2, removedElements: 0 } }],
-      } as any
-    );
+    const markdown = renderPageDocumentation({ url: '/x', title: 'X' }, {
+      summary: 'Static',
+      can: [],
+      might: [],
+      interactions: [{ action: 'Clicked button: Save', before: 'x', after: 'y', changes: { urlChanged: false, newElements: 2, removedElements: 0 } }],
+    } as any);
 
     expect(markdown).not.toContain('## State Map');
   });

--- a/tests/unit/doc-collector.test.ts
+++ b/tests/unit/doc-collector.test.ts
@@ -259,11 +259,13 @@ describe('doc-collector renderer', () => {
     );
 
     expect(markdown).toContain('```mermaid');
-    expect(markdown).toContain('page0 -->|"Clicked button: Import tests"| state0');
-    expect(markdown).toContain('page0 -->|"Clicked link: Suite"| page1');
-    expect(markdown).not.toContain('page1 -->|"Clicked link: Back"| page0');
-    expect(markdown).toContain('page1 -.->|"Clicked link: Back"| page0');
-    expect(markdown).toContain('subgraph sg_page0');
+    expect(markdown).toContain('flowchart LR');
+    expect(markdown).toContain('page0 --> state0');
+    expect(markdown).toContain('page0 --> page1');
+    expect(markdown).not.toContain('page1 --> page0');
+    expect(markdown).toContain('page1 -.-> page0');
+    expect(markdown).not.toContain('subgraph ');
+    expect(markdown).not.toContain('-->|"');
     expect(markdown).toContain('state0{{"');
     expect(markdown).toContain('classDef dialog');
     expect(markdown).toContain('class state0 dialog');
@@ -310,6 +312,84 @@ describe('doc-collector renderer', () => {
     expect(mermaid).toContain('page1 -.->|"Open X"| page0');
   });
 
+  it('renders a back-edge for a transition that closes a cycle longer than two', () => {
+    const mermaid = renderMermaidBody('D:/project/output/docs', [
+      {
+        url: '/a',
+        title: 'A',
+        summary: 'A',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 1,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [{ action: 'to B', before: 'A', after: 'B', targetState: { kind: 'page', label: 'B', url: '/b' } }],
+        filePath: 'D:/project/output/docs/pages/a.md',
+      },
+      {
+        url: '/b',
+        title: 'B',
+        summary: 'B',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 1,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [{ action: 'to C', before: 'B', after: 'C', targetState: { kind: 'page', label: 'C', url: '/c' } }],
+        filePath: 'D:/project/output/docs/pages/b.md',
+      },
+      {
+        url: '/c',
+        title: 'C',
+        summary: 'C',
+        canCount: 1,
+        mightCount: 0,
+        interactionCount: 1,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [{ action: 'to A', before: 'C', after: 'A', targetState: { kind: 'page', label: 'A', url: '/a' } }],
+        filePath: 'D:/project/output/docs/pages/c.md',
+      },
+    ]);
+
+    expect(mermaid).toContain('page0 -->|"to B"| page1');
+    expect(mermaid).toContain('page1 -->|"to C"| page2');
+    expect(mermaid).toContain('page2 -.->|"to A"| page0');
+  });
+
+  it('escapes hash, angle brackets, quotes, ampersand, and pipe in mermaid labels', () => {
+    const mermaid = renderMermaidBody('D:/project/output/docs', [
+      {
+        url: '/x',
+        title: 'Issue #42: <draft> & "final" | v2',
+        summary: 'x',
+        canCount: 0,
+        mightCount: 0,
+        interactionCount: 0,
+        canActions: [],
+        mightActions: [],
+        interactionActions: [],
+        qualityNotes: [],
+        interactions: [],
+        filePath: 'D:/project/output/docs/pages/x.md',
+      },
+    ]);
+
+    expect(mermaid).toContain('&#35;');
+    expect(mermaid).toContain('&#60;');
+    expect(mermaid).toContain('&#62;');
+    expect(mermaid).toContain('&amp;');
+    expect(mermaid).toContain('&quot;');
+    expect(mermaid).toContain('&#124;');
+    expect(mermaid).not.toContain('#42');
+  });
+
   it('exposes a fence-free Mermaid artifact via renderMermaidBody', () => {
     const mermaid = renderMermaidBody('D:/project/output/docs', [
       {
@@ -345,6 +425,84 @@ describe('doc-collector renderer', () => {
     expect(mermaid.startsWith('flowchart TD')).toBe(true);
     expect(mermaid).not.toContain('```');
     expect(mermaid).toContain('page0 -->|"Open B"| page1');
+  });
+
+  it('renders a compact LR overview that keeps transient edges without action labels', () => {
+    const pages = Array.from({ length: 3 }, (_, index) => ({
+      url: `/page-${index}`,
+      title: `Page ${index}`,
+      summary: 'page',
+      canCount: 1,
+      mightCount: 0,
+      interactionCount: 1,
+      canActions: [],
+      mightActions: [],
+      interactionActions: [],
+      qualityNotes: [],
+      interactions: [
+        {
+          action: `Open dialog ${index}`,
+          before: `Page ${index}`,
+          after: `Dialog ${index}`,
+          targetState: { kind: 'dialog' as const, label: `Dialog ${index}`, url: `/page-${index}` },
+        },
+      ],
+      filePath: `D:/project/output/docs/pages/page_${index}.md`,
+    }));
+
+    const markdown = renderSpecIndex('D:/project/output/docs', '/page-0', pages, [], 20);
+
+    expect(markdown).toContain('```mermaid\nflowchart LR');
+    expect(markdown).not.toContain('flowchart TD');
+    expect(markdown).not.toContain('-->|"');
+    expect(markdown).not.toContain('-.->|"');
+    expect(markdown).not.toContain('subgraph ');
+    expect(markdown).toContain('page0["Page 0<br/>/page-0"]');
+    expect(markdown).toContain('state0{{"Dialog 0<br/>dialog"}}');
+    expect(markdown).toContain('page0 --> state0');
+    expect(markdown).toContain('classDef dialog');
+    expect(markdown).toContain('click page0 "pages/page_0.md" "Open Page 0"');
+  });
+
+  it('renders a focused per-page state map when interactions target a transient state', () => {
+    const markdown = renderPageDocumentation(
+      { url: '/suites', title: 'Suites' },
+      {
+        summary: 'Suites page',
+        can: [],
+        might: [],
+        interactions: [
+          {
+            action: 'Clicked button: Import tests',
+            before: 'Suites',
+            after: 'Import tests',
+            targetState: { kind: 'dialog', label: 'Import tests', url: '/suites' },
+            screenshot: { title: 'Import tests', relativePath: '../screenshots/suites_import.png' },
+          },
+        ],
+      } as any
+    );
+
+    expect(markdown).toContain('## State Map');
+    expect(markdown).toContain('flowchart LR');
+    expect(markdown).toContain('self["Suites<br/>/suites"]');
+    expect(markdown).toContain('target0{{"Import tests<br/>dialog"}}');
+    expect(markdown).toContain('self -->|"Clicked button: Import tests"| target0');
+    expect(markdown).toContain('click target0 "../screenshots/suites_import.png" "Import tests"');
+  });
+
+  it('omits the per-page state map when no interaction targets a state', () => {
+    const markdown = renderPageDocumentation(
+      { url: '/x', title: 'X' },
+      {
+        summary: 'Static',
+        can: [],
+        might: [],
+        interactions: [{ action: 'Clicked button: Save', before: 'x', after: 'y', changes: { urlChanged: false, newElements: 2, removedElements: 0 } }],
+      } as any
+    );
+
+    expect(markdown).not.toContain('## State Map');
   });
 
   it('normalizes might-actions without duplicating prefixes', () => {


### PR DESCRIPTION
Make Docbot state diagram more compact
<img width="1280" height="1002" alt="image" src="https://github.com/user-attachments/assets/e1c6be47-bda0-4afd-8eca-04e4b1a6db65" />
