### PR TITLE
Strip variant-prefixed classes from combined HTML snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-08-11
+
+### Changes
+
+- Page snapshots no longer carry variant-prefixed classes such as `dark:`, `hover:` or `md:`. Those
+  classes describe how an element looks in some other state, not what it is, so the agents now read
+  a smaller and less noisy page.
+
 ## 2026-08-06
 
 ### Global Installation

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -1518,6 +1518,7 @@ function cleanElement(element: parse5TreeAdapter.Element): void {
       attr.value = attr.value
         .split(/\s+/)
         .filter((className) => !/\d/.test(className))
+        .filter((className) => !className.includes(':'))
         .filter((className) => !TAILWIND_CLASS_PATTERNS.some((pattern) => pattern.test(className)))
         .join(' ');
 


### PR DESCRIPTION
## What

`cleanElement()` in `src/utils/html.ts` now drops any class name containing `:`, so variant-prefixed classes (`dark:bg-slate`, `hover:underline`, `md:flex`, `group-hover:opacity`) no longer reach the combined HTML snapshot.

## Why

Those classes say how an element renders in some other state — a theme, a breakpoint, a pointer state — never what the element is. They are pure noise in the snapshot the agents read. Variants carrying a digit (`dark:bg-gray-800`) were already dropped by the existing digit filter; the ones without (`hover:underline`) survived.

`htmlMinimalUISnapshot` already filtered these through its `(:|__)` rule, so this only brings the combined path in line with the minimal one.

```
<div class="card dark:bg-slate hover:underline md:flex panel">   →   <div class="card panel">
```

## Verification

- `tests/unit/html.test.ts` — 55/55 pass with this change applied.
- Direct check via `bun -e` on `htmlCombinedSnapshot`, output above.

Note: running that test file again later hit a pre-existing environment failure — Bun refuses jsdom's CJS `require()` of ESM parse5. It reproduces on a clean `origin/main` checkout and also breaks `tests/unit/web-element.test.ts`, so it is unrelated to this change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)