### PR TITLE
Ship docs in the package, fix the site path in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ EXPLORBOT_KNOWLEDGE="Log in as admin@example.com / secret123" \
   npx explorbot explore /admin/users --max-tests 3
 ```
 
-Output lands in a per-host state directory, `~/.explorbot/state/<host>/`, so runs against the same app collect in one place and nothing is written to your project. Set `EXPLORBOT_EPHEMERAL=1` to keep nothing between runs. See [Agentic Usage](docs/workflow/agentic-usage.md).
+Output lands in a per-host site directory, `~/.explorbot/sites/<host>/`, so runs against the same app collect in one place and nothing is written to your project. Set `EXPLORBOT_EPHEMERAL=1` to keep nothing between runs. See [Agentic Usage](docs/workflow/agentic-usage.md).
 
 ## Teaching Explorbot
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -107,7 +107,7 @@ EXPLORBOT_AI_PROVIDER=openrouter \
 | `EXPLORBOT_NO_BANNER` | Suppress the startup banner, for machine-readable output |
 <!-- END env -->
 
-Explorbot resolves its configuration in this order: the path given to `--config`, then `explorbot.config.*` in the working directory, then the `EXPLORBOT_*` variables, and finally `~/.explorbot/config.*` from the global installation. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `openrouter`, `sambanova`.
+Explorbot resolves its configuration in this order: the path given to `--config`, then `explorbot.config.*` in the working directory, then the `EXPLORBOT_*` variables, and finally `~/.explorbot/config.*` from the global installation. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`.
 
 In this mode output goes to `~/.explorbot/sites/<host>/output/` (or `EXPLORBOT_OUTPUT`, or a temp directory with `EXPLORBOT_EPHEMERAL=1`), experience is kept beside it unless the run is ephemeral, and the Historian is off, so no generated test files appear. See [Agentic Usage](../workflow/agentic-usage.md) for the full picture.
 
@@ -846,6 +846,8 @@ npx explorbot init --global
 npx explorbot init --global --provider openrouter --api-key sk-...   # no wizard
 npx explorbot init --global --force                                  # reinstall
 ```
+
+The global config holds models and keys, never a site: every command names the site it runs against.
 
 | Option | Description |
 |--------|-------------|

--- a/docs/workflow/agentic-usage.md
+++ b/docs/workflow/agentic-usage.md
@@ -15,6 +15,12 @@ npx explorbot explore https://app.example.com/login --max-tests 3
 
 `init --global` writes `~/.explorbot/config.js` with the recommended model ids of this Explorbot version and stores the key in `~/.explorbot/.env`. It needs no terminal — with `--provider` there is no wizard, so an agent can run it unattended.
 
+The global config holds models and keys, never a site. Most commands carry the site themselves — `explore`, `plan`, `research`, `navigate`, `context`, `shell`, `freesail`, `docs collect`. The ones that take no URL argument — `test`, `learn`, `knows`, `experience`, `compact` — read it from `EXPLORBOT_URL`, and stop with `No site to explore` when it is unset:
+
+```bash
+EXPLORBOT_URL=https://app.example.com npx explorbot learn "/login" 'Sign in as ${env.APP_USER}'
+```
+
 This is the form to prefer. Each site explored gets its own folder under `~/.explorbot/sites/<host>/` holding `knowledge/`, `experience/`, and `output/`, so what Explorbot learns about an app is still there on the next run — the agent that explored `/checkout` yesterday does not start from zero today. Later runs can name the site by host instead of repeating the URL:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "files": [
     "dist/",
+    "docs/",
     "src/**/*.ts",
     "src/**/*.tsx",
     "bin/**/*.ts",


### PR DESCRIPTION
Found while checking the [`explorbot-setup` skill](https://github.com/testomatio/skills/pull/167) against `docs/workflow/agentic-usage.md`. Docs only, plus one line of `package.json`.

## `docs/` ships in the npm package

`files` listed `dist/`, `src/`, `bin/`, `rules/`, `assets/sample-files/`, and `models.json` — no docs. So `node_modules/explorbot/docs/` did not exist on any install, and an agent asking "what does `--configure` do" had nothing local to read. Confirmed against a real install.

## Doc fixes

- `README.md` said output lands in `~/.explorbot/state/<host>/`; sites are registered under `~/.explorbot/sites/<host>/`.
- `agentic-usage.md` and `commands.md` now state that the global config holds models and keys and never a site, and that the commands taking no URL argument — `test`, `learn`, `knows`, `experience`, `compact` — read `EXPLORBOT_URL`. That was undocumented, and the failure (`No site to explore`) is easy to hit on a first agentic run.
- `commands.md` gains the missing `mistral` in its provider list.

An earlier revision of this PR added `init --global --url` to pin a site in the global config. Dropped: the global install is machine-wide and every run names its own site, so a default site there is the wrong shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)