### PR TITLE
Fix the rerunner teardown test failing on main

### DIFF
--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -145,6 +145,11 @@ mock.module('codeceptjs', () => {
   };
 
   const container = {
+    // Bun applies this mock to `codeceptjs/lib/container` too, and it outlives this
+    // file: later test files importing Container get this object. Keep the statics
+    // codeceptjs itself reads at import time — aiTrace.js caches STANDARD_ACTING_HELPERS
+    // in a module-level const and throws on a for-of over undefined.
+    STANDARD_ACTING_HELPERS: ['Playwright', 'WebDriver', 'Puppeteer', 'Appium'],
     create: () => {},
     helpers: (name: string) => {
       if (name === 'Playwright') {


### PR DESCRIPTION
`main` has been red since #112, and every PR inherits the failure:

```
(fail) Rerunner healing plugin wiring > wires process-wide handlers only once across repeated setup/teardown cycles
 939 pass  1 fail
```

## What is happening

`tests/unit/explorer.test.ts` calls `mock.module('codeceptjs', …)`. Bun applies that mock to the subpath `codeceptjs/lib/container` too, and module mocks outlive the file that declared them — the whole `tests/unit` run shares one process, so every later file importing `Container` gets the fake object:

```
PROBE: STANDARD_ACTING_HELPERS = undefined
PROBE: Container is class? object [ "create", "helpers", "support", "started" ]
PROBE: aiTrace threw -> undefined is not an object (evaluating 'supportedHelpers')
```

`codeceptjs/lib/plugin/aiTrace.js` caches the list in a module-level const:

```js
const supportedHelpers = Container.STANDARD_ACTING_HELPERS
```

With the fake container that is `undefined`, so its `for…of` throws inside `Rerunner.setupPlugins()` — before the healing handlers are registered. The test counts zero `step.after` registrations and fails.

That is why it passes on its own and fails in the suite: `explorer` sorts before `rerunner-healing-teardown`.

## The fix

Give the fake container the static that codeceptjs reads at import time. aiTrace then finds no matching helper, warns, disables itself, and `setupPlugins()` gets to the healing wiring as it does in production.

`bun test tests/unit` → 940 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)