### PR TITLE
 Fix config loading on Windows

### DIFF
--- a/boat/api-tester/src/config.ts
+++ b/boat/api-tester/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path, { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { parseEnv } from 'node:util';
 import { type AIConfig, type ApiHookFn, type ApiConfig as BaseApiConfig, ConfigMissingError, EXPLORBOT_CONFIG_PATHS, createModel, envConfigRequested, materializeKnowledge, missingConfigMessage, resolveConfigModels, resolveModel, resolveOutputRoot } from '../../../src/config.ts';
 import { type SiteRecord, findGlobalConfig, globalEnvPath, isGlobalConfigPath, registerSite, resolveSiteTarget } from '../../../src/global-config.ts';
@@ -213,10 +214,11 @@ export class ApibotConfigParser {
 
   private async loadConfigModule(configPath: string): Promise<any> {
     const ext = configPath.split('.').pop();
+    const moduleUrl = pathToFileURL(resolve(configPath)).href;
 
     if (ext === 'ts') {
       try {
-        return await import(configPath);
+        return await import(moduleUrl);
       } catch {
         const require = (await import('node:module')).createRequire(import.meta.url);
         return require(configPath);
@@ -224,7 +226,7 @@ export class ApibotConfigParser {
     }
 
     if (ext === 'js' || ext === 'mjs') {
-      return await import(configPath);
+      return await import(moduleUrl);
     }
 
     const content = readFileSync(configPath, 'utf8');

--- a/boat/doc-collector/src/config.ts
+++ b/boat/doc-collector/src/config.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import path, { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { parseEnv } from 'node:util';
 import { ConfigParser } from '../../../src/config.ts';
 
@@ -90,10 +91,11 @@ class DocbotConfigParser {
 
   private async loadConfigModule(configPath: string): Promise<any> {
     const ext = configPath.split('.').pop();
+    const moduleUrl = pathToFileURL(resolve(configPath)).href;
 
     if (ext === 'ts') {
       try {
-        return await import(configPath);
+        return await import(moduleUrl);
       } catch {
         const require = (await import('node:module')).createRequire(import.meta.url);
         return require(configPath);
@@ -101,7 +103,7 @@ class DocbotConfigParser {
     }
 
     if (ext === 'js' || ext === 'mjs') {
-      return await import(configPath);
+      return await import(moduleUrl);
     }
 
     return JSON.parse(readFileSync(configPath, 'utf8'));

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path, { basename, dirname, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { parseEnv } from 'node:util';
 import dedent from 'dedent';
 import matter from 'gray-matter';
@@ -619,17 +620,18 @@ export class ConfigParser {
 
   private async loadConfigModule(configPath: string): Promise<any> {
     const ext = configPath.split('.').pop();
+    const moduleUrl = pathToFileURL(resolve(configPath)).href;
 
     if (ext === 'ts') {
       try {
-        const module = await import(configPath);
+        const module = await import(moduleUrl);
         return module;
       } catch (error) {
         const require = (await import('node:module')).createRequire(import.meta.url);
         return require(configPath);
       }
     } else if (ext === 'js' || ext === 'mjs') {
-      const module = await import(configPath);
+      const module = await import(moduleUrl);
       return module;
     } else {
       const content = readFileSync(configPath, 'utf8');

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -146,6 +146,7 @@ mock.module('codeceptjs', () => {
   };
 
   const container = {
+    STANDARD_ACTING_HELPERS: ['Playwright', 'WebDriver', 'Puppeteer', 'Appium'],
     create: () => {},
     helpers: (name: string) => {
       if (name === 'Playwright') {


### PR DESCRIPTION
## Summary

Fix Windows crash on config load (ERR_UNSUPPORTED_ESM_URL_SCHEME) by converting paths to file:// URLs before import()