### PR TITLE
Show the configuration a run uses with a config command

### DIFF
--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,23 @@
+# Notifies the testomat.ai site to rebuild when docs/ change, so
+# testomat.ai/docs/explorbot picks up the update immediately (the site also
+# refreshes daily on a schedule as a fallback).
+name: Notify docs site
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger testomat.ai docs rebuild
+        run: |
+          curl -sS -f -X POST \
+            -H "Authorization: Bearer ${{ secrets.TESTOMAT_SITE_DISPATCH_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/testomatio/testomat-ai/dispatches \
+            -d '{"event_type":"explorbot-docs-update"}'

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ bun.lockb
 # Regression harness run artifacts
 tests/regression/.runs/
 
+# Improvement plans written for other agents to pick up
+/plans/
+
 # Session state and browser sessions written by running the CLI in this repo
 session.json
 .playwright-cli/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## 2026-08-18
 
+### The configuration a run uses is one command away
+
+`explorbot config` prints what a run resolves to, instead of leaving you to reconstruct it from the
+config file, the environment, and the global installation:
+
+```bash
+explorbot config                            # the current site
+explorbot config https://app.example.com    # a specific site
+```
+
+```
+Config
+  config      /home/me/.explorbot/config.js
+  url         https://app.example.com
+  browser     chromium, headless
+  output      /home/me/.explorbot/sites/app.example.com/output
+  knowledge   /home/me/.explorbot/sites/app.example.com/knowledge
+  experience  /home/me/.explorbot/sites/app.example.com/experience
+
+Models
+  model   openai/gpt-oss-20b
+  tester  anthropic/claude-sonnet-4.5
+
+Environment
+  EXPLORBOT_AI_PROVIDER  openrouter
+```
+
+Every model role is listed, per-agent overrides included, next to the file they came from — or
+`EXPLORBOT_* environment variables` when the run is configured from the environment. Langfuse and
+Testomat.io show up when they are on.
+
+The boats answer for their own configuration the same way: `explorbot api config`,
+`explorbot docs config`, `explorbot prima config`. Inside a session, `/config`.
+
+### Changes
+
+- The `EXPLORBOT_*` reference no longer follows the help of every command and boat. It is printed
+  once, by `explorbot --help`, and `explorbot config` shows the variables actually in effect.
+
 ### Langfuse tracing is switched from config, not from environment variables
 
 Whether a run is traced is now decided by `ai.langfuse.enabled` in `explorbot.config.js`. It stays on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,13 @@ Testomat.io show up when they are on.
 The boats answer for their own configuration the same way: `explorbot api config`,
 `explorbot docs config`, `explorbot prima config`. Inside a session, `/config`.
 
+`--json` prints the same values as a machine-readable object, for a script that needs to know which
+model a run will use or where its output will land:
+
+```bash
+explorbot config --json
+```
+
 ### Changes
 
 - The `EXPLORBOT_*` reference no longer follows the help of every command and boat. It is printed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -474,6 +474,14 @@ explorbot drill /components --max-components 10  # limit to 10 components
 explorbot drill /login --knowledge /login  # save to knowledge file
 ```
 
+### Show resolved configuration:
+
+```bash
+explorbot config              # models, config file, paths, EXPLORBOT_* in effect
+explorbot config https://app.example.com   # for a specific site
+explorbot api config          # same for the API boat, also docs/prima
+```
+
 ### Initialize project configuration:
 
 ```bash

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -15,7 +15,7 @@ import { remote } from '../src/remote.js';
 import { Stats } from '../src/stats.js';
 import { Plan } from '../src/test-plan.js';
 import { getCliName } from '../src/utils/cli-name.ts';
-import { log, setPreserveConsoleLogs } from '../src/utils/logger.js';
+import { isVerboseMode, log, setPreserveConsoleLogs, setQuietMode } from '../src/utils/logger.js';
 import { jsonToTable } from '../src/utils/markdown-parser.js';
 import { parseMarkdownToTerminal } from '../src/utils/markdown-terminal.js';
 import { type NextStepSection, printNextSteps, relativeToCwd } from '../src/utils/next-steps.ts';
@@ -435,6 +435,22 @@ addCommonOptions(
   const cmd = new FreesailCommand(explorBot);
   await cmd.execute(args);
 });
+
+program
+  .command('config [url]')
+  .description('Show models, config file and paths used by this run')
+  .option('-c, --config <path>', 'Path to configuration file')
+  .option('-p, --path <path>', 'Working directory path')
+  .action(async (url, options) => {
+    setQuietMode(!isVerboseMode());
+    const { ConfigCommand } = await import('../src/commands/config-command.js');
+    try {
+      console.log(await ConfigCommand.summary({ config: options.config, path: options.path, url }));
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : 'Unknown error');
+      process.exit(1);
+    }
+  });
 
 program
   .command('init')
@@ -912,11 +928,6 @@ ${rows}
 `;
 };
 
-const addEnvHelp = (cmd: Command) => {
-  cmd.addHelpText('after', envHelp);
-  for (const sub of cmd.commands) addEnvHelp(sub);
-};
-
-addEnvHelp(program);
+program.addHelpText('after', envHelp);
 
 program.parse();

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -441,11 +441,12 @@ program
   .description('Show models, config file and paths used by this run')
   .option('-c, --config <path>', 'Path to configuration file')
   .option('-p, --path <path>', 'Working directory path')
+  .option('--json', 'Print the resolved config as JSON')
   .action(async (url, options) => {
     setQuietMode(!isVerboseMode());
     const { ConfigCommand } = await import('../src/commands/config-command.js');
     try {
-      console.log(await ConfigCommand.summary({ config: options.config, path: options.path, url }));
+      console.log(await ConfigCommand.summary({ config: options.config, path: options.path, url, json: options.json }));
     } catch (error) {
       console.error(error instanceof Error ? error.message : 'Unknown error');
       process.exit(1);

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -85,17 +85,19 @@ export function createApiCommands(name = 'api'): Command {
     }
   });
 
-  addCommonOptions(cmd.command('config [endpoint]').description('Show models, config file and paths used by this run')).action(async (endpoint, options) => {
-    const parser = ApibotConfigParser.getInstance();
-    const [site] = listSites();
-    try {
-      const config = await parser.loadConfig({ config: options.config, path: options.path, endpoint: endpoint || site?.url });
-      console.log(ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot() }));
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : 'Unknown error');
-      process.exit(1);
-    }
-  });
+  addCommonOptions(cmd.command('config [endpoint]').description('Show models, config file and paths used by this run'))
+    .option('--json', 'Print the resolved config as JSON')
+    .action(async (endpoint, options) => {
+      const parser = ApibotConfigParser.getInstance();
+      const [site] = listSites();
+      try {
+        const config = await parser.loadConfig({ config: options.config, path: options.path, endpoint: endpoint || site?.url });
+        console.log(ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot(), json: options.json }));
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : 'Unknown error');
+        process.exit(1);
+      }
+    });
 
   addCommonOptions(cmd.command('test <planfile> [index]').description('Execute tests from a plan file. Index: 1, 1-3, *')).action(async (planfile, index, options) => {
     setPreserveConsoleLogs(true);

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -1,9 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
+import { ConfigCommand } from '../../../src/commands/config-command.ts';
+import { listSites } from '../../../src/global-config.ts';
 import { setPreserveConsoleLogs } from '../../../src/utils/logger.ts';
 import { getStyles } from './ai/chief/styles.ts';
 import { ApiBot, type ApibotOptions } from './apibot.ts';
+import { ApibotConfigParser } from './config.ts';
 
 function buildOptions(options: any): ApibotOptions {
   return {
@@ -78,6 +81,18 @@ export function createApiCommands(name = 'api'): Command {
       process.exit(0);
     } catch (error) {
       console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
+      process.exit(1);
+    }
+  });
+
+  addCommonOptions(cmd.command('config [endpoint]').description('Show models, config file and paths used by this run')).action(async (endpoint, options) => {
+    const parser = ApibotConfigParser.getInstance();
+    const [site] = listSites();
+    try {
+      const config = await parser.loadConfig({ config: options.config, path: options.path, endpoint: endpoint || site?.url });
+      console.log(ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot() }));
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : 'Unknown error');
       process.exit(1);
     }
   });

--- a/boat/doc-collector/src/cli.ts
+++ b/boat/doc-collector/src/cli.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
-import { setPreserveConsoleLogs } from '../../../src/utils/logger.ts';
+import { ConfigCommand } from '../../../src/commands/config-command.ts';
+import { isVerboseMode, setPreserveConsoleLogs, setQuietMode } from '../../../src/utils/logger.ts';
 import { DocBot, type DocbotOptions } from './docbot.ts';
 
 function buildOptions(options: any): DocbotOptions {
@@ -61,6 +62,16 @@ export function createDocsCommands(name = 'docs'): Command {
       process.exit(0);
     } catch (error) {
       console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
+      process.exit(1);
+    }
+  });
+
+  addCommonOptions(cmd.command('config [url]').description('Show models, config file and paths used by this run')).action(async (url, options) => {
+    setQuietMode(!isVerboseMode());
+    try {
+      console.log(await ConfigCommand.summary({ config: options.config, path: options.path, url }));
+    } catch (error) {
+      console.error(error instanceof Error ? error.message : 'Unknown error');
       process.exit(1);
     }
   });

--- a/boat/doc-collector/src/cli.ts
+++ b/boat/doc-collector/src/cli.ts
@@ -66,15 +66,17 @@ export function createDocsCommands(name = 'docs'): Command {
     }
   });
 
-  addCommonOptions(cmd.command('config [url]').description('Show models, config file and paths used by this run')).action(async (url, options) => {
-    setQuietMode(!isVerboseMode());
-    try {
-      console.log(await ConfigCommand.summary({ config: options.config, path: options.path, url }));
-    } catch (error) {
-      console.error(error instanceof Error ? error.message : 'Unknown error');
-      process.exit(1);
-    }
-  });
+  addCommonOptions(cmd.command('config [url]').description('Show models, config file and paths used by this run'))
+    .option('--json', 'Print the resolved config as JSON')
+    .action(async (url, options) => {
+      setQuietMode(!isVerboseMode());
+      try {
+        console.log(await ConfigCommand.summary({ config: options.config, path: options.path, url, json: options.json }));
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : 'Unknown error');
+        process.exit(1);
+      }
+    });
 
   cmd
     .command('init')

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -186,13 +186,15 @@ export function createPrimaCommands(name = 'prima'): Command {
     await runPrima(options, `go ${target}`, (prima) => prima.go(target));
   });
 
-  addCommonOptions(cmd.command('config').description('Show models, config file and paths used by this run')).action(async (options) => {
-    setQuietMode(!isVerboseMode());
-    const prima = primaFor(options);
-    console.log(await prima.config().catch((error: unknown) => browserErrorMessage(error)));
-    await prima.stop().catch(() => {});
-    process.exit(0);
-  });
+  addCommonOptions(cmd.command('config').description('Show models, config file and paths used by this run'))
+    .option('--json', 'Print the resolved config as JSON')
+    .action(async (options) => {
+      setQuietMode(!isVerboseMode());
+      const prima = primaFor(options);
+      console.log(await prima.config(options.json).catch((error: unknown) => browserErrorMessage(error)));
+      await prima.stop().catch(() => {});
+      process.exit(0);
+    });
 
   addCommonOptions(cmd.command('status <hash>').description('Show the artifacts and page detail recorded for an earlier command')).action(async (hash, options) => {
     await runPrima(options, `status ${hash}`, (prima) => prima.status(hash), false);

--- a/boat/prima/src/cli.ts
+++ b/boat/prima/src/cli.ts
@@ -186,7 +186,7 @@ export function createPrimaCommands(name = 'prima'): Command {
     await runPrima(options, `go ${target}`, (prima) => prima.go(target));
   });
 
-  addCommonOptions(cmd.command('config').description('Show the AI models prima runs on and the config file they come from')).action(async (options) => {
+  addCommonOptions(cmd.command('config').description('Show models, config file and paths used by this run')).action(async (options) => {
     setQuietMode(!isVerboseMode());
     const prima = primaFor(options);
     console.log(await prima.config().catch((error: unknown) => browserErrorMessage(error)));

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -4,30 +4,31 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 import { tool } from 'ai';
 import dedent from 'dedent';
-import { z } from 'zod';
 import * as playwright from 'playwright';
 import type { Browser } from 'playwright';
+import { z } from 'zod';
 import { ActionResult } from '../../../src/action-result.ts';
+import { getPreviousResearch } from '../../../src/ai/researcher/cache.ts';
 import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
 import { createAgentTools, createCodeceptJSTools } from '../../../src/ai/tools.ts';
 import { getAliveEndpoint, launchServer, listInstances, stopServer } from '../../../src/browser-server.ts';
-import { listSites } from '../../../src/global-config.ts';
+import { ConfigCommand } from '../../../src/commands/config-command.ts';
 import { ConfigMissingError, ConfigParser, type ExplorbotConfig, outputPath } from '../../../src/config.ts';
 import { ExplorBot } from '../../../src/explorbot.ts';
+import { listSites } from '../../../src/global-config.ts';
 import { Reporter } from '../../../src/reporter.ts';
-import { Stats } from '../../../src/stats.ts';
 import type { WebPageState } from '../../../src/state-manager.ts';
+import { Stats } from '../../../src/stats.ts';
 import { Task, Test, TestResult } from '../../../src/test-plan.ts';
-import { getPreviousResearch } from '../../../src/ai/researcher/cache.ts';
 import { compactAriaSnapshot } from '../../../src/utils/aria.ts';
-import { mdq } from '../../../src/utils/markdown-query.ts';
 import { browserErrorMessage } from '../../../src/utils/browser-errors.ts';
 import { pluralize } from '../../../src/utils/logger.ts';
+import { mdq } from '../../../src/utils/markdown-query.ts';
 import { safeFilename } from '../../../src/utils/strings.ts';
 import { type EnvelopeData, type InstanceInfo, writeArtifacts } from './envelope.ts';
 import { isFunctionExpression, takePwValue, toCodeceptWrapper } from './pw-parser.ts';
-import { type SessionRun, latestSessionFile, readSession, recordCommand, sessionFile, sessionsDir } from './session-log.ts';
 import { type PwServerDescriptor, readDescriptors, selectDescriptor } from './pw-registry.ts';
+import { type SessionRun, latestSessionFile, readSession, recordCommand, sessionFile, sessionsDir } from './session-log.ts';
 
 const TESTER_ONLY_TOOLS = ['learnExperience', 'askUser'];
 const ITERATIONS_PER_INSTRUCTION = 2;
@@ -440,23 +441,9 @@ export class Prima {
     const [site] = listSites();
     if (site && !this.configBaseUrl()) this.sessionUrl = site.url;
     const config = await this.loadConfig();
+    const parser = ConfigParser.getInstance();
 
-    const named = (model: unknown): string => {
-      if (typeof model === 'string') return model;
-      return (model as any)?.modelId || (model as any)?.model || 'unknown';
-    };
-
-    const ai = config.ai || ({} as any);
-    const roles: Array<[string, unknown]> = [
-      ['model', ai.model],
-      ['agenticModel', ai.agenticModel],
-      ['visionModel', ai.visionModel],
-    ];
-
-    const lines = roles.filter(([, model]) => model).map(([role, model]) => `${role.padEnd(14)} ${named(model)}`);
-    lines.push(`config         ${ConfigParser.getInstance().getConfigPath() || 'built-in defaults'}`);
-    if (ai.langfuse?.enabled) lines.push('telemetry      langfuse');
-    return lines.join('\n');
+    return ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot() });
   }
 
   record(envelope: EnvelopeData, durationMs: number): void {

--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -437,13 +437,13 @@ export class Prima {
     return stopped;
   }
 
-  async config(): Promise<string> {
+  async config(json?: boolean): Promise<string> {
     const [site] = listSites();
     if (site && !this.configBaseUrl()) this.sessionUrl = site.url;
     const config = await this.loadConfig();
     const parser = ConfigParser.getInstance();
 
-    return ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot() });
+    return ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot(), json });
   }
 
   record(envelope: EnvelopeData, durationMs: number): void {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -51,6 +51,7 @@ Inside the TUI, use the matching slash command: `/explore`, `/research`, `/plan`
 | Manage persistent browser | `npx explorbot browser {start\|stop\|status}` | — | Share browser across runs |
 | Initialize project | `npx explorbot init` | — | Generates `explorbot.config.*`, or `~/.explorbot` with `--global` |
 | List registered sites | `npx explorbot sites` | — | Sites stored in the global installation |
+| Show resolved configuration | `npx explorbot config [url]` | `/config` | Models, config file, paths and `EXPLORBOT_*` in effect |
 | Clean generated files | `npx explorbot clean [target]` | `/clean [target]` | Same targets both ways |
 
 ## Common CLI Options
@@ -106,6 +107,8 @@ EXPLORBOT_AI_PROVIDER=openrouter \
 | `EXPLORBOT_API_SPEC` | OpenAPI spec path for the API boat |
 | `EXPLORBOT_NO_BANNER` | Suppress the startup banner, for machine-readable output |
 <!-- END env -->
+
+`npx explorbot config` prints the values a run actually uses — models per role, the config file behind them, the output, knowledge and experience directories, and every `EXPLORBOT_*` variable currently set. The boats answer for their own configuration the same way: `npx explorbot api config`, `npx explorbot docs config`, `npx explorbot prima config`.
 
 Explorbot resolves its configuration in this order: the path given to `--config`, then `explorbot.config.*` in the working directory, then the `EXPLORBOT_*` variables, and finally `~/.explorbot/config.*` from the global installation. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`.
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -51,7 +51,7 @@ Inside the TUI, use the matching slash command: `/explore`, `/research`, `/plan`
 | Manage persistent browser | `npx explorbot browser {start\|stop\|status}` | — | Share browser across runs |
 | Initialize project | `npx explorbot init` | — | Generates `explorbot.config.*`, or `~/.explorbot` with `--global` |
 | List registered sites | `npx explorbot sites` | — | Sites stored in the global installation |
-| Show resolved configuration | `npx explorbot config [url]` | `/config` | Models, config file, paths and `EXPLORBOT_*` in effect |
+| Show resolved configuration | `npx explorbot config [url] [--json]` | `/config` | Models, config file, paths and `EXPLORBOT_*` in effect |
 | Clean generated files | `npx explorbot clean [target]` | `/clean [target]` | Same targets both ways |
 
 ## Common CLI Options
@@ -108,7 +108,7 @@ EXPLORBOT_AI_PROVIDER=openrouter \
 | `EXPLORBOT_NO_BANNER` | Suppress the startup banner, for machine-readable output |
 <!-- END env -->
 
-`npx explorbot config` prints the values a run actually uses — models per role, the config file behind them, the output, knowledge and experience directories, and every `EXPLORBOT_*` variable currently set. The boats answer for their own configuration the same way: `npx explorbot api config`, `npx explorbot docs config`, `npx explorbot prima config`.
+`npx explorbot config` prints the values a run actually uses — models per role, the config file behind them, the output, knowledge and experience directories, and every `EXPLORBOT_*` variable currently set. The boats answer for their own configuration the same way: `npx explorbot api config`, `npx explorbot docs config`, `npx explorbot prima config`. Add `--json` on any of them to get the same values as an object a script can read.
 
 Explorbot resolves its configuration in this order: the path given to `--config`, then `explorbot.config.*` in the working directory, then the `EXPLORBOT_*` variables, and finally `~/.explorbot/config.*` from the global installation. A bare provider name fills every model role from the recommendations in [Providers](../basics/providers.md); a `provider/model-id` spec pins one model and splits on the first slash, so `openrouter/openai/gpt-oss-120b:nitro` selects OpenRouter with model `openai/gpt-oss-120b:nitro`. Supported providers: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`.
 

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -4,7 +4,7 @@ import { NodeSDK } from '@opentelemetry/sdk-node';
 import { generateObject, generateText, isStepCount, registerTelemetry } from 'ai';
 import type { ModelMessage } from 'ai';
 import { clearActivity, setActivity } from '../activity.ts';
-import type { AIConfig } from '../config.js';
+import { type AIConfig, configuredModels, modelName as getModelName } from '../config.js';
 import { executionController } from '../execution-controller.ts';
 import { Observability } from '../observability.ts';
 import { Stats } from '../stats.ts';
@@ -88,10 +88,6 @@ export class Provider {
     this.initLangfuse();
   }
 
-  private getModelName(model: any): string {
-    return model?.modelId || model?.model || 'unknown';
-  }
-
   async validateConnection(): Promise<void> {
     try {
       await generateText({
@@ -121,13 +117,7 @@ export class Provider {
   }
 
   getConfiguredModels(): Record<string, string> {
-    const models: Record<string, string> = { model: this.getModelName(this.config.model) };
-    if (this.config.agenticModel) models.agenticModel = this.getModelName(this.config.agenticModel);
-    if (this.config.visionModel) models.visionModel = this.getModelName(this.config.visionModel);
-    for (const [agent, agentConfig] of Object.entries(this.config.agents || {})) {
-      if (agentConfig?.model) models[agent] = this.getModelName(agentConfig.model);
-    }
-    return models;
+    return configuredModels(this.config);
   }
 
   getSystemPromptForAgent(agentName: string, currentUrl?: string): string | undefined {
@@ -316,7 +306,7 @@ export class Provider {
   }
 
   async chat(messages: ModelMessage[], model: any, options: any = {}): Promise<any> {
-    const modelName = this.getModelName(model);
+    const modelName = getModelName(model);
     setActivity(`🤖 Asking ${modelName}`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
@@ -360,7 +350,7 @@ export class Provider {
   }
 
   async generateWithTools(messages: ModelMessage[], model: any, tools: any, options: any = {}): Promise<any> {
-    const modelName = this.getModelName(model);
+    const modelName = getModelName(model);
     setActivity(`🤖 Asking ${modelName} with dynamic tools`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
@@ -418,7 +408,7 @@ export class Provider {
 
   async generateObject(messages: ModelMessage[], schema: any, model?: any, options: any = {}): Promise<any> {
     const modelToUse = model || this.config.model;
-    const modelName = this.getModelName(modelToUse);
+    const modelName = getModelName(modelToUse);
     setActivity(`🤖 Asking ${modelName} for structured output`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
@@ -620,7 +610,7 @@ export class Provider {
       clearActivity();
       responseLog(response.text);
 
-      this.recordUsage('vision', this.getModelName(this.config.visionModel), response.usage);
+      this.recordUsage('vision', getModelName(this.config.visionModel), response.usage);
 
       return response;
     } catch (error: any) {

--- a/src/commands/config-command.ts
+++ b/src/commands/config-command.ts
@@ -1,0 +1,96 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import { type AIConfig, ConfigParser, EXPLORBOT_ENV_VARS, type ReporterConfig, configuredModels } from '../config.js';
+import { listSites } from '../global-config.js';
+import { Reporter } from '../reporter.js';
+import { getCliName } from '../utils/cli-name.js';
+import { tag } from '../utils/logger.js';
+import { BaseCommand } from './base-command.js';
+
+export class ConfigCommand extends BaseCommand {
+  name = 'config';
+  description = 'Show models, config file and paths used by this run';
+
+  async execute(): Promise<void> {
+    const parser = ConfigParser.getInstance();
+    tag('info').log(ConfigCommand.render(this.explorBot.getConfig(), { configPath: parser.getConfigPath(), root: parser.getProjectRoot() }));
+  }
+
+  static async summary(options: { config?: string; path?: string; url?: string } = {}): Promise<string> {
+    const parser = ConfigParser.getInstance();
+    const [site] = listSites();
+    const load = (baseUrl?: string) => parser.loadConfig({ config: options.config, path: options.path, baseUrl });
+
+    const config = await load(options.url).catch((error) => {
+      if (!site) throw error;
+      return load(site.url);
+    });
+
+    return ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot() });
+  }
+
+  static render(config: SummarizedConfig, options: ConfigSummaryOptions = {}): string {
+    const lines: string[] = [];
+    const section = (title: string, entries: [string, string][]) => {
+      if (!entries.length) return;
+      const width = Math.max(...entries.map(([label]) => label.length));
+      lines.push(chalk.bold(title));
+      for (const [label, value] of entries) lines.push(`  ${chalk.dim(label.padEnd(width))}  ${value}`);
+      lines.push('');
+    };
+
+    let source = 'EXPLORBOT_* environment variables';
+    if (options.configPath && existsSync(options.configPath)) source = options.configPath;
+
+    const general: [string, string][] = [['config', source]];
+    const url = config.playwright?.url || config.web?.url || config.api?.baseEndpoint;
+    if (url) general.push(['url', url]);
+    if (config.playwright?.browser) {
+      let window = 'headless';
+      if (config.playwright.show) window = 'visible';
+      general.push(['browser', `${config.playwright.browser}, ${window}`]);
+    }
+    if (options.root) {
+      const dirs: Record<string, string> = { output: 'output', ...config.dirs };
+      for (const [name, dir] of Object.entries(dirs)) general.push([name, path.join(options.root, dir)]);
+    }
+    section('Config', general);
+
+    const models: [string, string][] = Object.entries(configuredModels(config.ai));
+    if (!models.length) models.push(['model', chalk.red(`not configured — run ${getCliName()} init`)]);
+    section('Models', models);
+
+    const integrations: [string, string][] = [];
+    if (config.ai?.langfuse?.enabled) integrations.push(['langfuse', 'traces sent']);
+    if (Reporter.resolveEnabled(config.reporter)) integrations.push(['testomatio', 'runs reported']);
+    section('Integrations', integrations);
+
+    const env: [string, string][] = [];
+    for (const variable of EXPLORBOT_ENV_VARS) {
+      const value = process.env[variable.name];
+      if (!value) continue;
+      let shown = value;
+      if (shown.length > 60) shown = `${shown.slice(0, 57)}...`;
+      env.push([variable.name, shown]);
+    }
+    section('Environment', env);
+
+    lines.push(chalk.dim(`Every EXPLORBOT_* variable: ${getCliName()} --help`));
+    return lines.join('\n');
+  }
+}
+
+interface ConfigSummaryOptions {
+  configPath?: string | null;
+  root?: string;
+}
+
+interface SummarizedConfig {
+  ai?: AIConfig;
+  playwright?: { url?: string; browser?: string; show?: boolean };
+  web?: { url?: string };
+  api?: { baseEndpoint?: string };
+  dirs?: Record<string, string>;
+  reporter?: ReporterConfig;
+}

--- a/src/commands/config-command.ts
+++ b/src/commands/config-command.ts
@@ -17,7 +17,7 @@ export class ConfigCommand extends BaseCommand {
     tag('info').log(ConfigCommand.render(this.explorBot.getConfig(), { configPath: parser.getConfigPath(), root: parser.getProjectRoot() }));
   }
 
-  static async summary(options: { config?: string; path?: string; url?: string } = {}): Promise<string> {
+  static async summary(options: { config?: string; path?: string; url?: string; json?: boolean } = {}): Promise<string> {
     const parser = ConfigParser.getInstance();
     const [site] = listSites();
     const load = (baseUrl?: string) => parser.loadConfig({ config: options.config, path: options.path, baseUrl });
@@ -27,10 +27,45 @@ export class ConfigCommand extends BaseCommand {
       return load(site.url);
     });
 
-    return ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot() });
+    return ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot(), json: options.json });
+  }
+
+  static data(config: SummarizedConfig, options: ConfigSummaryOptions = {}): ConfigData {
+    let configPath = '';
+    if (options.configPath && existsSync(options.configPath)) configPath = options.configPath;
+
+    const dirs: Record<string, string> = {};
+    if (options.root) {
+      for (const [name, dir] of Object.entries({ output: 'output', ...config.dirs })) {
+        dirs[name] = path.join(options.root, dir);
+      }
+    }
+
+    const env: Record<string, string> = {};
+    for (const variable of EXPLORBOT_ENV_VARS) {
+      const value = process.env[variable.name];
+      if (value) env[variable.name] = value;
+    }
+
+    return {
+      config: configPath,
+      url: config.playwright?.url || config.web?.url || config.api?.baseEndpoint || '',
+      browser: config.playwright?.browser || '',
+      headless: !config.playwright?.show,
+      dirs,
+      models: configuredModels(config.ai),
+      integrations: {
+        langfuse: !!config.ai?.langfuse?.enabled,
+        testomatio: Reporter.resolveEnabled(config.reporter),
+      },
+      env,
+    };
   }
 
   static render(config: SummarizedConfig, options: ConfigSummaryOptions = {}): string {
+    const data = ConfigCommand.data(config, options);
+    if (options.json) return JSON.stringify(data, null, 2);
+
     const lines: string[] = [];
     const section = (title: string, entries: [string, string][]) => {
       if (!entries.length) return;
@@ -40,40 +75,30 @@ export class ConfigCommand extends BaseCommand {
       lines.push('');
     };
 
-    let source = 'EXPLORBOT_* environment variables';
-    if (options.configPath && existsSync(options.configPath)) source = options.configPath;
-
-    const general: [string, string][] = [['config', source]];
-    const url = config.playwright?.url || config.web?.url || config.api?.baseEndpoint;
-    if (url) general.push(['url', url]);
-    if (config.playwright?.browser) {
-      let window = 'headless';
-      if (config.playwright.show) window = 'visible';
-      general.push(['browser', `${config.playwright.browser}, ${window}`]);
+    const general: [string, string][] = [['config', data.config || 'EXPLORBOT_* environment variables']];
+    if (data.url) general.push(['url', data.url]);
+    if (data.browser) {
+      let window = 'visible';
+      if (data.headless) window = 'headless';
+      general.push(['browser', `${data.browser}, ${window}`]);
     }
-    if (options.root) {
-      const dirs: Record<string, string> = { output: 'output', ...config.dirs };
-      for (const [name, dir] of Object.entries(dirs)) general.push([name, path.join(options.root, dir)]);
-    }
+    for (const [name, dir] of Object.entries(data.dirs)) general.push([name, dir]);
     section('Config', general);
 
-    const models: [string, string][] = Object.entries(configuredModels(config.ai));
+    const models: [string, string][] = Object.entries(data.models);
     if (!models.length) models.push(['model', chalk.red(`not configured — run ${getCliName()} init`)]);
     section('Models', models);
 
     const integrations: [string, string][] = [];
-    if (config.ai?.langfuse?.enabled) integrations.push(['langfuse', 'traces sent']);
-    if (Reporter.resolveEnabled(config.reporter)) integrations.push(['testomatio', 'runs reported']);
+    if (data.integrations.langfuse) integrations.push(['langfuse', 'traces sent']);
+    if (data.integrations.testomatio) integrations.push(['testomatio', 'runs reported']);
     section('Integrations', integrations);
 
-    const env: [string, string][] = [];
-    for (const variable of EXPLORBOT_ENV_VARS) {
-      const value = process.env[variable.name];
-      if (!value) continue;
+    const env: [string, string][] = Object.entries(data.env).map(([name, value]) => {
       let shown = value;
       if (shown.length > 60) shown = `${shown.slice(0, 57)}...`;
-      env.push([variable.name, shown]);
-    }
+      return [name, shown];
+    });
     section('Environment', env);
 
     lines.push(chalk.dim(`Every EXPLORBOT_* variable: ${getCliName()} --help`));
@@ -84,6 +109,18 @@ export class ConfigCommand extends BaseCommand {
 interface ConfigSummaryOptions {
   configPath?: string | null;
   root?: string;
+  json?: boolean;
+}
+
+export interface ConfigData {
+  config: string;
+  url: string;
+  browser: string;
+  headless: boolean;
+  dirs: Record<string, string>;
+  models: Record<string, string>;
+  integrations: { langfuse: boolean; testomatio: boolean };
+  env: Record<string, string>;
 }
 
 interface SummarizedConfig {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,6 +3,7 @@ import { AddRuleCommand } from './add-rule-command.js';
 import type { BaseCommand } from './base-command.js';
 import { CleanCommand } from './clean-command.js';
 import { CompactCommand } from './compact-command.js';
+import { ConfigCommand } from './config-command.js';
 import { ContextAriaCommand } from './context-aria-command.js';
 import { ContextCommand } from './context-command.js';
 import { ContextDataCommand } from './context-data-command.js';
@@ -70,6 +71,7 @@ const commandClasses: CommandClass[] = [
   RunsCommand,
   RerunCommand,
   StatusCommand,
+  ConfigCommand,
   DebugCommand,
   ExitCommand,
 ];

--- a/src/config.ts
+++ b/src/config.ts
@@ -762,6 +762,23 @@ export function missingConfigMessage(configFile = 'explorbot.config.js'): string
   `;
 }
 
+export function modelName(model: unknown): string {
+  if (typeof model === 'string') return model;
+  return (model as any)?.modelId || (model as any)?.model || 'unknown';
+}
+
+export function configuredModels(ai?: AIConfig): Record<string, string> {
+  if (!ai?.model) return {};
+
+  const models: Record<string, string> = { model: modelName(ai.model) };
+  if (ai.agenticModel) models.agenticModel = modelName(ai.agenticModel);
+  if (ai.visionModel) models.visionModel = modelName(ai.visionModel);
+  for (const [agent, agentConfig] of Object.entries(ai.agents || {})) {
+    if (agentConfig?.model) models[agent] = modelName(agentConfig.model);
+  }
+  return models;
+}
+
 export async function resolveConfigModels(ai?: AIConfig): Promise<void> {
   if (!ai) return;
 

--- a/tests/unit/config-command.test.ts
+++ b/tests/unit/config-command.test.ts
@@ -22,12 +22,12 @@ beforeEach(() => {
   tmpPath = mkdtempSync(path.join(tmpdir(), 'explorbot-config-command-'));
   configPath = path.join(tmpPath, 'explorbot.config.js');
   writeFileSync(configPath, 'export default {};');
-  delete process.env.EXPLORBOT_AI_PROVIDER;
+  Reflect.deleteProperty(process.env, 'EXPLORBOT_AI_PROVIDER');
 });
 
 afterEach(() => {
   rmSync(tmpPath, { recursive: true, force: true });
-  delete process.env.EXPLORBOT_AI_PROVIDER;
+  Reflect.deleteProperty(process.env, 'EXPLORBOT_AI_PROVIDER');
 });
 
 describe('ConfigCommand.data', () => {

--- a/tests/unit/config-command.test.ts
+++ b/tests/unit/config-command.test.ts
@@ -1,0 +1,93 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { ConfigCommand } from '../../src/commands/config-command.js';
+
+let tmpPath = '';
+let configPath = '';
+
+const config = {
+  playwright: { browser: 'firefox', url: 'http://localhost:3000', show: true },
+  ai: {
+    model: { modelId: 'openai/gpt-oss-20b' },
+    visionModel: { modelId: 'google/gemma-4-31b-it' },
+    agents: { tester: { model: { modelId: 'anthropic/claude-sonnet-4.5' } } },
+    langfuse: { enabled: true },
+  },
+  dirs: { output: 'out', knowledge: 'kb', experience: 'exp' },
+} as any;
+
+beforeEach(() => {
+  tmpPath = mkdtempSync(path.join(tmpdir(), 'explorbot-config-command-'));
+  configPath = path.join(tmpPath, 'explorbot.config.js');
+  writeFileSync(configPath, 'export default {};');
+  delete process.env.EXPLORBOT_AI_PROVIDER;
+});
+
+afterEach(() => {
+  rmSync(tmpPath, { recursive: true, force: true });
+  delete process.env.EXPLORBOT_AI_PROVIDER;
+});
+
+describe('ConfigCommand.data', () => {
+  it('reports models per role including agent overrides', () => {
+    const data = ConfigCommand.data(config, { configPath, root: tmpPath });
+
+    expect(data.models).toEqual({
+      model: 'openai/gpt-oss-20b',
+      visionModel: 'google/gemma-4-31b-it',
+      tester: 'anthropic/claude-sonnet-4.5',
+    });
+  });
+
+  it('resolves configured directories against the project root', () => {
+    const data = ConfigCommand.data(config, { configPath, root: tmpPath });
+
+    expect(data.dirs).toEqual({
+      output: path.join(tmpPath, 'out'),
+      knowledge: path.join(tmpPath, 'kb'),
+      experience: path.join(tmpPath, 'exp'),
+    });
+  });
+
+  it('leaves the config file empty when it was built from the environment', () => {
+    const data = ConfigCommand.data(config, { configPath: path.join(tmpPath, 'never-written.js'), root: tmpPath });
+
+    expect(data.config).toBe('');
+    expect(data.url).toBe('http://localhost:3000');
+    expect(data.headless).toBe(false);
+  });
+
+  it('lists only the EXPLORBOT_ variables that are set', () => {
+    process.env.EXPLORBOT_AI_PROVIDER = 'openrouter';
+    const data = ConfigCommand.data(config, { configPath, root: tmpPath });
+
+    expect(data.env.EXPLORBOT_AI_PROVIDER).toBe('openrouter');
+    expect(data.env.EXPLORBOT_KNOWLEDGE).toBeUndefined();
+  });
+
+  it('falls back to the API base endpoint when there is no page url', () => {
+    const data = ConfigCommand.data({ ai: config.ai, api: { baseEndpoint: 'https://api.example.com' } }, { root: tmpPath });
+
+    expect(data.url).toBe('https://api.example.com');
+    expect(data.browser).toBe('');
+  });
+});
+
+describe('ConfigCommand.render', () => {
+  it('prints the same values it reports as data', () => {
+    const rendered = ConfigCommand.render(config, { configPath, root: tmpPath });
+
+    expect(rendered).toContain(configPath);
+    expect(rendered).toContain('firefox, visible');
+    expect(rendered).toContain('anthropic/claude-sonnet-4.5');
+    expect(rendered).toContain('langfuse');
+  });
+
+  it('returns json when asked for it', () => {
+    const rendered = ConfigCommand.render(config, { configPath, root: tmpPath, json: true });
+
+    expect(JSON.parse(rendered)).toEqual(ConfigCommand.data(config, { configPath, root: tmpPath }));
+  });
+});


### PR DESCRIPTION
## What

`explorbot config` prints the configuration a run actually resolves to — no more reconstructing it from the config file, the environment, and the global installation:

```
Config
  config      /home/me/.explorbot/config.js
  url         https://app.example.com
  browser     chromium, headless
  output      /home/me/.explorbot/sites/app.example.com/output
  knowledge   /home/me/.explorbot/sites/app.example.com/knowledge
  experience  /home/me/.explorbot/sites/app.example.com/experience

Models
  model   openai/gpt-oss-20b
  tester  anthropic/claude-sonnet-4.5

Integrations
  langfuse    traces sent

Environment
  EXPLORBOT_AI_PROVIDER  openrouter

Every EXPLORBOT_* variable: explorbot --help
```

`--json` prints the same values as an object, for a script that needs to know which model a run will use or where its output lands:

```bash
explorbot config --json
```

Every model role is listed, per-agent overrides included, next to the file behind them — or `EXPLORBOT_* environment variables` when the run is configured from the environment. The boats answer for their own configuration the same way: `explorbot api config`, `explorbot docs config`, `explorbot prima config` (which already had one, now sharing the renderer). Inside a session, `/config`.

## Why

The `EXPLORBOT_*` reference was appended to the help of **every** command and every mounted boat — `explorbot explore --help`, `explorbot api plan --help`, all of them ended in 20 lines nobody asked for. It is now printed once, under the top-level `explorbot --help`, and `explorbot config` shows the variables actually in effect.

## Notes

- `plans/` is now gitignored, and the workflow that rebuilds the testomat.ai docs site on `docs/**` changes rides along.
- One renderer in `src/commands/config-command.ts`, used by the CLI, the three boats and the TUI command; callers pass their own parser's config path and project root, so each boat reports its own file.
- Prima's private `named()` and `Provider.getModelName`/`getConfiguredModels` bodies collapse into one `modelName()`/`configuredModels()` in `src/config.ts`.
- Verified in all four configuration modes: project-local config, global `~/.explorbot`, the `EXPLORBOT_*` one-liner, and no configuration at all (prints the `init` guidance, exits 1).
- `tests/unit/config-command.test.ts` covers what the command reports: model roles with agent overrides, directories resolved against the project root, the env-built case, and json matching the table. 998 unit + 80 integration tests pass; format and lint clean. Docs in `docs/reference/commands.md`, CHANGELOG entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
