### PR TITLE
Show which provider serves each model in config output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026-08-19
+
+### `explorbot config` names the provider behind every model
+
+Model ids alone do not say where a model is served from — `openai/gpt-oss-120b` may run through
+OpenRouter, and a config can mix providers across roles. Each model is now printed next to the
+provider it comes from:
+
+```
+Models
+  model         groq        gpt-oss-120b
+  agenticModel  anthropic   claude-sonnet-4.5
+  visionModel   openrouter  google/gemma-4-31b-it
+  tester        openai      gpt-5
+```
+
+`--json` carries the same information as a `providers` object keyed by role, alongside `models`.
+
 ## 2026-08-18
 
 ### A run streamed over `--ws` reports what it is testing, not only what it logs

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -117,7 +117,9 @@ export class Provider {
   }
 
   getConfiguredModels(): Record<string, string> {
-    return configuredModels(this.config);
+    const models: Record<string, string> = {};
+    for (const [role, model] of Object.entries(configuredModels(this.config))) models[role] = model.name;
+    return models;
   }
 
   getSystemPromptForAgent(agentName: string, currentUrl?: string): string | undefined {

--- a/src/commands/config-command.ts
+++ b/src/commands/config-command.ts
@@ -47,13 +47,21 @@ export class ConfigCommand extends BaseCommand {
       if (value) env[variable.name] = value;
     }
 
+    const models: Record<string, string> = {};
+    const providers: Record<string, string> = {};
+    for (const [role, model] of Object.entries(configuredModels(config.ai))) {
+      models[role] = model.name;
+      if (model.provider) providers[role] = model.provider;
+    }
+
     return {
       config: configPath,
       url: config.playwright?.url || config.web?.url || config.api?.baseEndpoint || '',
       browser: config.playwright?.browser || '',
       headless: !config.playwright?.show,
       dirs,
-      models: configuredModels(config.ai),
+      models,
+      providers,
       integrations: {
         langfuse: !!config.ai?.langfuse?.enabled,
         testomatio: Reporter.resolveEnabled(config.reporter),
@@ -85,7 +93,11 @@ export class ConfigCommand extends BaseCommand {
     for (const [name, dir] of Object.entries(data.dirs)) general.push([name, dir]);
     section('Config', general);
 
-    const models: [string, string][] = Object.entries(data.models);
+    const providerWidth = Math.max(0, ...Object.values(data.providers).map((provider) => provider.length));
+    const models: [string, string][] = Object.entries(data.models).map(([role, model]) => {
+      if (!providerWidth) return [role, model];
+      return [role, `${chalk.dim((data.providers[role] || '').padEnd(providerWidth))}  ${model}`];
+    });
     if (!models.length) models.push(['model', chalk.red(`not configured — run ${getCliName()} init`)]);
     section('Models', models);
 
@@ -119,6 +131,7 @@ export interface ConfigData {
   headless: boolean;
   dirs: Record<string, string>;
   models: Record<string, string>;
+  providers: Record<string, string>;
   integrations: { langfuse: boolean; testomatio: boolean };
   env: Record<string, string>;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -780,14 +780,23 @@ export function modelName(model: unknown): string {
   return (model as any)?.modelId || (model as any)?.model || 'unknown';
 }
 
-export function configuredModels(ai?: AIConfig): Record<string, string> {
+export function modelProvider(model: unknown): string {
+  const provider = (model as any)?.provider;
+  if (typeof provider === 'string') return provider.split('.')[0];
+  if (typeof model === 'string') return model.split('/')[0];
+  return '';
+}
+
+export function configuredModels(ai?: AIConfig): Record<string, ConfiguredModel> {
   if (!ai?.model) return {};
 
-  const models: Record<string, string> = { model: modelName(ai.model) };
-  if (ai.agenticModel) models.agenticModel = modelName(ai.agenticModel);
-  if (ai.visionModel) models.visionModel = modelName(ai.visionModel);
+  const describe = (model: unknown): ConfiguredModel => ({ name: modelName(model), provider: modelProvider(model) });
+
+  const models: Record<string, ConfiguredModel> = { model: describe(ai.model) };
+  if (ai.agenticModel) models.agenticModel = describe(ai.agenticModel);
+  if (ai.visionModel) models.visionModel = describe(ai.visionModel);
   for (const [agent, agentConfig] of Object.entries(ai.agents || {})) {
-    if (agentConfig?.model) models[agent] = modelName(agentConfig.model);
+    if (agentConfig?.model) models[agent] = describe(agentConfig.model);
   }
   return models;
 }
@@ -868,6 +877,11 @@ export async function createModel(provider: string, modelId: string): Promise<an
 
 type ModelRole = 'model' | 'visionModel' | 'agenticModel';
 
+interface ConfiguredModel {
+  name: string;
+  provider: string;
+}
+
 interface ProviderInfo {
   envKey: string;
   load: () => Promise<(modelId: string) => any>;
@@ -879,4 +893,4 @@ interface EnvVar {
   required?: boolean;
 }
 
-export type { ModelRole, EnvVar, ProviderInfo };
+export type { ModelRole, EnvVar, ProviderInfo, ConfiguredModel };

--- a/tests/unit/config-command.test.ts
+++ b/tests/unit/config-command.test.ts
@@ -10,9 +10,9 @@ let configPath = '';
 const config = {
   playwright: { browser: 'firefox', url: 'http://localhost:3000', show: true },
   ai: {
-    model: { modelId: 'openai/gpt-oss-20b' },
-    visionModel: { modelId: 'google/gemma-4-31b-it' },
-    agents: { tester: { model: { modelId: 'anthropic/claude-sonnet-4.5' } } },
+    model: { modelId: 'openai/gpt-oss-20b', provider: 'openrouter' },
+    visionModel: { modelId: 'google/gemma-4-31b-it', provider: 'openrouter' },
+    agents: { tester: { model: { modelId: 'anthropic/claude-sonnet-4.5', provider: 'anthropic.messages' } } },
     langfuse: { enabled: true },
   },
   dirs: { output: 'out', knowledge: 'kb', experience: 'exp' },
@@ -39,6 +39,22 @@ describe('ConfigCommand.data', () => {
       visionModel: 'google/gemma-4-31b-it',
       tester: 'anthropic/claude-sonnet-4.5',
     });
+  });
+
+  it('reports the provider each model comes from', () => {
+    const data = ConfigCommand.data(config, { configPath, root: tmpPath });
+
+    expect(data.providers).toEqual({
+      model: 'openrouter',
+      visionModel: 'openrouter',
+      tester: 'anthropic',
+    });
+  });
+
+  it('leaves providers out when models do not name one', () => {
+    const data = ConfigCommand.data({ ai: { model: { modelId: 'gpt-oss-20b' } } } as any, { root: tmpPath });
+
+    expect(data.providers).toEqual({});
   });
 
   it('resolves configured directories against the project root', () => {
@@ -82,6 +98,7 @@ describe('ConfigCommand.render', () => {
     expect(rendered).toContain(configPath);
     expect(rendered).toContain('firefox, visible');
     expect(rendered).toContain('anthropic/claude-sonnet-4.5');
+    expect(rendered).toContain('openrouter');
     expect(rendered).toContain('langfuse');
   });
 


### PR DESCRIPTION
## Summary

`explorbot config` printed model ids only, which do not say where a model is served from — `openai/gpt-oss-120b` may run through OpenRouter, and a config can combine providers across roles. Each model is now printed next to its provider:

```
Models
  model         groq        gpt-oss-120b
  agenticModel  anthropic   claude-sonnet-4.5
  visionModel   openrouter  google/gemma-4-31b-it
  tester        openai      gpt-5
```

`--json` carries the same information as a `providers` object keyed by role, next to `models`.

## How

- `modelProvider()` in `src/config.ts` reads the AI SDK model's own `provider` field and keeps its first segment (`anthropic.messages` → `anthropic`), so nothing is re-derived from the config.
- `configuredModels()` returns `{ name, provider }` per role, so both come from one traversal; `Provider.getConfiguredModels()` maps back to names, leaving `Stats.modelsTable` matching untouched.
- `ConfigData` gains an additive `providers` record. Roles whose model names no provider are omitted rather than set to `""`, so the existing `models` shape in `--json` is unchanged.
- The provider column is dim and padded, and disappears entirely when no model names a provider.

## Test plan

- `bun test tests/unit/config-command.test.ts` — 9 pass, covering the extracted provider, the empty-provider fallback, and `--json` matching `data()`
- `bun run lint` and `bun run format` clean
- Verified against a real config (`explorbot config`, `explorbot config --json`) and a mixed-provider config

🤖 Generated with [Claude Code](https://claude.com/claude-code)