### PR TITLE
Stop a failed precondition check from looping the Pilot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-20
+
+### Changes
+
+- [Pilot] A test no longer burns its whole budget asking for the same test data over and over. When
+  the page check that decides whether the test can go on without that data failed, nothing came back
+  at all, so the request looked unanswered and was repeated until the test ran out of steps without
+  ever touching the browser. The check now always answers, even when it cannot look at the page.
+- [Pilot] When test data could not be prepared, the answer now says so plainly — it was not created,
+  it cannot be created automatically, and the test should carry on with what the page already shows.
+
 ## 2026-08-18
 
 ### Changes

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -718,6 +718,7 @@ export class Pilot implements Agent {
   }
 
   private buildPreconditionTool(task: Test) {
+    const unavailable = 'Data was not created and cannot be created automatically. Do not call precondition again for this test — continue with what the page already shows.';
     return {
       precondition: tool({
         description: 'Create fresh disposable data that the test will act on (edit, delete, filter). Describe WHAT to create, not what exists. Do NOT request users. Examples: "1 post", "1 comment", "1 label named Bug".',
@@ -732,7 +733,7 @@ export class Pilot implements Agent {
           if (!this.fisherman || !this.fisherman.isAvailable()) {
             const skipReason = await this.checkDataAvailability(task, description, 'Fisherman not available');
             if (skipReason) return { noted: true, prepared: false, skipped: true, reason: skipReason };
-            return { noted: true, prepared: false, reason: 'Fisherman not available' };
+            return { noted: true, prepared: false, reason: unavailable };
           }
 
           const result = await this.fisherman.prepareData(description, task.startUrl, task.sessionName);
@@ -741,7 +742,7 @@ export class Pilot implements Agent {
             if (result.summary) tag('warning').log(`Precondition failed: ${result.summary}`);
             const skipReason = await this.checkDataAvailability(task, description, result.summary);
             if (skipReason) return { noted: true, prepared: false, skipped: true, reason: skipReason };
-            return { noted: true, prepared: false, reason: result.summary };
+            return { noted: true, prepared: false, reason: `${result.summary || 'Data preparation failed'}. ${unavailable}` };
           }
 
           const items = result.created.map((c) => {
@@ -778,7 +779,7 @@ export class Pilot implements Agent {
       Reply with YES or NO on the first line, then a one-sentence reason on the second line.
     `;
 
-    const answer = await this.researcher.answerQuestionAboutScreenshot(screenshotState, question);
+    const answer = await this.researcher.answerQuestionAboutScreenshot(screenshotState, question).catch(() => null);
     if (!answer) return null;
 
     const firstLine = answer.split('\n')[0]?.trim().toUpperCase() ?? '';


### PR DESCRIPTION
## The bug

A test can spend its entire budget asking for the same test data and never touch the browser.

Two tests in the 2026-08-19 session are total losses:

| Trace | Scenario | `precondition` calls | Duration | Browser steps |
|---|---|---|---|---|
| `cb11add35dd90384d4324685352f1179` | Close the item detail overlay | 5 | 98s | 0 |
| `541335d3a9441b15e3c6023df22d9171` | Update a suite name and verify changes persist | 4 | 95s | 0 |

In both, the tool input was byte-identical every time, the tool output was recorded as `null`, there were zero `codeceptjs.step` observations, and neither `finish` nor `stop` was ever reached.

## Root cause

`buildPreconditionTool` → `checkDataAvailability` in `src/ai/pilot.ts`.

When data preparation fails, `checkDataAvailability` asks a vision model whether the scenario can still be carried out with what the page shows. Every vision call failed in that session, so `answerQuestionAboutScreenshot` threw. That rejection propagated out of the tool's `execute`, so the model received nothing back at all — which reads as "not answered yet", so it called `precondition` again with the same argument, until the test died.

The `explorer.capture` call on the line above was already guarded with `.catch(() => null)`. `answerQuestionAboutScreenshot` was the only unguarded await on that path.

## The fix

`.catch(() => null)` on the vision call. `null` is already the handled "cannot tell" branch immediately below (`if (!answer) return null;`), so `execute` now completes and returns a real result instead of rejecting. This matches the `.catch`-over-`try/catch` convention already used one line up.

**This is the fix for the observed loop.**

## Hardening (unobserved case)

The two failure returns previously reported `reason: 'Fisherman not available'` and `reason: result.summary`, both of which read as soft and unsettled — a model could reasonably re-request the data even when the tool did answer. They now state that the data was not created, cannot be created automatically, and that the test should continue with what the page already shows. `result.summary` can be `undefined`, so it gets a fallback.

This part is hardening against a case that was not observed in the traces. No counters, attempt tracking, or new state were added.

## Not in scope

The underlying vision-call failure is a separate issue being handled elsewhere; nothing here touches it.

## Verification

- `bun run format`, `bun run lint:fix` — clean
- `bun test tests/unit/` — 1022 pass, 0 fail
- `bun test tests/integration/` — 80 pass, 1 skip, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)