### PR TITLE
Tell the AI a command did not parse instead of sending it hunting for a missing element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-20
+
+### Changes
+
+- A click whose command never parsed as JavaScript is now reported as a broken command, not as a
+  missing element. Mismatched quotes or brackets used to be answered with advice to hunt the DOM
+  with `xpathCheck()`, `see()` or `visualClick()`, so the AI searched for an element that was never
+  looked up and re-emitted the same broken command. It is now told the string was invalid, that
+  nothing was learned about the page, and to re-emit the same intent as valid CodeceptJS.
+- `xpathCheck` that matches nothing no longer suggests broadening to a generic expression. It now
+  asks for narrowing down from what is known about the target — its role, its visible text, its
+  nearest labelled ancestor — one constraint at a time, instead of inviting another blind guess.
+
 ## 2026-08-18
 
 ### Changes

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1015,7 +1015,7 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
 
         if (result.totalFound === 0) {
           return failedToolResult('xpathCheck', `No elements matched XPath: ${xpath}`, {
-            suggestion: 'Try a broader expression. Examples: //*[contains(@class, "btn")], //button, //*[contains(text(), "keyword")]',
+            suggestion: 'Do not guess another expression. Narrow down from what you know about the target: its role, its visible text, its nearest labelled ancestor. Add one constraint at a time.',
           });
         }
 
@@ -1276,6 +1276,10 @@ export function clickFailureSuggestion(attempts: Array<{ error?: string }>): str
 
   if (errors.some((e) => e.includes('is not visible'))) {
     return 'Element is in the DOM but not visible. Reveal it first — scroll to it, expand its section, or open the panel holding it.';
+  }
+
+  if (errors.some((e) => e.includes('SyntaxError'))) {
+    return 'The command string never parsed as JavaScript — quotes or brackets do not match. No element was looked up, so this tells you nothing about the page. Re-emit the same intent as valid CodeceptJS.';
   }
 
   const notFound = errors.filter((e) => e.includes('was not found'));

--- a/tests/unit/click-failure-suggestion.test.ts
+++ b/tests/unit/click-failure-suggestion.test.ts
@@ -15,6 +15,7 @@ const COVERED = ['TimeoutError: locator.click: Timeout 3000ms exceeded.', 'Call 
 
 const NOT_VISIBLE = ['TimeoutError: locator.click: Timeout 3000ms exceeded.', 'Call log:', '  - waiting for element to be visible', '    - element is not visible'].join('\n');
 
+const MALFORMED = 'SyntaxError: missing ) after argument list';
 const CONTAINER_MISS = 'Error: Clickable element "New test" was not found inside element .dropdown-content';
 const LOCATOR_MISS = 'Error: Clickable element "Close panel" was not found by text|CSS|XPath';
 
@@ -50,6 +51,14 @@ describe('clickFailureSuggestion', () => {
     const suggestion = clickFailureSuggestion([{ error: DISABLED }, { error: LOCATOR_MISS }]);
 
     expect(suggestion).toContain('DISABLED');
+  });
+
+  it('reports an unparsable command instead of sending the model hunting for an element', () => {
+    const suggestion = clickFailureSuggestion([{ error: MALFORMED }]);
+
+    expect(suggestion).toContain('never parsed');
+    expect(suggestion).not.toContain('xpathCheck');
+    expect(suggestion).not.toContain('visualClick');
   });
 
   it('falls back to a generic hint when no attempt carried an error', () => {


### PR DESCRIPTION
## The bug

When the AI emits a CodeceptJS command whose string does not parse as JavaScript, the click tool answers with advice for a **missing element**. The model then goes hunting the DOM for an element that was never looked up, and keeps re-emitting broken commands.

Diagnosed from a real Langfuse session (2026-08-19):

- **18 attempt-level failures were malformed JavaScript** — `SyntaxError: missing ) after argument list`, from mismatched quotes like `I.click('//a[...]']`.
- In trace `9b4d3abae20f99897c26a00ab6d90651` ("Copy a suite via node-specific actions", 28 steps, 285s, ended with no verdict) the model emitted such a command three separate times. Each time it was answered with *"Try xpathCheck() to find the element's actual position, see() for visual analysis, or visualClick() to click by visual appearance."*
- Session-wide tool failure rates: `click` failed **201/334 (60%)**, `xpathCheck` failed **101/123 (82%)**.

## Fix 1 — a SyntaxError branch in `clickFailureSuggestion`

`clickFailureSuggestion` is already a classifier over the attempt error text, with branches for `not enabled`, `intercepts pointer events`, `is not visible`, `was not found inside element` and `was not found`. There was simply no branch for "the command never parsed", so a SyntaxError fell through to the generic element-hunting default.

One branch is added, above the not-found checks, keyed on the JavaScript engine's own error class name. It says the command string was invalid, that no element was looked up so the page tells us nothing, and to re-emit the same intent as valid CodeceptJS. It deliberately names no lookup tool, because no lookup happened.

This extends an existing classifier keyed on the runtime's own error type — it is not a new validator and not a pattern derived from any one session.

## Fix 2 — xpathCheck's no-match suggestion

Was: `'Try a broader expression. Examples: //*[contains(@class, "btn")], //button, //*[contains(text(), "keyword")]'`

Two problems: it invites another blind guess (which is how `xpathCheck` reached an 82% failure rate), and it hardcodes example selectors into AI-facing text, against CLAUDE.md's rule on specific classes and locators in prompts.

Now it asks the model to narrow down from what is actually known about the target — its role, its visible text, its nearest labelled ancestor — adding one constraint at a time. No example selectors.

## Scope

Two suggestion strings, one new classifier branch, one unit test for the new branch. No change to the click tool's control flow, the attempt ladder, or any other suggestion string.

Known and deliberate: `xpathCheck`'s own `description` and its `xpath` inputSchema text still say "start broad" with example selectors, which now reads slightly against the new no-match suggestion. Left alone to keep this PR to its stated scope.

## Tests

- `bun run format` — clean, no fixes applied
- `bun run lint:fix` — clean, no fixes applied
- `bun test tests/unit/` — **1023 pass, 0 fail** (79 files)
- `bun test tests/integration/` — **80 pass, 1 skip, 0 fail** (9 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)