### PR TITLE
Make context() read the page it reports, with refs attached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-08-20
+
+### Changes
+
+- The `context()` tool now reads the page again instead of re-printing the snapshot the AI was
+  already given. It used to answer from the last stored state, so an AI that asked for fresh
+  context after the page moved on got the stale one back.
+- The refreshed context carries element refs, the same ones the page context carries when a test
+  starts. Refs previously disappeared the moment the AI refreshed its context, so it kept clicking
+  refs that no longer existed and the click failed.
+- `xpathCheck` matches XPath against the page as it is now, so its match list and its
+  "element is visible" answer describe the same page.
+- The clickRef tool no longer suggests refs have a fixed short form — a ref is an opaque id that
+  varies with the page and with the frame the element sits in, and must be copied exactly.
+
 ## 2026-08-18
 
 ### Changes

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -11,7 +11,7 @@ import { Observability } from '../observability.ts';
 import type { StateTransition } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Test, TestResult, type TestResultType } from '../test-plan.ts';
-import { compactAriaSnapshot, detectFocusArea } from '../utils/aria.ts';
+import { detectFocusArea, interactiveAriaWithRefs } from '../utils/aria.ts';
 import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
@@ -602,7 +602,7 @@ export class Tester extends TaskAgent implements Agent {
         </page>
 
         <page_aria>
-        ${await this.interactiveAriaWithRefs(currentState)}
+        ${await interactiveAriaWithRefs(this.explorer, currentState)}
         </page_aria>
         ${uiMapSection}
 
@@ -639,15 +639,9 @@ export class Tester extends TaskAgent implements Agent {
       </page>
 
       <page_aria>
-      ${await this.interactiveAriaWithRefs(currentState)}
+      ${await interactiveAriaWithRefs(this.explorer, currentState)}
       </page_aria>
     `;
-  }
-
-  private async interactiveAriaWithRefs(state: ActionResult): Promise<string> {
-    const withRefs = await Promise.resolve(this.explorer?.withPage?.((page: any) => page.locator('body').ariaSnapshot({ mode: 'ai' }))).catch(() => null);
-    if (!withRefs) return state.getInteractiveARIA();
-    return compactAriaSnapshot(withRefs, false);
   }
 
   private finishTest(task: Test): void {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -5,7 +5,7 @@ import { ActionResult, type PageDiff, type ToolResultMetadata } from '../action-
 import type { ExperienceTracker } from '../experience-tracker.ts';
 import { Stats } from '../stats.ts';
 import { type Task, TestResult } from '../test-plan.js';
-import { LARGE_ARIA_CHANGE_THRESHOLD } from '../utils/aria.ts';
+import { LARGE_ARIA_CHANGE_THRESHOLD, interactiveAriaWithRefs } from '../utils/aria.ts';
 import { isFatalBrowserError } from '../utils/browser-errors.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { pause } from '../utils/loop.js';
@@ -34,7 +34,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
       description: dedent`
         Click an element by trying multiple CodeceptJS commands in order until one succeeds.
 
-        Use this only for elements the page context gives you no ref for. When the element shows a ref such as [ref=e14],
+        Use this only for elements the page context gives you no ref for. When the element is followed by [ref=...],
         call clickRef with that ref instead — composing a locator for an element that already has a ref is wasted work,
         and a locator can match several elements where a ref cannot.
 
@@ -153,15 +153,16 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
 
     clickRef: tool({
       description: dedent`
-        Click an element by the ref the page context gave it, e.g. [ref=e14].
+        Click an element by the ref the page context gave it, printed after the element as [ref=...].
 
         Prefer this over click() whenever the element you want carries a ref. A ref names one exact element, so it
         cannot match several by mistake and never needs disambiguating — it is the fastest way to click.
-        Only pass a ref that appears in the page context you were given. Never invent or guess one.
+        A ref is an opaque id whose form varies with the page and with the frame the element lives in.
+        Copy it character for character from the page context you were given. Never invent, guess, shorten or rebuild one.
         If it reports the ref is gone, the page has been rebuilt: get fresh context and use the new ref.
       `,
       inputSchema: z.object({
-        ref: z.string().describe('The ref exactly as it appears in the page context, e.g. "e14"'),
+        ref: z.string().describe('The ref copied character for character from the page context, as it appears inside [ref=...]'),
         element: z.string().describe('Role and name of the element you are clicking, for the record'),
       }),
       execute: async ({ ref, element }) => {
@@ -646,19 +647,24 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
             return failedToolResult('context', 'No current page state available.');
           }
 
-          const actionResult = ActionResult.fromState(currentState);
+          const actionResult = await explorer.capture();
+          if (actionResult.error) {
+            return failedToolResult('context', `Page state could not be captured: ${actionResult.error}`);
+          }
+
           const html = await actionResult.simplifiedHtml();
-          const aria = actionResult.getInteractiveARIA();
+          const aria = await interactiveAriaWithRefs(explorer, actionResult);
 
           return successToolResult('context', {
-            url: currentState.url,
-            title: currentState.title,
+            url: actionResult.url,
+            title: actionResult.title,
             suggestion: 'If not enough context received, call see() to visually identify elements in page contents',
             aria: cap(aria, ARIA_OUTPUT_CAP),
             html: cap(html, HTML_OUTPUT_CAP),
             reminder: 'Context provided. Do not call context() again until you perform actions or suspect page changed.',
           });
         } catch (error) {
+          throwIfFatalBrowserError(error);
           const errorMessage = errorText(error);
           return failedToolResult('context', `Context tool failed: ${errorMessage}`);
         }
@@ -1000,7 +1006,7 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
           return failedToolResult('xpathCheck', 'No current page state available.');
         }
 
-        const html = ActionResult.fromState(currentState).html;
+        const html = (await explorer.capture()).html;
         if (!html) {
           return failedToolResult('xpathCheck', 'No HTML available for current page state.');
         }

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -532,6 +532,12 @@ export const compactAriaSnapshot = (snapshot: string | null, keepNamed = false, 
   return renderTree(tree, 0, offload);
 };
 
+export const interactiveAriaWithRefs = async (explorer: { withPage?: (fn: (page: any) => Promise<string>) => Promise<string> } | undefined, state: { getInteractiveARIA: () => string }): Promise<string> => {
+  const withRefs = await Promise.resolve(explorer?.withPage?.((page: any) => page.locator('body').ariaSnapshot({ mode: 'ai' }))).catch(() => null);
+  if (!withRefs) return state.getInteractiveARIA();
+  return compactAriaSnapshot(withRefs, false);
+};
+
 export const diffAriaSnapshots = (previous: string | null, current: string | null): AriaDiff => {
   const flat = (snap: string | null): FlatEntry[] => {
     let tree = parseSnapshot(snap);

--- a/tests/unit/aria.test.ts
+++ b/tests/unit/aria.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { compactAriaSnapshot, diffAriaSnapshots } from '../../src/utils/aria.ts';
+import { compactAriaSnapshot, diffAriaSnapshots, interactiveAriaWithRefs } from '../../src/utils/aria.ts';
 
 describe('aria', () => {
   it('returns null diff for identical snapshots', () => {
@@ -243,6 +243,21 @@ describe('aria', () => {
 
   it('leaves a short value inline', () => {
     expect(compactAriaSnapshot('- textbox "Name": Bench probe', true)).toContain(': Bench probe');
+  });
+
+  it('takes refs from the live snapshot when the page is reachable', async () => {
+    const explorer = { withPage: async (fn: (page: any) => Promise<string>) => fn({ locator: () => ({ ariaSnapshot: async () => '- button "Save" [ref=e7]' }) }) };
+
+    const result = await interactiveAriaWithRefs(explorer, { getInteractiveARIA: () => '- button "Save"' });
+
+    expect(result).toContain('ref=e7');
+  });
+
+  it('falls back to the stored snapshot when the live one is unavailable', async () => {
+    const explorer = { withPage: async () => Promise.reject(new Error('page closed')) };
+
+    expect(await interactiveAriaWithRefs(explorer, { getInteractiveARIA: () => '- button "Save"' })).toBe('- button "Save"');
+    expect(await interactiveAriaWithRefs(undefined, { getInteractiveARIA: () => '- button "Save"' })).toBe('- button "Save"');
   });
 
   it('keeps refs on stateful nodes nested in a tree', () => {


### PR DESCRIPTION
Two stacked defects made `context()` useless and `clickRef` almost always fail. Diagnosed from a Langfuse session on 2026-08-19.

## What was wrong

**`context()` never captured.** It read `stateManager.getCurrentState()` and re-rendered it through `ActionResult.fromState(...)`, so it handed back the snapshot the model already had, while its own description sells it as fresh state ("You suspect page changed externally"). `verify` in the same file has always done `await explorer.capture()`.

**`getInteractiveARIA()` carries no element refs.** In that session, `context()` output contained `[ref=...]` in **0 of 38 calls**, while the injected `<page_aria>` carried refs in **305 of 677 blocks**. Refs appeared in the prompt, vanished the moment the model refreshed its context, and the model fell back on stale ones. `clickRef` failed **18 of 20 calls (90%)** with `Invalid frame in aria-ref selector` and ref-not-found timeouts.

## The fix

1. The live-snapshot helper (`page.locator('body').ariaSnapshot({ mode: 'ai' })`) moved out of `Tester` into `src/utils/aria.ts` as `interactiveAriaWithRefs(explorer, state)`, next to `compactAriaSnapshot`. Both Tester call sites now use it, no copy left behind. **The degradation is preserved exactly**: when `withPage` fails, it falls back to the ref-free `getInteractiveARIA()`. The 305-of-677 split shows the live path fails routinely, so `context()` must never start throwing where it previously answered. Covered by two new tests in `tests/unit/aria.test.ts`.
2. `context()` captures fresh, then takes its ARIA from that helper. Both halves ship together on purpose — adding refs *without* the fresh capture would hand the model confident-looking stale refs, which is exactly what produces `Invalid frame in aria-ref selector` today, and `clickRef` would get worse rather than better.
3. `clickRef`'s description taught that a ref looks like `e14`. Real refs are frame-scoped and longer. It now states the shape generally — an opaque id whose form varies with the page and the frame, to be copied character for character, never invented or rebuilt. `click`'s description carried the same false `[ref=e14]` example one screen up and is fixed with it.

## Behaviour change: `context()` now counts as state activity

`explorer.capture()` has a side effect the cached read did not: it reaches `stateManager.updateState(result, codeBlock)` (`src/action.ts:175`). So `context()` calls now participate in transition history and dead-loop bookkeeping. `verify` already does this. Verified rather than assumed:

- `ActionResult.getStateHash()` is built from url + h1 + h2 only, so an unchanged page re-captured yields the same hash.
- `StateManager.updateState` pushes a `StateTransition` **only** when the hash changed (or a dialog appeared), and `isInDeadLoop()` reads `stateHistory`. An unchanged page therefore adds nothing to stall detection.

What does change: `currentState` is replaced by a fresher `ActionResult` (so a later tool's `pageDiff` is measured from a fresher baseline — more accurate, not less), a state id is consumed, and a state html/aria file is written. If the page genuinely moved on since the last recorded state, the capture records that transition — which is the point of the tool.

Two smaller consequences of capturing, both matching what neighbouring tools already do: fatal browser errors now propagate out of `context()` instead of being flattened into a failed tool result (commit 754dffc exists so a dead browser stops the run), and a non-fatal capture failure returns a failed tool result rather than `success: true` with empty content.

## Rejected: making capture globally produce ref-annotated snapshots

Changing `src/action.ts:147` to `ariaSnapshot({ mode: 'ai' })` looks like the simpler fix and **breaks `diffAriaSnapshots`**. Refs renumber on every snapshot, so an identical page re-snapshotted diffs as all-changed. Reproduced directly against `src/utils/aria.ts` — same content, refs `e1..e6` vs `f4e116..f4e121`:

```
{ "count": 6, "text": "ariaDiff:\n  added:\n    - button \"New item\" [ref=f4e121]\n ... removed:\n    - button \"New item\" [ref=e6] ..." }
```

That is the `ariaDiff` the Tester and Pilot rely on for progress and stall detection, so `action.ts:147` is left alone. The ref-carrying snapshot is taken separately, after the capture, only for what the model reads.

## Optional, separable

`xpathCheck` had the same defect class — it matched XPath against `ActionResult.fromState(currentState).html` while checking visibility against the live browser, so the two halves could describe different pages. It was a genuine one-liner (`const html = (await explorer.capture()).html;`) and the failure path stays graceful: an error `ActionResult` returns `''` from `.html` and the existing `if (!html)` guard fires. **Drop this hunk if you disagree — nothing else depends on it.** The state-activity note above applies to it too: it captures, so it updates state the same way.

The `research` tool (`src/ai/tools.ts`, its `aria:` field) still reports `getInteractiveARIA()` off cached state. Same defect class, deliberately left out of scope here.

## Tests

- `bun run format`, `bun run lint:fix` — clean
- `bun test tests/unit/` — 1024 pass, 0 fail
- `bun test tests/integration/` — 80 pass, 1 skip, 0 fail
- `tsc --noEmit` — the repo has pre-existing errors; none added by this change, and one in `tester.ts` was removed (the helper's `withRefs` was inferred as `{}` and is now typed).

Not regression-tested — that is the user's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
