### PR TITLE
Never guess credentials — ask the user, or read them from knowledge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Changelog
 
+## 2026-08-21
+
+### The Navigator asks for credentials instead of inventing them
+
+A page that redirected to a login form used to be treated as a form to fill: the model made up an
+email and a password, submitted them, and spent the rest of its attempts on a form that was never
+going to let it in. Credentials now have exactly two sources — the knowledge of the page, or the
+user. When neither has them, the Navigator asks:
+
+```
+Which credentials should I sign in with?
+
+Your suggestion ("skip" to continue):
+```
+
+and carries on with the answer. Where nobody can answer, it stops and names what is missing, so the
+reason reaches the log next to the `explorbot learn "<path>"` hint for recording the credentials
+once and for all.
+
+Invented values are ruled out for anything that identifies an account — logins, passwords, codes,
+tokens. A scenario that explicitly creates something, such as registering a new user, still makes
+up the values it needs.
+
+### An answer can be kept as knowledge for the page
+
+When an answer is a lasting fact about the page — how to authorize, what its data means — the
+question and the answer are appended to the knowledge file of that page, and later runs read it
+instead of asking again:
+
+```
+Knowledge saved to knowledge/login.md
+```
+
+Answers that only serve the test running now are not saved. Knowledge is filed under the path of
+the page with any query string dropped, so it still matches on the next visit when the redirect
+carries a different message in the URL.
+
+### Changes
+
+- The question the Pilot asks is offered only where somebody can answer it. A run with no one at
+  the keyboard no longer spends a step on a tool whose only possible reply was "user input not
+  available".
+
 ## 2026-08-18
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,19 +23,28 @@ Invented values are ruled out for anything that identifies an account — logins
 tokens. A scenario that explicitly creates something, such as registering a new user, still makes
 up the values it needs.
 
-### An answer can be kept as knowledge for the page
+### What the user answers becomes experience for the page
 
-When an answer is a lasting fact about the page — how to authorize, what its data means — the
-question and the answer are appended to the knowledge file of that page, and later runs read it
-instead of asking again:
+An answer no longer stops at the run that needed it. From the moment a question is answered the log
+is recorded, and once the work is done the Captain reads that log to judge one thing: was the answer
+worth more than this run? After a test it judges the finished test, and outside a test the command
+that was running — a research, a navigation. When the answer proved itself, the question and the
+answer are kept verbatim in the experience of the page they were asked on, under a how-to heading:
 
 ```
-Knowledge saved to knowledge/login.md
+Added FLOW to: 8f3c21a9.md
 ```
 
-Answers that only serve the test running now are not saved. Knowledge is filed under the path of
-the page with any query string dropped, so it still matches on the next visit when the redirect
-carries a different message in the URL.
+Nothing is written when the log does not show the answer being used, when what followed it failed,
+when the answer only applied to that one run, or when the page already carries the same fact. The
+user is never asked to confirm, and no knowledge file is touched.
+
+### Experience arrives with the page, not with the scenario
+
+Experience files are keyed by page state, but a test only ever saw the experience of the page it
+started on. Landing on a login form, a detail page or a dialog mid-test brought its ARIA and its UI
+map and nothing of what earlier runs had learned there. The page a test lands on now brings its own
+experience with it, and the Pilot reviewing that page can open the recipes listed for it.
 
 ### Changes
 

--- a/src/ai/captain.ts
+++ b/src/ai/captain.ts
@@ -8,7 +8,7 @@ import type { WebPageState } from '../state-manager.ts';
 import { Task, Test } from '../test-plan.ts';
 import { formatHeadings } from '../utils/context-formatter.ts';
 import { HooksRunner } from '../utils/hooks-runner.ts';
-import { startLogCapture, stopLogCapture, tag } from '../utils/logger.js';
+import { startLogCapture, stopAnswerCapture, stopLogCapture, tag } from '../utils/logger.js';
 import { loop } from '../utils/loop.js';
 import { truncateJson } from '../utils/strings.ts';
 import type { Agent } from './agent.js';
@@ -514,6 +514,76 @@ export class Captain extends CaptainBase implements Agent {
     }
 
     return null;
+  }
+
+  async reviewAnswers(task?: Task): Promise<void> {
+    const experienceTracker = this.getExperienceTracker();
+    const answers = experienceTracker.takeAnswers();
+    if (!answers.length) return;
+
+    const logs = stopAnswerCapture();
+
+    for (const { state, question, answer } of answers) {
+      const howTo = await this.howToFromAnswer(state, question, answer, logs, task);
+      if (!howTo) continue;
+      experienceTracker.writeFlow(state, `## FLOW: ${howTo}\n\n* ${question}\n* ${answer}\n\n---\n`);
+    }
+  }
+
+  private async howToFromAnswer(state: ActionResult, question: string, answer: string, logs: string[], task?: Task): Promise<string> {
+    const existingExperience = this.getExperienceTracker()
+      .getRelevantExperience(state)
+      .map((experience) => experience.content)
+      .filter(Boolean)
+      .join('\n')
+      .slice(0, 2000);
+
+    const prompt = dedent`
+      A run asked the user for help and got an answer. Decide from the log whether the answer was
+      worth more than this run: it moved the run forward, and the same situation can recur on a
+      later visit to this page.
+
+      <question_asked>
+      ${question}
+      </question_asked>
+
+      <user_answer>
+      ${answer}
+      </user_answer>
+
+      <page>
+      ${state.url || ''}
+      </page>
+
+      ${task ? `<task>\n${task.description}\nResult: ${task.getRunResult() || 'unknown'}\n${task.notesToString()}\n</task>` : ''}
+
+      <log_after_the_answer>
+      ${logs.join('\n')}
+      </log_after_the_answer>
+
+      ${existingExperience ? `<existing_experience_for_this_page>\n${existingExperience}\n</existing_experience_for_this_page>` : ''}
+
+      If it was, return ONE line: an imperative how-to naming what the answer makes possible on this
+      page. Lowercase first letter, no trailing punctuation, no code, no explanation. The answer
+      itself is kept verbatim — do not repeat it.
+
+      Return an EMPTY response if any of:
+      - The log does not show the answer being used.
+      - What followed the answer failed or was abandoned.
+      - The answer only applied to this run and says nothing about the page.
+      - The existing experience already covers it.
+    `;
+
+    const response = await this.getProvider().chat(
+      [
+        { role: 'system', content: 'Judge whether an answer the user gave during a run is worth keeping as experience for the page. Return one how-to line when it is, nothing when it is not.' },
+        { role: 'user', content: prompt },
+      ],
+      this.getProvider().getModelForAgent('captain'),
+      { agentName: 'captain', telemetryFunctionId: 'captain.reviewAnswers' }
+    );
+
+    return (response?.text || '').trim().split('\n')[0].trim();
   }
 }
 

--- a/src/ai/navigator.ts
+++ b/src/ai/navigator.ts
@@ -24,7 +24,7 @@ import type { Provider } from './provider.js';
 import { Researcher } from './researcher.ts';
 import { actionRule, locatorRule, unexpectedPopupRule } from './rules.js';
 import { isInteractive } from './task-agent.js';
-import { createLearnExperienceTool } from './tools.ts';
+import { createAskUserTool, createLearnExperienceTool } from './tools.ts';
 
 const debugLog = createDebug('explorbot:navigator');
 
@@ -54,11 +54,15 @@ class Navigator implements Agent {
     NEVER navigate away from the base URL domain. Stay on the same origin at all times.
     NEVER attempt to rewrite, replace, mock, or spoof the URL via JavaScript, history API, location assignment, or any client-side trick.
     NEVER use executeScript, executeAsyncScript, or any JS evaluation to change the URL, bypass redirects, or fake the page state.
-    If the target URL redirects to an authentication/login page, DO NOT try to force the original URL. Instead:
-      1. Look for credentials in the provided knowledge/hint context and perform a real login through the form.
-      2. If no credentials are available, ask the user for credentials or ask the user to log in manually.
-    A redirect to /login, /sign_in, /auth, or similar is a signal that authentication is required — treat it as such, never as an obstacle to bypass.
+    A redirect to an authentication route means a real login is required — never force the original URL past it.
   </constraints>
+
+  <credentials>
+    Do not guess credentials on login forms and for authorization.
+    Use only provided credentials, if missing: ask them via askUser or stop immediately.
+    When scenario explicitly requires creating a new user or account, fresh values are allowed.
+    Page placeholders and labels are not credentials.
+  </credentials>
   `;
   private freeSailSystemPrompt = dedent`
   <role>
@@ -229,15 +233,15 @@ class Navigator implements Agent {
     conversation.addUserText(await this.buildResolutionPrompt(message, actionResult));
 
     let stopReason: string | null = null;
-    const tools = {
+    const tools: Record<string, unknown> = {
       stop: tool({
         description: dedent`
           Stop the navigation because no locator or strategy change can reach the goal.
           Use this when reaching the goal requires something only the user can supply or that the
-          page cannot grant from the current state — for example: an authentication failure you
-          cannot guess past, a captcha or human-verification step, a permission the test cannot
-          satisfy, a piece of data not present in the available knowledge / hint context, or a
-          blocking error or dialog you cannot dismiss.
+          page cannot grant from the current state — for example: credentials or data missing from
+          the available knowledge / hint context, a captcha or human-verification step, a permission
+          the test cannot satisfy, or a blocking error or dialog you cannot dismiss.
+          Ask the user first when you can; stop once nobody can supply what is missing.
           Do NOT use this for locator or strategy problems — for those, emit new code blocks instead.
         `,
         inputSchema: z.object({
@@ -249,6 +253,7 @@ class Navigator implements Agent {
         },
       }),
     };
+    if (isInteractive()) tools.askUser = createAskUserTool(this.stateManager);
 
     let codeBlocks: string[] = [];
     let htmlContextAdded = false;
@@ -274,6 +279,7 @@ class Navigator implements Agent {
           debugLog('Received AI response:', aiResponse?.length ?? 0, 'characters');
           codeBlocks = extractCodeBlocks(aiResponse ?? '');
           codeBlockIndex = 0;
+          if (codeBlocks.length === 0 && result.toolExecutions?.length) return;
         }
 
         if (codeBlocks.length === 0) {
@@ -446,7 +452,7 @@ class Navigator implements Agent {
 
       Choose exactly ONE path based on what the diffs actually show — do not assume the previous step submitted any particular kind of data:
 
-      A. The diff indicates the application requires something only the user can supply — for example: an authentication failure you cannot guess past, a captcha, a permission the test cannot satisfy, or knowledge that is not present in the provided context. Call the stop() tool and quote what you saw in the diff and what is needed.
+      A. The diff indicates the application requires something only the user can supply — for example: a rejected authentication, a captcha, a permission the test cannot satisfy, or knowledge that is not present in the provided context. Ask the user for it, and call the stop() tool when nobody can supply it — quote what you saw in the diff and what is needed.
 
       B. The diff indicates the next step is something you can perform from the existing knowledge / hint context — for example: re-emit a step with a value that exists in the knowledge but was used incorrectly; dismiss an unexpected modal; accept a confirmation; take a follow-up step the page now requires. Emit code blocks for that next step. Do NOT change the locator of a step that already produced a reaction.
 

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -515,7 +515,7 @@ export class Pilot implements Agent {
         First: evaluate whether this navigation makes sense for the scenario goal. If the page is unrelated, instruct Tester to back() or reset(). Then plan next steps.
       `,
       'pilot.reviewNewPage',
-      { task }
+      { tools: true, maxToolRoundtrips: 2, task }
     );
   }
 

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -426,6 +426,7 @@ export class Tester extends TaskAgent implements Agent {
     await this.hooksRunner.runAfterHook('tester', finalUrl);
 
     await this.getHistorian().saveSession(task, initialState, conversation);
+    await this.captain?.reviewAnswers(task);
     if (task.plan) {
       this.getHistorian().savePlanToFile(task.plan);
     }
@@ -611,6 +612,10 @@ export class Tester extends TaskAgent implements Agent {
         Do not interact with elements that are not listed in <page_aria> and <page_html>
         Refer to information on page sections in <page_ui_map> and use container CSS locators to interact with elements inside sections
       `;
+
+      const experience = this.getExperience(currentState);
+      if (experience) context += `\n\n${experience}`;
+
       return context;
     }
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -10,7 +10,6 @@ import { LARGE_ARIA_CHANGE_THRESHOLD } from '../utils/aria.ts';
 import { isFatalBrowserError } from '../utils/browser-errors.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { pause } from '../utils/loop.js';
-import { extractStatePath } from '../utils/url-matcher.ts';
 import { WebElement } from '../utils/web-element.ts';
 import type { ToolDeps } from './agent.ts';
 import { Navigator } from './navigator.ts';
@@ -586,9 +585,8 @@ export function createAskUserTool(stateManager: StateManager) {
     inputSchema: z.object({
       question: z.string().describe('What you need help with - be specific about what failed'),
       context: z.string().optional().describe('Relevant context like locators tried, errors received'),
-      persistent: z.boolean().optional().describe('True if the answer is a lasting fact about this page (saved as knowledge for later runs). False if it only applies to this test.'),
     }),
-    execute: async ({ question, context, persistent }) => {
+    execute: async ({ question, context }) => {
       let prompt = `${question}\n\nYour suggestion ("skip" to continue):`;
       if (context) prompt = `${question}\n\nContext: ${context}\n\nYour suggestion ("skip" to continue):`;
 
@@ -598,23 +596,14 @@ export function createAskUserTool(stateManager: StateManager) {
         return { success: false, message: 'User skipped' };
       }
 
-      const result: Record<string, unknown> = {
+      const state = stateManager.getCurrentState();
+      if (state) stateManager.getExperienceTracker().rememberAnswer(ActionResult.fromState(state), question, userInput);
+
+      return {
         success: true,
         userSuggestion: userInput,
         instruction: 'Use this answer as the next concrete step.',
       };
-
-      const state = stateManager.getCurrentState();
-      if (persistent && state) {
-        const path = extractStatePath(state.url || state.fullUrl || '/')
-          .split('?')[0]
-          .split('#')[0];
-        const { filePath } = stateManager.getKnowledgeTracker().addKnowledge(path, `${question}\n\n${userInput}`);
-        tag('success').log(`Knowledge saved to ${filePath}`);
-        result.knowledgeFile = filePath;
-      }
-
-      return result;
     },
   });
 }

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -3,12 +3,14 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { ActionResult, type PageDiff, type ToolResultMetadata } from '../action-result.ts';
 import type { ExperienceTracker } from '../experience-tracker.ts';
+import type { StateManager } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Task, TestResult } from '../test-plan.js';
 import { LARGE_ARIA_CHANGE_THRESHOLD } from '../utils/aria.ts';
 import { isFatalBrowserError } from '../utils/browser-errors.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { pause } from '../utils/loop.js';
+import { extractStatePath } from '../utils/url-matcher.ts';
 import { WebElement } from '../utils/web-element.ts';
 import type { ToolDeps } from './agent.ts';
 import { Navigator } from './navigator.ts';
@@ -413,7 +415,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
         I.selectOption({"role":"combobox","text":"Category"}, 'Technology')
 
         Do not submit form - use verify() first to check fields were filled correctly, then click() to submit.
-        Do not use: wait functions, amOnPage, reloadPage, saveScreenshot        
+        Do not use: wait functions, amOnPage, reloadPage, saveScreenshot
       `,
       inputSchema: z.object({
         codeBlock: z.string().describe('Valid CodeceptJS code starting with I. Can contain multiple commands separated by newlines.'),
@@ -569,6 +571,54 @@ export function createLearnExperienceTool({ getExperienceTracker, getState }: { 
   });
 }
 
+export function createAskUserTool(stateManager: StateManager) {
+  return tool({
+    description: dedent`
+      Ask the user for help when automated recovery is stuck or the next step is unclear.
+
+      Use when:
+      - The same locator or element keeps failing
+      - An element that should exist cannot be found
+      - Form interaction isn't working as expected
+      - A value only the user owns is needed, such as credentials
+      - You need a human decision on how to proceed
+    `,
+    inputSchema: z.object({
+      question: z.string().describe('What you need help with - be specific about what failed'),
+      context: z.string().optional().describe('Relevant context like locators tried, errors received'),
+      persistent: z.boolean().optional().describe('True if the answer is a lasting fact about this page (saved as knowledge for later runs). False if it only applies to this test.'),
+    }),
+    execute: async ({ question, context, persistent }) => {
+      let prompt = `${question}\n\nYour suggestion ("skip" to continue):`;
+      if (context) prompt = `${question}\n\nContext: ${context}\n\nYour suggestion ("skip" to continue):`;
+
+      const userInput = await pause(prompt);
+
+      if (!userInput || userInput.toLowerCase() === 'skip') {
+        return { success: false, message: 'User skipped' };
+      }
+
+      const result: Record<string, unknown> = {
+        success: true,
+        userSuggestion: userInput,
+        instruction: 'Use this answer as the next concrete step.',
+      };
+
+      const state = stateManager.getCurrentState();
+      if (persistent && state) {
+        const path = extractStatePath(state.url || state.fullUrl || '/')
+          .split('?')[0]
+          .split('#')[0];
+        const { filePath } = stateManager.getKnowledgeTracker().addKnowledge(path, `${question}\n\n${userInput}`);
+        tag('success').log(`Knowledge saved to ${filePath}`);
+        result.knowledgeFile = filePath;
+      }
+
+      return result;
+    },
+  });
+}
+
 export function createAgentTools({ explorer, stateManager, ai, researcher, navigator, supervisor, withExperience }: AgentToolDeps): any {
   const tools: Record<string, any> = {
     see: tool({
@@ -624,12 +674,12 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
     context: tool({
       description: dedent`
         Get current page HTML and ARIA snapshot.
-        
+
         DO NOT call this if:
         - You just performed an action (pageDiff already provided in response)
         - You already have recent <page_html>/<page_aria> in context
         - You're about to perform an action (you'll get pageDiff after)
-        
+
         Call ONLY when:
         - Context is stale (many conversation turns since last state update)
         - You suspect page changed externally (timers, auto-refresh)
@@ -729,18 +779,18 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
       description: dedent`
         Research the current page to understand its structure, UI elements, and navigation.
         This tool provides UI map report including forms, buttons, menus, and other interactive elements.
-        
+
         DO NOT call this if:
         - You already have <page_ui_map> or <initial_page_ui_map> in context
         - You just navigated to a page (research is provided automatically)
         - You're on the same page you already researched
         - pageDiff was small (minor changes don't need full research)
-        
+
         Call ONLY when:
         - Page structure is unclear and no UI map was provided
         - You need to discover hidden/collapsed elements not in current context
         - Page has dramatically changed after previous action
-        
+
         Avoid calling this tool twice in a row.
       `,
       inputSchema: z.object({
@@ -761,7 +811,7 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
             aria: cap(ActionResult.fromState(currentState).getInteractiveARIA(), ARIA_OUTPUT_CAP),
             message: `Successfully researched page: ${currentState.url}.`,
             suggestion: dedent`
-              You received comprehensive UI map report. Use it to understand the page structure and navigate to the elements. 
+              You received comprehensive UI map report. Use it to understand the page structure and navigate to the elements.
               Do not ask for research() if you have <page_ui_map> for current page.
               Follow <section_context_rule> when selecting locators for all tools.
 
@@ -1065,46 +1115,8 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
     });
   }
 
-  if (supervisor) {
-    tools.askUser = tool({
-      description: dedent`
-        Ask the user for help when automated recovery is stuck or the next step is unclear.
-        Only available in interactive mode (TUI).
-
-        Use when:
-        - The Tester keeps failing the same locator/element
-        - An element that should exist cannot be found
-        - Form interaction isn't working as expected
-        - You need a human decision on how to proceed
-      `,
-      inputSchema: z.object({
-        question: z.string().describe('What you need help with - be specific about what failed'),
-        context: z.string().optional().describe('Relevant context like locators tried, errors received'),
-      }),
-      execute: async ({ question, context }) => {
-        if (!isInteractive()) {
-          return {
-            success: false,
-            message: 'User input not available in non-interactive mode',
-            suggestion: 'Continue with automated recovery',
-          };
-        }
-
-        const prompt = context ? `${question}\n\nContext: ${context}\n\nYour suggestion ("skip" to continue):` : `${question}\n\nYour suggestion ("skip" to continue):`;
-
-        const userInput = await pause(prompt);
-
-        if (!userInput || userInput.toLowerCase() === 'skip') {
-          return { success: false, message: 'User skipped' };
-        }
-
-        return {
-          success: true,
-          userSuggestion: userInput,
-          instruction: 'Relay this suggestion to the Tester as the next concrete step.',
-        };
-      },
-    });
+  if (supervisor && isInteractive()) {
+    tools.askUser = createAskUserTool(stateManager);
   }
 
   withdrawVisionTools(tools);

--- a/src/command-handler.ts
+++ b/src/command-handler.ts
@@ -115,6 +115,11 @@ export class CommandHandler implements InputManager {
   }
 
   async executeCommand(input: string): Promise<void> {
+    await this.dispatch(input);
+    await this.explorBot.agentCaptain().reviewAnswers();
+  }
+
+  private async dispatch(input: string): Promise<void> {
     const trimmedInput = input.trim();
     const lowered = trimmedInput.toLowerCase();
 

--- a/src/experience-tracker.ts
+++ b/src/experience-tracker.ts
@@ -5,7 +5,7 @@ import type { ActionResult } from './action-result.js';
 import { ConfigParser } from './config.js';
 import { KnowledgeTracker } from './knowledge-tracker.js';
 import type { WebPageState } from './state-manager.js';
-import { createDebug, pluralize, tag } from './utils/logger.js';
+import { createDebug, pluralize, startAnswerCapture, tag } from './utils/logger.js';
 import { loadMarkdownFiles } from './utils/markdown-files.js';
 import { mdq } from './utils/markdown-query.js';
 import { redactSecrets } from './utils/secrets.js';
@@ -38,6 +38,7 @@ export class ExperienceTracker {
   private experienceDir: string;
   private disabled: boolean;
   private knowledgeTracker: KnowledgeTracker;
+  private answers: UserAnswer[] = [];
 
   constructor(knowledgeTracker: KnowledgeTracker, options: { disabled?: boolean } = {}) {
     const configParser = ConfigParser.getInstance();
@@ -177,6 +178,15 @@ export class ExperienceTracker {
     this.writeExperienceFile(stateHash, updatedContent, data);
 
     tag('operation').log(`Added ACTION to: ${stateHash}.md`);
+  }
+
+  rememberAnswer(state: ActionResult, question: string, answer: string): void {
+    this.answers.push({ state, question, answer });
+    startAnswerCapture();
+  }
+
+  takeAnswers(): UserAnswer[] {
+    return this.answers.splice(0, this.answers.length);
   }
 
   writeFlow(state: ActionResult, body: string, relatedUrls?: string[]): void {
@@ -506,6 +516,12 @@ export interface ExperienceFile {
   data: { url?: string; title?: string; [key: string]: any };
   content: string;
   mtime: Date;
+}
+
+export interface UserAnswer {
+  state: ActionResult;
+  question: string;
+  answer: string;
 }
 
 export interface ActionInput {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -307,15 +307,20 @@ class ReactDestination implements LogDestination {
   }
 }
 
+const ANSWER_LOG_LIMIT = 200;
+
 class CaptainDestination implements LogDestination {
   private entries: TaggedLogEntry[] = [];
   private capturing = false;
+
+  constructor(private limit = Number.POSITIVE_INFINITY) {}
 
   isEnabled(): boolean {
     return this.capturing;
   }
 
   startCapture(): void {
+    if (this.capturing) return;
     this.entries = [];
     this.capturing = true;
   }
@@ -328,6 +333,7 @@ class CaptainDestination implements LogDestination {
   }
 
   write(entry: TaggedLogEntry): void {
+    if (this.entries.length >= this.limit) return;
     this.entries.push(entry);
   }
 }
@@ -340,6 +346,7 @@ class Logger {
   private span = new SpanDestination();
   public react = new ReactDestination();
   public captain = new CaptainDestination();
+  public answers = new CaptainDestination(ANSWER_LOG_LIMIT);
   private extra: LogDestination[] = [];
   private truncateTags: string[] = ['page_html'];
 
@@ -482,6 +489,7 @@ class Logger {
     if (this.file.isEnabled()) this.file.write(entry);
     if (this.span.isEnabled()) this.span.write(entry);
     if (this.captain.isEnabled()) this.captain.write(entry);
+    if (this.answers.isEnabled()) this.answers.write(entry);
     for (const destination of this.extra) {
       if (destination.isEnabled()) destination.write(entry);
     }
@@ -564,6 +572,8 @@ export const getMethodsOfObject = (obj: any): string[] => {
 
 export const startLogCapture = () => logger.captain.startCapture();
 export const stopLogCapture = () => logger.captain.stopCapture();
+export const startAnswerCapture = () => logger.answers.startCapture();
+export const stopAnswerCapture = () => logger.answers.stopCapture();
 export const setVerboseMode = (enabled: boolean) => logger.setVerboseMode(enabled);
 export const setPreserveConsoleLogs = (enabled: boolean) => logger.setPreserveConsoleLogs(enabled);
 export const setQuietMode = (enabled: boolean) => logger.setQuietMode(enabled);

--- a/tests/unit/captain-answers.test.ts
+++ b/tests/unit/captain-answers.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import { Captain } from '../../src/ai/captain.ts';
+import { startAnswerCapture, tag } from '../../src/utils/logger.ts';
+
+function buildCaptain(reply: string, answers: Array<{ state: any; question: string; answer: string }>) {
+  const written: Array<{ url: string; body: string }> = [];
+  const prompts: string[] = [];
+
+  const experienceTracker = {
+    takeAnswers: () => answers.splice(0, answers.length),
+    getRelevantExperience: () => [],
+    writeFlow: (state: any, body: string) => written.push({ url: state.url, body }),
+  };
+
+  const provider = {
+    getModelForAgent: () => 'model',
+    chat: async (messages: any[]) => {
+      prompts.push(messages[messages.length - 1].content);
+      return { text: reply };
+    },
+  };
+
+  const captain = Object.assign(Object.create(Captain.prototype), {
+    experienceTracker,
+    explorBot: { experienceTracker: () => experienceTracker, getProvider: () => provider },
+  }) as Captain;
+
+  return { captain, written, prompts };
+}
+
+describe('Captain reviewAnswers', () => {
+  it('keeps the answer verbatim under the how-to the model judged it worth', async () => {
+    const { captain, written } = buildCaptain('sign in as the owner', [{ state: { url: '/login' }, question: 'How do I authorize?', answer: 'owner@example.org / hunter2' }]);
+
+    await captain.reviewAnswers();
+
+    expect(written).toEqual([{ url: '/login', body: '## FLOW: sign in as the owner\n\n* How do I authorize?\n* owner@example.org / hunter2\n\n---\n' }]);
+  });
+
+  it('writes nothing when the model judges the answer not worth keeping', async () => {
+    const { captain, written } = buildCaptain('', [{ state: { url: '/defects' }, question: 'Which row should I open?', answer: 'the second one' }]);
+
+    await captain.reviewAnswers();
+
+    expect(written).toEqual([]);
+  });
+
+  it('does not reach the model when no answer was collected', async () => {
+    const { captain, prompts } = buildCaptain('never asked', []);
+
+    await captain.reviewAnswers();
+
+    expect(prompts).toEqual([]);
+  });
+
+  it('reviews the answer against the log that followed it', async () => {
+    startAnswerCapture();
+    tag('step').log("I.fillField('#email', 'owner@example.org')");
+    const { captain, prompts } = buildCaptain('', [{ state: { url: '/login' }, question: 'How do I authorize?', answer: 'owner@example.org / hunter2' }]);
+
+    await captain.reviewAnswers();
+
+    expect(prompts[0]).toContain("I.fillField('#email', 'owner@example.org')");
+  });
+});

--- a/tests/unit/command-handler-answers.test.ts
+++ b/tests/unit/command-handler-answers.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'bun:test';
+import { CommandHandler } from '../../src/command-handler.ts';
+
+function buildHandler(order: string[]) {
+  const captain = {
+    setCommandExecutor: () => {},
+    reviewAnswers: async () => {
+      order.push('ask');
+    },
+    handle: async () => null,
+  };
+
+  const handler = new CommandHandler({ agentCaptain: () => captain } as any);
+  (handler as any).commands = [
+    {
+      name: 'demo',
+      aliases: [],
+      matches: (name: string) => name === 'demo',
+      execute: async () => {
+        order.push('execute');
+      },
+      printSuggestions: () => {},
+    },
+  ];
+
+  return handler;
+}
+
+describe('CommandHandler', () => {
+  it('has the Captain review collected answers once the command has finished', async () => {
+    const order: string[] = [];
+
+    await buildHandler(order).executeCommand('/demo');
+
+    expect(order).toEqual(['execute', 'ask']);
+  });
+});

--- a/tests/unit/navigator-resolve-state.test.ts
+++ b/tests/unit/navigator-resolve-state.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it } from 'bun:test';
 import { Navigator } from '../../src/ai/navigator.ts';
+import { executionController } from '../../src/execution-controller.ts';
 
 const BASE_URL = 'http://localhost:3000';
 
@@ -21,6 +22,7 @@ function createHarness(
     ariaChanged?: string;
     stopAt?: number;
     stopReason?: string;
+    askAt?: number;
     attempt?: (code: string, page: { url: string; hash: string }) => boolean;
     onWait?: (page: { url: string; hash: string }) => void;
   } = {}
@@ -29,6 +31,7 @@ function createHarness(
   const sent: string[] = [];
   const attempts: string[] = [];
   const flows: string[] = [];
+  const answers: any[] = [];
   let responseIndex = 0;
 
   const state = () => ({
@@ -65,16 +68,45 @@ function createHarness(
     invokeConversation: async (_conversation: any, tools: any) => {
       const index = responseIndex++;
       if (options.stopAt === index) await tools.stop.execute({ reason: options.stopReason ?? 'blocked' });
+      if (options.askAt === index) {
+        answers.push(await tools.askUser.execute({ question: 'Which credentials should I sign in with?' }));
+        return { response: { text: options.responses?.[index] ?? '' }, toolExecutions: [{ toolName: 'askUser' }] };
+      }
       return { response: { text: options.responses?.[index] ?? '' } };
     },
   };
   navigator.explorer = { action: () => action, capture: async () => state() };
   navigator.stateManager = action.stateManager;
 
-  return { navigator, page, sent, attempts, flows };
+  return { navigator, page, sent, attempts, flows, answers };
 }
 
 describe('Navigator resolveState', () => {
+  afterEach(() => {
+    executionController.clearInputCallback();
+  });
+
+  it('carries on with what the user answered instead of a guessed value', async () => {
+    executionController.setInputCallback(async () => 'sign in as owner@example.org / hunter2');
+
+    const harness = createHarness({
+      askAt: 0,
+      responses: ['', "```js\nI.fillField('#email', 'owner@example.org')\nI.fillField('#password', 'hunter2')\nI.click('Sign In')\n```"],
+      attempt: (code, page) => {
+        if (!code.startsWith('I.')) return false;
+        page.url = '/defects';
+        page.hash = 'defects';
+        return true;
+      },
+    });
+
+    const resolved = await harness.navigator.resolveState('reach /defects', fakeActionResult(), { expectedUrl: '/defects' });
+
+    expect(resolved).toBe(true);
+    expect(harness.answers[0].userSuggestion).toContain('owner@example.org');
+    expect(harness.attempts.join('\n')).toContain("I.fillField('#password', 'hunter2')");
+  });
+
   it('resolves when a proposed step reaches the expected URL', async () => {
     const harness = createHarness({
       responses: ["```js\nI.amOnPage('/login')\nI.click('#login-btn')\n```"],

--- a/tests/unit/navigator-resolve-state.test.ts
+++ b/tests/unit/navigator-resolve-state.test.ts
@@ -51,7 +51,7 @@ function createHarness(
       action.lastError = ok ? null : new Error('element not visible\n    at Object.<anonymous>');
       return ok;
     },
-    stateManager: { getCurrentState: state },
+    stateManager: { getCurrentState: state, getExperienceTracker: () => ({ rememberAnswer: () => {} }) },
     getActor: () => ({ wait: async () => options.onWait?.(page) }),
   };
 

--- a/tests/unit/tester-new-page-experience.test.ts
+++ b/tests/unit/tester-new-page-experience.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test';
+import { Tester } from '../../src/ai/tester.ts';
+
+function buildTester(experienceToc: string) {
+  const requestedFor: string[] = [];
+
+  const tester = Object.assign(Object.create(Tester.prototype), {
+    previousUrl: '/defects',
+    seenUiMapUrls: new Set<string>(['/login']),
+    stateManager: {
+      otherTabs: [],
+      getExperienceTracker: () => ({
+        renderExperienceTocFor: (state: any) => {
+          requestedFor.push(state.url);
+          return experienceToc;
+        },
+      }),
+    },
+    interactiveAriaWithRefs: async () => 'aria',
+  }) as any;
+
+  return { tester, requestedFor };
+}
+
+const newPage = {
+  url: '/login',
+  hash: 'login-hash',
+  title: 'Sign in',
+  ariaSnapshot: '',
+  isInsideIframe: false,
+  focusedElement: null,
+};
+
+describe('Tester context on a new page', () => {
+  it('injects the experience of the page it just landed on', async () => {
+    const { tester, requestedFor } = buildTester('<experience>\nA.1 ## FLOW: sign in as the owner\n</experience>');
+
+    const context = await tester.reinjectContextIfNeeded(3, newPage);
+
+    expect(requestedFor).toEqual(['/login']);
+    expect(context).toContain('## FLOW: sign in as the owner');
+  });
+
+  it('adds nothing when the page has no experience', async () => {
+    const { tester } = buildTester('');
+
+    const context = await tester.reinjectContextIfNeeded(3, newPage);
+
+    expect(context).toContain('CURRENT URL: /login');
+    expect(context).not.toContain('<experience>');
+  });
+});

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -89,37 +89,38 @@ describe('createAskUserTool', () => {
   });
 
   function fakeStateManager() {
-    const learned: Array<{ url: string; description: string }> = [];
+    const remembered: Array<{ url: string; question: string; answer: string }> = [];
     return {
-      learned,
-      getCurrentState: () => ({ url: '/login?info=You+must+be+logged+in', fullUrl: 'http://localhost:3000/login?info=You+must+be+logged+in' }),
+      remembered,
+      getCurrentState: () => ({ url: '/login', html: '<html></html>' }),
       getKnowledgeTracker: () => ({
-        addKnowledge: (url: string, description: string) => {
-          learned.push({ url, description });
-          return { filename: 'login.md', filePath: 'knowledge/login.md', isNewFile: true };
+        addKnowledge: () => {
+          throw new Error('askUser must not write knowledge');
         },
+      }),
+      getExperienceTracker: () => ({
+        rememberAnswer: (state: any, question: string, answer: string) => remembered.push({ url: state.url, question, answer }),
       }),
     } as any;
   }
 
-  it('writes a persistent answer to the knowledge of the current page', async () => {
+  it('remembers the answer for the page it was asked on, without writing knowledge', async () => {
     executionController.setInputCallback(async () => 'sign in as owner@example.org');
     const stateManager = fakeStateManager();
 
-    const result: any = await createAskUserTool(stateManager).execute({ question: 'How do I authorize?', persistent: true }, {} as any);
+    const result: any = await createAskUserTool(stateManager).execute({ question: 'How do I authorize?' }, {} as any);
 
-    expect(result.knowledgeFile).toBe('knowledge/login.md');
-    expect(stateManager.learned).toEqual([{ url: '/login', description: 'How do I authorize?\n\nsign in as owner@example.org' }]);
+    expect(result.userSuggestion).toBe('sign in as owner@example.org');
+    expect(stateManager.remembered).toEqual([{ url: '/login', question: 'How do I authorize?', answer: 'sign in as owner@example.org' }]);
   });
 
-  it('keeps a one-off answer out of knowledge', async () => {
-    executionController.setInputCallback(async () => 'pick the second row');
+  it('remembers nothing when the user skips', async () => {
+    executionController.setInputCallback(async () => 'skip');
     const stateManager = fakeStateManager();
 
     const result: any = await createAskUserTool(stateManager).execute({ question: 'Which row should I open?' }, {} as any);
 
-    expect(result.userSuggestion).toBe('pick the second row');
-    expect(result.knowledgeFile).toBeUndefined();
-    expect(stateManager.learned).toEqual([]);
+    expect(result.success).toBe(false);
+    expect(stateManager.remembered).toEqual([]);
   });
 });

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'bun:test';
-import { createCodeceptJSTools, createIframeTools, createLearnExperienceTool } from '../../src/ai/tools.ts';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { createAskUserTool, createCodeceptJSTools, createIframeTools, createLearnExperienceTool } from '../../src/ai/tools.ts';
+import { executionController } from '../../src/execution-controller.ts';
 
 function fakeDeps(): any {
   return {
@@ -79,5 +80,46 @@ describe('createLearnExperienceTool', () => {
     const result = await tool.execute({ fileTag: 'A', sectionIndex: 1 }, {} as any);
 
     expect(result).toBe('## FLOW: login');
+  });
+});
+
+describe('createAskUserTool', () => {
+  afterEach(() => {
+    executionController.clearInputCallback();
+  });
+
+  function fakeStateManager() {
+    const learned: Array<{ url: string; description: string }> = [];
+    return {
+      learned,
+      getCurrentState: () => ({ url: '/login?info=You+must+be+logged+in', fullUrl: 'http://localhost:3000/login?info=You+must+be+logged+in' }),
+      getKnowledgeTracker: () => ({
+        addKnowledge: (url: string, description: string) => {
+          learned.push({ url, description });
+          return { filename: 'login.md', filePath: 'knowledge/login.md', isNewFile: true };
+        },
+      }),
+    } as any;
+  }
+
+  it('writes a persistent answer to the knowledge of the current page', async () => {
+    executionController.setInputCallback(async () => 'sign in as owner@example.org');
+    const stateManager = fakeStateManager();
+
+    const result: any = await createAskUserTool(stateManager).execute({ question: 'How do I authorize?', persistent: true }, {} as any);
+
+    expect(result.knowledgeFile).toBe('knowledge/login.md');
+    expect(stateManager.learned).toEqual([{ url: '/login', description: 'How do I authorize?\n\nsign in as owner@example.org' }]);
+  });
+
+  it('keeps a one-off answer out of knowledge', async () => {
+    executionController.setInputCallback(async () => 'pick the second row');
+    const stateManager = fakeStateManager();
+
+    const result: any = await createAskUserTool(stateManager).execute({ question: 'Which row should I open?' }, {} as any);
+
+    expect(result.userSuggestion).toBe('pick the second row');
+    expect(result.knowledgeFile).toBeUndefined();
+    expect(stateManager.learned).toEqual([]);
   });
 });


### PR DESCRIPTION
## What happened

A page that redirected to a login form was treated as a form to fill. The model invented an email and a password, submitted them, and spent the rest of its attempts on a login that was never going to succeed:

```
AI Navigator resolving state at /users/sign_in?info=You+must+be+logged+in...
  > I.fillField({"role":"textbox","text":"name@email.com"}, "Enrique.Schinner@gmail.com")
  > I.fillField({"role":"textbox","text":"********"}, "RV6kXHNcheHiUIz")
  > I.click({"role":"button","text":"Sign In"})
URL verification failed: expected /projects/Testomat/defects, got /users/sign_in
```

The system prompt already said to ask the user for credentials — but `resolveState` exposed only `stop`. The instruction had no mechanism behind it, so guessing was the only move on the table.

## Changes

**Credentials have two sources, and neither is invention.** The `<credentials>` block in the Navigator prompt rules out made-up values for anything that identifies an account. A scenario that explicitly creates something, such as registering a new user, still makes up the values it needs.

**The Navigator can ask.** `askUser` is now among the tools in `resolveState`, so credentials are requested at the moment they are needed and the run carries on with the answer. Where nobody can answer, it stops and names what is missing — the failure path already points at `explorbot learn "<path>"` for recording them once.

**The loop survives an ask-only turn.** A turn that called a tool and returned no code used to end the loop, so the user's answer arrived after the Navigator had given up and was discarded (`src/ai/navigator.ts`, one line).

**An answer can become knowledge.** `askUser` takes `persistent`: a lasting fact about the page is appended to that page's knowledge file, and later runs read it instead of asking again. It is filed under the page path with the query string dropped — `normalizeUrl` only trims, and `matchesUrl` keeps a query in the compared path whenever the pattern has one, so filing under `/users/sign_in?info=You+must+be+logged+in...` would have written a file no later visit could match.

**The tool is offered only where somebody can answer it.** The Pilot's inline copy became the shared `createAskUserTool`, and both call sites gate on `isInteractive()` rather than handing the model a tool whose only possible reply was "user input not available".

## Tests

Two paths that could silently not work are covered: the ask → fill round trip in `navigator-resolve-state.test.ts` (verified to fail without the loop fix — the first version of it passed for the wrong reason, via the end-of-loop fallback), and persistence in `tools.test.ts`, where the fake state carries a query string so the path stripping stays locked in.

Unit 1026 pass / 3 fail, integration 80 pass / 0 fail. The 3 failures are pre-existing and untracked on `main` — `navigator-user-redirect.test.ts` and `execution-controller-resume.test.ts` test a `<user_redirect>` feature that does not exist in `navigator.ts`; confirmed by stashing this branch's changes.

## Known, not fixed

- Answering the same persistent question in a later run appends a second block under a `---` separator. `addKnowledge` has always appended rather than deduped.
- `askUser` answers are not passed to `registerSecret`, so a password typed at the prompt is written verbatim into the experience file when the successful login flow is recorded.
- `LearnCommand` passes `state.url` to `addKnowledge` unstripped and has the same query-string issue; left alone as out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)