### PR TITLE
Give clickRef to prima only, the one agent whose context carries refs

### DIFF
--- a/boat/prima/src/prima.ts
+++ b/boat/prima/src/prima.ts
@@ -10,7 +10,7 @@ import { z } from 'zod';
 import { ActionResult } from '../../../src/action-result.ts';
 import { getPreviousResearch } from '../../../src/ai/researcher/cache.ts';
 import { actionRule, locatorRule } from '../../../src/ai/rules.ts';
-import { createAgentTools, createCodeceptJSTools } from '../../../src/ai/tools.ts';
+import { createAgentTools, createCodeceptJSTools, createRefTools } from '../../../src/ai/tools.ts';
 import { getAliveEndpoint, launchServer, listInstances, stopServer } from '../../../src/browser-server.ts';
 import { ConfigCommand } from '../../../src/commands/config-command.ts';
 import { ConfigMissingError, ConfigParser, type ExplorbotConfig, outputPath } from '../../../src/config.ts';
@@ -148,7 +148,7 @@ export class Prima {
     const deps = { explorer: this.bot.getExplorer(), stateManager: this.bot.stateManager(), ai: provider };
     const ledger: LedgerEntry[] = instructions.map((text) => ({ text, status: 'open', proof: '' }));
     const descent = { markup: false };
-    const tools = { ...createCodeceptJSTools(deps, task), ...this.testerTools(deps), context: this.contextTool(descent), completed: this.completedTool(), blocked: this.blockedTool() };
+    const tools = { ...createCodeceptJSTools(deps, task), ...createRefTools(deps, task), ...this.testerTools(deps), context: this.contextTool(descent), completed: this.completedTool(), blocked: this.blockedTool() };
     conversation.addUserText(await this.instructionPrompt(instructions, await this.capturedResult(previousState)));
 
     const used: string[] = [];

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -4,10 +4,6 @@ export const recommendedCodeceptCommands = ['I.click', 'I.type', 'I.fillField', 
 
 const locatorPriorityRule = dedent`
   <locator_priority>
-  When the page context shows the element a ref, such as [ref=e14], there is no locator to select: click it with clickRef
-  and that ref. A ref names one exact element, so it never matches the wrong one and never has to be narrowed. Everything
-  below is for elements the context gives no ref for.
-
   Use the following priority when selecting locators:
 
   1. ARIA locators (first choice) - target browser's accessibility tree, most reliable

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -11,7 +11,7 @@ import { Observability } from '../observability.ts';
 import type { StateTransition } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Test, TestResult, type TestResultType } from '../test-plan.ts';
-import { compactAriaSnapshot, detectFocusArea } from '../utils/aria.ts';
+import { detectFocusArea } from '../utils/aria.ts';
 import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
@@ -602,7 +602,7 @@ export class Tester extends TaskAgent implements Agent {
         </page>
 
         <page_aria>
-        ${await this.interactiveAriaWithRefs(currentState)}
+        ${currentState.getInteractiveARIA()}
         </page_aria>
         ${uiMapSection}
 
@@ -639,15 +639,9 @@ export class Tester extends TaskAgent implements Agent {
       </page>
 
       <page_aria>
-      ${await this.interactiveAriaWithRefs(currentState)}
+      ${currentState.getInteractiveARIA()}
       </page_aria>
     `;
-  }
-
-  private async interactiveAriaWithRefs(state: ActionResult): Promise<string> {
-    const withRefs = await Promise.resolve(this.explorer?.withPage?.((page: any) => page.locator('body').ariaSnapshot({ mode: 'ai' }))).catch(() => null);
-    if (!withRefs) return state.getInteractiveARIA();
-    return compactAriaSnapshot(withRefs, false);
   }
 
   private finishTest(task: Test): void {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -34,10 +34,6 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
       description: dedent`
         Click an element by trying multiple CodeceptJS commands in order until one succeeds.
 
-        Use this only for elements the page context gives you no ref for. When the element shows a ref such as [ref=e14],
-        call clickRef with that ref instead — composing a locator for an element that already has a ref is wasted work,
-        and a locator can match several elements where a ref cannot.
-
         Follow <locator_priority> from system prompt for locator selection.
 
         I.click(locator) - click element matching locator
@@ -148,41 +144,6 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
           },
           action.lastError
         );
-      },
-    }),
-
-    clickRef: tool({
-      description: dedent`
-        Click an element by the ref the page context gave it, e.g. [ref=e14].
-
-        Prefer this over click() whenever the element you want carries a ref. A ref names one exact element, so it
-        cannot match several by mistake and never needs disambiguating — it is the fastest way to click.
-        Only pass a ref that appears in the page context you were given. Never invent or guess one.
-        If it reports the ref is gone, the page has been rebuilt: get fresh context and use the new ref.
-      `,
-      inputSchema: z.object({
-        ref: z.string().describe('The ref exactly as it appears in the page context, e.g. "e14"'),
-        element: z.string().describe('Role and name of the element you are clicking, for the record'),
-      }),
-      execute: async ({ ref, element }) => {
-        const activeNote = task.startNote(`Click ${element}`);
-        const previousState = ActionResult.fromState(stateManager.getCurrentState()!);
-        const action = explorer.action();
-        const named = await describeRef(explorer, ref);
-        const run = `I.usePlaywrightTo(${JSON.stringify(`click ${element}`)}, async ({ page }) => page.locator(${JSON.stringify(`aria-ref=${ref}`)}).click())`;
-
-        if (!(await action.attempt(run, `Click ${element}`))) {
-          activeNote.commit(TestResult.FAILED);
-          return failedToolResult('clickRef', `Ref ${ref} could not be clicked: ${errorText(action.lastError)}`, {
-            suggestion: 'The ref may belong to an older version of the page. Get fresh context and use the ref it gives, or fall back to click() with a locator.',
-          });
-        }
-
-        // a ref belongs to this session only, so the run is reported as the locator a later test can replay
-        const code = named ? `I.click(${JSON.stringify(named)})` : run;
-        const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, code);
-        await commitNote(activeNote, TestResult.PASSED, toolResult, action);
-        return successToolResult('clickRef', { ...toolResult, code }, action);
       },
     }),
 
@@ -387,8 +348,6 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
         Execute raw CodeceptJS code block with multiple commands.
         USE THIS TOOL for typing text into fields: I.fillField, I.type
 
-        Do not put a click on a ref-bearing element in here — clickRef with its ref is cheaper and cannot mis-target.
-
         Follow <actions> from system prompt for available commands.
         Follow <locator_priority> from system prompt for locator selection.
 
@@ -497,6 +456,45 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
           const errorMessage = errorText(error);
           return failedToolResult('form', `Form tool failed: ${errorMessage}`);
         }
+      },
+    }),
+  };
+}
+
+export function createRefTools({ explorer, stateManager }: ToolDeps, task: Task) {
+  return {
+    clickRef: tool({
+      description: dedent`
+        Click an element by the ref the page context gave it, e.g. [ref=e14].
+
+        Prefer this over click() whenever the element you want carries a ref. A ref names one exact element, so it
+        cannot match several by mistake and never needs disambiguating — it is the fastest way to click.
+        Only pass a ref that appears in the page context you were given. Never invent or guess one.
+        If it reports the ref is gone, the page has been rebuilt: get fresh context and use the new ref.
+      `,
+      inputSchema: z.object({
+        ref: z.string().describe('The ref exactly as it appears in the page context, e.g. "e14"'),
+        element: z.string().describe('Role and name of the element you are clicking, for the record'),
+      }),
+      execute: async ({ ref, element }) => {
+        const activeNote = task.startNote(`Click ${element}`);
+        const previousState = ActionResult.fromState(stateManager.getCurrentState()!);
+        const action = explorer.action();
+        const named = await describeRef(explorer, ref);
+        const run = `I.usePlaywrightTo(${JSON.stringify(`click ${element}`)}, async ({ page }) => page.locator(${JSON.stringify(`aria-ref=${ref}`)}).click())`;
+
+        if (!(await action.attempt(run, `Click ${element}`))) {
+          activeNote.commit(TestResult.FAILED);
+          return failedToolResult('clickRef', `Ref ${ref} could not be clicked: ${errorText(action.lastError)}`, {
+            suggestion: 'The ref may belong to an older version of the page. Get fresh context and use the ref it gives, or fall back to click() with a locator.',
+          });
+        }
+
+        // a ref belongs to this session only, so the run is reported as the locator a later test can replay
+        const code = named ? `I.click(${JSON.stringify(named)})` : run;
+        const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, code);
+        await commitNote(activeNote, TestResult.PASSED, toolResult, action);
+        return successToolResult('clickRef', { ...toolResult, code }, action);
       },
     }),
   };

--- a/tests/unit/tools.test.ts
+++ b/tests/unit/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { createCodeceptJSTools, createIframeTools, createLearnExperienceTool } from '../../src/ai/tools.ts';
+import { createCodeceptJSTools, createIframeTools, createLearnExperienceTool, createRefTools } from '../../src/ai/tools.ts';
 
 function fakeDeps(): any {
   return {
@@ -48,6 +48,16 @@ describe('createCodeceptJSTools click validation', () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain('Invalid commands');
+  });
+});
+
+describe('createRefTools', () => {
+  it('keeps ref tools out of the shared CodeceptJS tools', () => {
+    expect(Object.keys(createCodeceptJSTools(fakeDeps(), fakeTask()))).not.toContain('clickRef');
+  });
+
+  it('returns the clickRef tool for callers that supply refs', () => {
+    expect(Object.keys(createRefTools(fakeDeps(), fakeTask()))).toEqual(['clickRef']);
   });
 });
 


### PR DESCRIPTION
PR #110 stated the rule and the squashed commit broke it:

> A tool's schema is shared with every caller, and Tester never receives ref-bearing snapshots, so it must not be shown a ref parameter it could only fill by inventing one. The ref tools live in the boat that uses them.

What landed instead put `clickRef` in `createCodeceptJSTools` — shared with Tester, Captain, Rerunner and Driller — and added `interactiveAriaWithRefs` so the Tester began receiving ref-bearing snapshots after all. There is no `boat/prima/src/tools.ts`.

## Why it mattered in the Tester

`ACTION_TOOLS` (`src/ai/tester.ts:43`) never listed `clickRef`, so a **successful** ref-click was invisible to `shouldStopForStalledExecution` (`:458`) and `prepareInstructionsForNextStep` (`:484`) never offered it. The locator rule told the model to prefer `clickRef` while the loop scored using it as no progress.

Seen in a live session: after a modal was dismissed, the Tester filled the title via `clickRef` + `type`, that worked, and the stall detector ended the test three iterations later having counted none of it. The recorded step was `I.usePlaywrightTo("click Title textbox", fn())` — a Playwright closure in what is meant to be replayable CodeceptJS.

## Changes

- `src/ai/tools.ts` — `clickRef` extracted into `createRefTools({explorer, stateManager}, task)`, mirroring the `createIframeTools` precedent in the same file. `click()` and `form()` no longer name it: a shared description must not reference a tool the caller does not have.
- `src/ai/rules.ts` — ref paragraph out of `locatorPriorityRule`, which is shared by Researcher, Tester, Navigator, Captain, Rerunner, Driller and prima. Prima states it in its own `<targets>` / `<targets_first>`.
- `src/ai/tester.ts` — both call sites back to `currentState.getInteractiveARIA()`, method deleted. Exact revert of the #110 hunk.
- `boat/prima/src/prima.ts:151` — spreads `createRefTools(deps, task)`.
- `tests/unit/tools.test.ts` — guards the split so it cannot drift back.

## Invariant

Refs in context if and only if a ref tool is present.

| Agent | refs | clickRef |
| --- | --- | --- |
| prima | `refAriaSnapshot()` (`prima.ts:918`) | yes (`prima.ts:151`) |
| Tester / Captain / Rerunner / Navigator | no | no |
| Driller | calls `annotatePageElements` but discards it (`driller.ts:188-198`) | no |

`tests/integration/prima-do.test.ts:140` already asserted prima keeps `clickRef`, and `:108-109` drive real calls — still passing.

## Verification

`bun test tests/unit/` 1024 pass · `bun test tests/integration/` 81 pass · lint clean · format clean.

Branched off `main` rather than the current working branch so it does not stack behind #129. CHANGELOG deliberately untouched.

## Not in scope

`describeRef` (`src/ai/tools.ts`) still cannot name an empty text input — no `aria-label`, no `innerText`, empty `value` — so it returns `null` and prima records the unreplayable `usePlaywrightTo(..., fn())` instead of `I.click(...)`. Falling back to `placeholder` and the associated `<label for>` would fix the whole class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
