### PR TITLE
Require playwright-core 1.62+, where asLocator now lives

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "parse5": "^8.0.0",
         "pixelmatch": "^7.2.0",
         "playwright": "^1.62",
+        "playwright-core": "^1.62",
         "pngjs": "^7.0.0",
         "react": "^19.1.1",
         "sambanova-ai-provider": "^1.2.2",
@@ -2155,7 +2156,7 @@
 
     "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.54.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-Nbjs2zjj0htNhzgiy5wu+3w09YetDx5pkrpI/kZotDlDUaYk0HVA5xrBVPdow4SAUIlhgKcJeJg4GRKW6xHusA=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
@@ -3208,8 +3209,6 @@
     "parse5-parser-stream/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "playwright/playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "parse5": "^8.0.0",
     "pixelmatch": "^7.2.0",
     "playwright": "^1.62",
+    "playwright-core": "^1.62",
     "pngjs": "^7.0.0",
     "react": "^19.1.1",
     "sambanova-ai-provider": "^1.2.2",

--- a/src/playwright-recorder.ts
+++ b/src/playwright-recorder.ts
@@ -9,7 +9,7 @@ const RECORDABLE: Record<string, Set<string>> = {
   Page: new Set(['goBack', 'goForward', 'reload', 'keyboardPress', 'keyboardType', 'keyboardDown', 'keyboardUp', 'keyboardInsertText', 'mouseClick', 'mouseDblclick', 'mouseMove', 'mouseDown', 'mouseUp', 'mouseWheel']),
 };
 
-const PLAYWRIGHT_INCOMPATIBLE = "Playwright output is not compatible with this Playwright version (playwright-core/lib/utils does not expose asLocator). Use output.framework: 'codeceptjs' instead, or pin Playwright to a version shipping lib/utils/isomorphic/locatorGenerators.js.";
+const PLAYWRIGHT_INCOMPATIBLE = "Playwright output requires playwright-core 1.62 or newer (lib/coreBundle does not expose iso.asLocator). Use output.framework: 'codeceptjs' instead.";
 
 let cachedAsLocator: ((lang: string, selector: string) => string) | null = null;
 let asLocatorLoadAttempted = false;
@@ -20,16 +20,11 @@ function getAsLocator(): (lang: string, selector: string) => string {
   if (asLocatorLoadAttempted) throw new Error(PLAYWRIGHT_INCOMPATIBLE);
 
   asLocatorLoadAttempted = true;
-  try {
-    const mod = nodeRequire('playwright-core/lib/utils');
-    if (typeof (mod as any)?.asLocator === 'function') {
-      cachedAsLocator = (mod as any).asLocator;
-      return cachedAsLocator!;
-    }
-  } catch {
-    // Module not exported or not found
-  }
-  throw new Error(PLAYWRIGHT_INCOMPATIBLE);
+  const asLocator = nodeRequire('playwright-core/lib/coreBundle')?.iso?.asLocator;
+  if (typeof asLocator !== 'function') throw new Error(PLAYWRIGHT_INCOMPATIBLE);
+
+  cachedAsLocator = asLocator;
+  return cachedAsLocator;
 }
 
 export interface TraceCall {


### PR DESCRIPTION
`main`, #129 and #130 all fail the same twelve `renderCall` tests. None of them caused it.

```
error: Playwright output is not compatible with this Playwright version
(playwright-core/lib/utils does not expose asLocator)
  at getAsLocator (src/playwright-recorder.ts:20)
```

## Cause

Playwright 1.62 dropped `lib/utils` from `playwright-core` and moved the isomorphic helpers into `lib/coreBundle`, which the package publicly exports:

```json
"exports": { "./lib/coreBundle": "./lib/coreBundle.js", ... }
```

`asLocator` now lives there under `iso`. The recorder still required `playwright-core/lib/utils`.

`package.json` asked for `playwright ^1.62` but never for `playwright-core`, so the copy at the root of the tree was whatever satisfied `@axe-core/playwright`'s `playwright-core >= 1.0.0` peer. A fresh install dedupes it to 1.62.1 and CI goes red; a tree still holding an older copy resolves `lib/utils` and passes. That is the whole CI-vs-local split, and it made the break invisible during development.

## Change

- `package.json` — `playwright-core: ^1.62` as a direct dependency, so the root copy is the one the recorder is written against.
- `src/playwright-recorder.ts` — `getAsLocator()` reads `iso.asLocator` from `lib/coreBundle`. One entry point, no version ladder.

```ts
const asLocator = nodeRequire('playwright-core/lib/coreBundle')?.iso?.asLocator;
```

Explorbot supports Playwright 1.62+.

## Verification

With `playwright-core@1.62.1` now at the root, the local tree is the same one CI builds — no simulation involved:

`bun test tests/unit/` 1022 pass · `bun test tests/integration/` 80 pass, 1 skip (live-session test) · lint clean · format clean · `build:npm` ok.

The twelve `renderCall` tests are the regression guard — they fail the moment `asLocator` cannot be reached.

Merging this turns #129 and #130 green too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
