### PR TITLE
Compact the error a failed command reports, instead of Playwright's whole retry log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-21
+
+### Changes
+
+- A browser command that fails now reports a short error instead of Playwright's full retry log.
+  Click, hover, key press, form and back/reset failures used to carry every wait and retry line,
+  the same reason repeated once per attempt, and terminal color codes — around 850 characters for
+  one disabled button. What is left is the element the locator resolved to and the reason it could
+  not be acted on, so the AI reads the blocker instead of scrolling past bookkeeping.
+
 ## 2026-08-18
 
 ### Changes

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -15,6 +15,7 @@ import { compactAriaSnapshot, detectFocusArea } from '../utils/aria.ts';
 import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
+import { compactErrorMessage } from '../utils/strings.ts';
 import type { Agent, AgentDeps } from './agent.ts';
 import type { Captain } from './captain.ts';
 import type { Conversation } from './conversation.ts';
@@ -947,7 +948,7 @@ export class Tester extends TaskAgent implements Agent {
           };
 
           if (resetAction.lastError) {
-            result.error = resetAction.lastError.toString();
+            result.error = compactErrorMessage(resetAction.lastError);
           }
 
           return result;

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -8,6 +8,7 @@ import { type Task, TestResult } from '../test-plan.js';
 import { LARGE_ARIA_CHANGE_THRESHOLD } from '../utils/aria.ts';
 import { isFatalBrowserError } from '../utils/browser-errors.ts';
 import { createDebug, tag } from '../utils/logger.js';
+import { compactErrorMessage } from '../utils/strings.ts';
 import { pause } from '../utils/loop.js';
 import { WebElement } from '../utils/web-element.ts';
 import type { ToolDeps } from './agent.ts';
@@ -98,7 +99,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
           const success = await action.attempt(command, explanation);
 
           const attempt: { command: string; success: boolean; error?: string } = { command, success };
-          if (action.lastError) attempt.error = action.lastError.toString();
+          if (action.lastError) attempt.error = errorText(action.lastError);
           attempts.push(attempt);
 
           if (success) {
@@ -124,7 +125,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
 
           for (const retryCmd of retryCommands) {
             if (!(await action.attempt(retryCmd, explanation))) {
-              attempts.push({ command: retryCmd, success: false, error: action.lastError?.toString() });
+              attempts.push({ command: retryCmd, success: false, error: errorText(action.lastError) });
               continue;
             }
             const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, retryCmd);
@@ -237,7 +238,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
         for (const command of commands) {
           const success = await action.attempt(command, explanation);
           const attempt: { command: string; success: boolean; error?: string } = { command, success };
-          if (action.lastError) attempt.error = action.lastError.toString();
+          if (action.lastError) attempt.error = errorText(action.lastError);
           attempts.push(attempt);
 
           if (!success) continue;
@@ -320,7 +321,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
               );
             }
 
-            const errorMsg = `pressKey fallback to type() failed: ${action.lastError?.toString()}`;
+            const errorMsg = `pressKey fallback to type() failed: ${errorText(action.lastError)}`;
             await commitNote(activeNote, TestResult.FAILED, toolResult, action);
             return failedToolResult('pressKey', errorMsg, {
               ...toolResult,
@@ -366,7 +367,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
             );
           }
 
-          const errorMsg = `pressKey() failed: ${action.lastError?.toString()}`;
+          const errorMsg = `pressKey() failed: ${errorText(action.lastError)}`;
           await commitNote(activeNote, TestResult.FAILED, toolResult, action);
           return failedToolResult('pressKey', errorMsg, {
             ...toolResult,
@@ -448,7 +449,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
           const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, formLocator);
 
           if (action.lastError) {
-            const message = action.lastError ? String(action.lastError) : 'Unknown error';
+            const message = errorText(action.lastError);
             await commitNote(activeNote, TestResult.FAILED, toolResult, action);
 
             let formSuggestion = 'Look into error message and identify which commands passed and which failed. Continue execution using step-by-step approach using click() and form() tools.';
@@ -952,7 +953,7 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
         }
 
         const failData: Record<string, any> = { suggestion: 'Try reset() to return to the starting page.' };
-        if (action.lastError) failData.error = action.lastError.toString();
+        if (action.lastError) failData.error = errorText(action.lastError);
         return failedToolResult('back', `Failed to navigate back to ${targetUrl}`, failData);
       },
     }),
@@ -1154,7 +1155,7 @@ function transformContainsCommand(command: string): string {
 }
 
 function errorText(error: unknown): string {
-  if (error instanceof Error) return error.toString();
+  if (error instanceof Error) return compactErrorMessage(error);
   return 'Unknown error occurred';
 }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import stripAnsi from 'strip-ansi';
 
 export function truncateJson(input: any): string {
   if (!input) return '';
@@ -40,3 +41,38 @@ export function safeFilename(name: string, ext = '', maxBytes = 240): string {
   }
   return truncated + suffix + ext;
 }
+
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 3)}...`;
+}
+
+const MAX_COMPACT_ERROR = 400;
+
+export function compactErrorMessage(error: unknown): string {
+  let text = stripAnsi(String(error));
+  for (const strip of STRIP_STRATEGIES) {
+    text = strip(text);
+  }
+  return truncate(text, MAX_COMPACT_ERROR);
+}
+
+function stripCallLog(text: string): string {
+  const CALL_LOG = 'Call log:';
+  const NOISE = ['attempting', 'retrying', 'waiting'];
+
+  const [headline, ...log] = text.split(CALL_LOG);
+  if (!log.length) return text;
+
+  const lines = new Set<string>();
+  for (const line of log.join(CALL_LOG).split('\n')) {
+    const cleaned = normalizeInlineText(line);
+    if (!cleaned) continue;
+    if (NOISE.some((noise) => cleaned.includes(noise))) continue;
+    lines.add(cleaned);
+  }
+
+  return [headline.trim(), ...lines].join(' ');
+}
+
+const STRIP_STRATEGIES = [stripCallLog];


### PR DESCRIPTION
A failed browser command handed the model Playwright's entire call log — ~850 characters for one disabled Save button: every wait and retry line, `element is not enabled` once per attempt, a class attribute broken across six lines, and ANSI color codes around all of it.

**Before**

```
TimeoutError: click: Timeout 3000ms exceeded.
Call log:
  - waiting for getByRole('button', { name: 'Save' }).first()
  - locator resolved to <button disabled type="button" class="secondary-btn
      btn-text-and-icon

      btn-lg

      disabled">…</button>
  - attempting click action
    2 × waiting for element to be visible, enabled and stable
      - element is not enabled
    - retrying click action
    - waiting 20ms
    … 8 more lines
```

**After** (192 chars)

```
TimeoutError: click: Timeout 3000ms exceeded. - locator resolved to <button disabled type="button" class="secondary-btn btn-text-and-icon btn-lg disabled">…</button> - element is not enabled
```

## The implementation

```js
export function compactErrorMessage(error: unknown): string {
  let text = stripAnsi(String(error));
  for (const strip of STRIP_STRATEGIES) {
    text = strip(text);
  }
  return truncate(text, MAX_COMPACT_ERROR);
}
```

In `src/utils/strings.ts`, next to the `normalizeInlineText` and `truncate` it reuses. It takes anything and stringifies inside, so no call site wraps its error. No regex, no new file, no new module.

`stripCallLog` is the only strategy today: split on the marker, drop `waiting` / `retrying` / `attempting` lines, dedupe the rest with a `Set`, join. Another error shape — a network failure, a stack trace — is a second function in `STRIP_STRATEGIES`, and both the marker and its noise list stay local to the strategy that uses them.

The locator line goes with the other `waiting` lines because the tool result already carries `command` and `locator`; repeating it costs tokens and tells the model nothing new. Errors with no `Call log:` section (`MultipleElementsFound` and its element listing) come back unchanged.

The seven raw `lastError.toString()` / `String(lastError)` sites in click, hover, pressKey, form, back and reset now route through `errorText()`, so that stringification exists in one place.

`clickFailureSuggestion()` reads this text to tell the model whether the element was disabled, covered, hidden or absent. All four markers sit on lines the filter keeps.

## Natural next caller

`navigator.ts:476` trims a failed attempt inline — first non-`at ` line, capped at 220. That is a stack-strip strategy waiting to move into this list, but it changes navigator's output, so it is not in this PR.

## Tests

`bun test tests/integration/` 81 pass. Unit suite passes except the 12 `renderCall` failures from the `asLocator` lookup on `main`, which #131 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)