### PR TITLE
Improve tool recovery, API feedback, and cache provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 2026-08-21
+
+### Changes
+
+- AI models that emit channel markers in tool names (e.g. `click<|channel|>commentary`, common with
+  gpt-oss and gemma) no longer waste a turn: the provider now repairs the name to the real tool and
+  executes it, instead of rejecting the call and telling the AI to retry. In a 24h CI sample this
+  rejection burned 93 tool calls across 34 test traces.
+- [Fisherman] A captured request rejected by the API is no longer presented as a valid request
+  example. OpenAPI definitions take precedence when available, and failed responses now identify
+  whether validation, authorization, routing, conflict, temporary, or server handling is needed.
+- [Researcher/Planner] Similar HTML is reused only after URL-aware matching: new fingerprints
+  store their source URL, candidates from other page families are filtered before the best match is
+  selected, and Planner applies the same check before reusing a state hash. Legacy fingerprints
+  without URL metadata remain readable for backward compatibility.
+- Configuration: absolute configured directories are now respected as-is instead of being joined
+  onto the project root, which produced doubled, unusable paths on Windows.
+
 ## 2026-08-18
 
 ### Changes

--- a/src/ai/fisherman-tools.ts
+++ b/src/ai/fisherman-tools.ts
@@ -29,6 +29,28 @@ export function createFishermanTools(apiClient: ApiClient, requestStore: Request
 
         const captured = requestStore.findCapturedRequest(method, path);
         if (captured) {
+          if (captured.status >= 400) {
+            const rejectedCapture = {
+              status: captured.status,
+              requestBody: captured.requestBody || 'no body',
+            };
+            if (opts.spec) {
+              try {
+                const definition = extractEndpointDefinition(opts.spec, path, opts.baseEndpoint);
+                return { source: 'spec', method, path, definition, rejectedCapture };
+              } catch {
+                return { source: 'captured', method, path, usable: false, rejectedRequestBody: captured.requestBody || 'no body', status: captured.status };
+              }
+            }
+            return {
+              source: 'captured',
+              method: captured.method,
+              path: captured.path,
+              status: captured.status,
+              usable: false,
+              rejectedRequestBody: captured.requestBody || 'no body',
+            };
+          }
           return {
             source: 'captured',
             method: captured.method,
@@ -87,6 +109,7 @@ export function createFishermanTools(apiClient: ApiClient, requestStore: Request
             success: false,
             status: reqResult.status,
             statusText: reqResult.statusText,
+            category: responseCategory(reqResult.status),
             errorPreview: reqResult.rawResponseBody.substring(0, 300),
           };
         }
@@ -149,6 +172,16 @@ export function createFishermanTools(apiClient: ApiClient, requestStore: Request
   return { tools, getResult, isFinished };
 }
 
+function responseCategory(status: number): ResponseCategory {
+  if (status === 400 || status === 422) return 'validation';
+  if (status === 401 || status === 403) return 'authorization';
+  if (status === 404) return 'not_found';
+  if (status === 409) return 'conflict';
+  if (status === 408 || status === 425 || status === 429) return 'temporary';
+  if (status >= 500) return 'server';
+  return 'client';
+}
+
 function extractKeyFields(body: any, result: Record<string, any> = {}, depth = 0): Record<string, any> {
   if (!body || typeof body !== 'object' || depth > 5) return result;
 
@@ -179,3 +212,5 @@ export interface FishermanResult {
   created: Array<{ type: string; id?: string | number; title?: string }>;
   failed: Array<{ type: string; reason: string }>;
 }
+
+type ResponseCategory = 'validation' | 'authorization' | 'not_found' | 'conflict' | 'temporary' | 'server' | 'client';

--- a/src/ai/fisherman.ts
+++ b/src/ai/fisherman.ts
@@ -208,7 +208,8 @@ export class Fisherman implements Agent {
       RULES:
       - Always call getEndpointSpec before your first request to an unfamiliar endpoint
       - Chain requests logically — create parent resources before children
-      - If a request fails, try once more with adjusted data before reporting failure
+      - Use the response category and error text to decide what failed: validation requires corrected data, authorization requires valid access, not_found requires a valid path or parent, and conflict requires resolving the conflicting state
+      - Retry temporary or server failures once. Retry other failures only when the specification or error text gives a concrete correction
       - Use realistic but unique data for each item (vary names, titles)
 
       ${dataProtectionRules}

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -149,7 +149,7 @@ export class Planner extends PlannerBase implements Agent {
 
       const actionResult = ActionResult.fromState(state);
       const combinedHtml = await actionResult.combinedHtml();
-      const similarHash = await findSimilarStateHash(combinedHtml);
+      const similarHash = await findSimilarStateHash(combinedHtml, state.url);
       if (similarHash) {
         const planned = getPlannedByStateHash(similarHash);
         if (planned) {

--- a/src/ai/planner/subpages.ts
+++ b/src/ai/planner/subpages.ts
@@ -4,7 +4,7 @@ import { normalizeUrl } from '../../state-manager.ts';
 import type { StateManager } from '../../state-manager.ts';
 import type { Plan } from '../../test-plan.ts';
 import { tag } from '../../utils/logger.ts';
-import { isDynamicSegment } from '../../utils/url-matcher.ts';
+import { isSamePageFamily } from '../../utils/url-matcher.ts';
 import type { Provider } from '../provider.ts';
 import type { Constructor } from '../researcher/mixin.ts';
 
@@ -39,18 +39,7 @@ function buildKey(url: string, feature?: string): string {
 }
 
 export function isTemplateMatch(urlA: string, urlB: string): boolean {
-  const partsA = normalizeUrl(urlA).split('/');
-  const partsB = normalizeUrl(urlB).split('/');
-  if (partsA.length !== partsB.length) return false;
-
-  let diffCount = 0;
-  for (let i = 0; i < partsA.length; i++) {
-    if (partsA[i] === partsB[i]) continue;
-    diffCount++;
-    if (diffCount > 1) return false;
-    if (!isDynamicSegment(partsA[i]) && !isDynamicSegment(partsB[i])) return false;
-  }
-  return diffCount === 1;
+  return isSamePageFamily(urlA, urlB);
 }
 
 export function getPlannedByStateHash(hash: string): PlanRecord | null {

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -365,7 +365,7 @@ export class Provider {
     const extraStop = options.stopWhen;
     const stopConditions: any[] = [isStepCount(maxRoundtrips)];
     if (extraStop) stopConditions.push(extraStop);
-    const config = this.buildGenerateConfig({ tools, maxOutputTokens: 16384, toolChoice: 'auto' }, { stopWhen: stopConditions, model }, options);
+    const config = this.buildGenerateConfig({ tools, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairChannelMarker }, { stopWhen: stopConditions, model }, options);
     try {
       const response = await withRetry(async () => {
         const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
@@ -625,6 +625,19 @@ export class Provider {
   hasVision(): boolean {
     return this.config.visionModel !== undefined;
   }
+}
+
+/**
+ * Some reasoning models append an internal channel marker to tool names.
+ * Strip it only when the remaining name matches an available tool.
+ */
+function repairChannelMarker({ toolCall, tools }: { toolCall: any; tools: any }): any | null {
+  const markerIndex = toolCall.toolName.indexOf('<|channel|>');
+  if (markerIndex <= 0) return null;
+  const toolName = toolCall.toolName.slice(0, markerIndex);
+  if (!tools[toolName]) return null;
+  tag('warning').log(`Repaired tool name '${toolCall.toolName}' → '${toolName}'`);
+  return { ...toolCall, toolName };
 }
 
 export { AiError, Provider as AIProvider };

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -365,7 +365,7 @@ export class Provider {
     const extraStop = options.stopWhen;
     const stopConditions: any[] = [isStepCount(maxRoundtrips)];
     if (extraStop) stopConditions.push(extraStop);
-    const config = this.buildGenerateConfig({ tools, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairChannelMarker }, { stopWhen: stopConditions, model }, options);
+    const config = this.buildGenerateConfig({ tools, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairToolCall }, { stopWhen: stopConditions, model }, options);
     try {
       const response = await withRetry(async () => {
         const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
@@ -627,11 +627,12 @@ export class Provider {
   }
 }
 
-/**
- * Some reasoning models append an internal channel marker to tool names.
- * Strip it only when the remaining name matches an available tool.
- */
-function repairChannelMarker({ toolCall, tools }: { toolCall: any; tools: any }): any | null {
+function repairToolCall(options: ToolCallRepairOptions): any | null {
+  if (options.toolCall.toolName.includes('<|channel|>')) return repairChannelMarker(options);
+  return null;
+}
+
+function repairChannelMarker({ toolCall, tools }: ToolCallRepairOptions): any | null {
   const markerIndex = toolCall.toolName.indexOf('<|channel|>');
   if (markerIndex <= 0) return null;
   const toolName = toolCall.toolName.slice(0, markerIndex);
@@ -641,3 +642,5 @@ function repairChannelMarker({ toolCall, tools }: { toolCall: any; tools: any })
 }
 
 export { AiError, Provider as AIProvider };
+
+type ToolCallRepairOptions = { toolCall: any; tools: any };

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -139,10 +139,10 @@ export class Researcher extends ResearcherBase implements Agent {
       const combinedHtml = await this.actionResult!.combinedHtml();
 
       if (!deep && !force) {
-        const similar = await findSimilarResearch(combinedHtml);
+        const similar = await findSimilarResearch(combinedHtml, state.url);
         if (similar) {
           tag('operation').log('Similar research found, reusing cached result');
-          if (stateHash) saveResearch(stateHash, similar, combinedHtml);
+          if (stateHash) saveResearch(stateHash, similar, combinedHtml, state.url);
           tag('multiline').log(formatResearchSummary(similar));
           tag('success').log('Research complete (reused)');
           await this.hooksRunner.runAfterHook('researcher', state.url);
@@ -286,7 +286,7 @@ export class Researcher extends ResearcherBase implements Agent {
 
       let researchFile: string | null = null;
       if (stateHash) {
-        researchFile = saveResearch(stateHash, result.text, combinedHtml);
+        researchFile = saveResearch(stateHash, result.text, combinedHtml, state.url);
       }
 
       const summaryText = mdq(result.text).query('section2(/^summary/)').query('paragraph[0]').text().trim();

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -97,6 +97,7 @@ export class Researcher extends ResearcherBase implements Agent {
     let retriesLeft = opts._retriesLeft ?? maxRetries;
     this.actionResult = ActionResult.fromState(state);
     const stateHash = state.hash || this.actionResult.getStateHash();
+    const researchState = { ...state, hash: stateHash };
 
     if (!force && stateHash) {
       const cached = getCachedResearch(stateHash);
@@ -142,7 +143,7 @@ export class Researcher extends ResearcherBase implements Agent {
         const similar = await findSimilarResearch(combinedHtml, state.url);
         if (similar) {
           tag('operation').log('Similar research found, reusing cached result');
-          if (stateHash) saveResearch(stateHash, similar, combinedHtml, state.url);
+          if (stateHash) saveResearch(researchState, similar, combinedHtml);
           tag('multiline').log(formatResearchSummary(similar));
           tag('success').log('Research complete (reused)');
           await this.hooksRunner.runAfterHook('researcher', state.url);
@@ -286,7 +287,7 @@ export class Researcher extends ResearcherBase implements Agent {
 
       let researchFile: string | null = null;
       if (stateHash) {
-        researchFile = saveResearch(stateHash, result.text, combinedHtml, state.url);
+        researchFile = saveResearch(researchState, result.text, combinedHtml);
       }
 
       const summaryText = mdq(result.text).query('section2(/^summary/)').query('paragraph[0]').text().trim();

--- a/src/ai/researcher/cache.ts
+++ b/src/ai/researcher/cache.ts
@@ -60,7 +60,8 @@ export function getPreviousResearch(hash: string): string {
   return readFileSync(researchFile, 'utf8');
 }
 
-export function saveResearch(hash: string, text: string, combinedHtml?: string, url?: string): string {
+export function saveResearch(state: ResearchState, text: string, combinedHtml?: string): string {
+  const { hash, url } = state;
   const researchDir = outputPath('research');
   const researchFile = join(researchDir, `${hash}.md`);
   if (!existsSync(researchDir)) mkdirSync(researchDir, { recursive: true });
@@ -130,3 +131,4 @@ export async function findSimilarStateHash(combinedHtml: string, url?: string): 
 
 type FingerprintRecord = { entries: string[]; url?: string };
 type FingerprintMatch = { hash: string; similarity: number; url?: string };
+type ResearchState = { hash: string; url?: string };

--- a/src/ai/researcher/cache.ts
+++ b/src/ai/researcher/cache.ts
@@ -60,7 +60,7 @@ export function getPreviousResearch(hash: string): string {
   return readFileSync(researchFile, 'utf8');
 }
 
-export function saveResearch(hash: string, text: string, combinedHtml?: string): string {
+export function saveResearch(hash: string, text: string, combinedHtml?: string, url?: string): string {
   const researchDir = outputPath('research');
   const researchFile = join(researchDir, `${hash}.md`);
   if (!existsSync(researchDir)) mkdirSync(researchDir, { recursive: true });
@@ -74,14 +74,16 @@ export function saveResearch(hash: string, text: string, combinedHtml?: string):
     if (!existsSync(statesDir)) mkdirSync(statesDir, { recursive: true });
     const fingerprint = computeHtmlFingerprint(combinedHtml);
     const fingerprintFile = join(statesDir, `${hash}.fingerprint`);
-    writeFileSync(fingerprintFile, fingerprint.join('\n'));
+    const record: FingerprintRecord = { entries: fingerprint };
+    if (url) record.url = url;
+    writeFileSync(fingerprintFile, JSON.stringify(record));
     debugLog(`Fingerprint saved to ${fingerprintFile}`);
   }
 
   return researchFile;
 }
 
-function findSimilarMatch(combinedHtml: string): Promise<{ hash: string; similarity: number } | null> {
+function findSimilarMatch(combinedHtml: string, url?: string): Promise<FingerprintMatch | null> {
   const statesDir = getStatesDir();
   if (!existsSync(statesDir)) return Promise.resolve(null);
 
@@ -93,7 +95,7 @@ function findSimilarMatch(combinedHtml: string): Promise<{ hash: string; similar
       resolve(null);
     }, FINGERPRINT_WORKER_TIMEOUT_MS);
 
-    worker.on('message', (data: { matchHash: string | null; similarity: number }) => {
+    worker.on('message', (data: { matchHash: string | null; similarity: number; url?: string }) => {
       clearTimeout(timeout);
       const { matchHash, similarity } = data;
       if (!matchHash) {
@@ -102,7 +104,7 @@ function findSimilarMatch(combinedHtml: string): Promise<{ hash: string; similar
       }
 
       debugLog(`Similar fingerprint found: ${matchHash} (${similarity}% similar)`);
-      resolve({ hash: matchHash, similarity });
+      resolve({ hash: matchHash, similarity, url: data.url });
     });
 
     worker.postMessage({
@@ -110,17 +112,21 @@ function findSimilarMatch(combinedHtml: string): Promise<{ hash: string; similar
       statesDir,
       maxAgeMs: FINGERPRINT_MAX_AGE_MS,
       threshold: SIMILARITY_THRESHOLD,
+      url,
     });
   });
 }
 
-export async function findSimilarResearch(combinedHtml: string): Promise<string | null> {
-  const match = await findSimilarMatch(combinedHtml);
+export async function findSimilarResearch(combinedHtml: string, url?: string): Promise<string | null> {
+  const match = await findSimilarMatch(combinedHtml, url);
   if (!match) return null;
   return getCachedResearch(match.hash) || null;
 }
 
-export async function findSimilarStateHash(combinedHtml: string): Promise<string | null> {
-  const match = await findSimilarMatch(combinedHtml);
+export async function findSimilarStateHash(combinedHtml: string, url?: string): Promise<string | null> {
+  const match = await findSimilarMatch(combinedHtml, url);
   return match?.hash || null;
 }
+
+type FingerprintRecord = { entries: string[]; url?: string };
+type FingerprintMatch = { hash: string; similarity: number; url?: string };

--- a/src/ai/researcher/deep-analysis.ts
+++ b/src/ai/researcher/deep-analysis.ts
@@ -128,7 +128,7 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
         updated = `${cached.trimEnd()}\n\n# Extended Research\n\n${sectionMarkdown}\n`;
       }
 
-      saveResearch(pageStateHash, updated);
+      saveResearch({ hash: pageStateHash }, updated);
       tag('substep').log(`Overlay research appended: ${focusArea.name}`);
       return sectionMarkdown;
     }

--- a/src/ai/researcher/fingerprint-worker.ts
+++ b/src/ai/researcher/fingerprint-worker.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 import { parentPort } from 'node:worker_threads';
 import { computeHtmlFingerprint } from '../../utils/html-diff.ts';
+import { isSamePageFamily } from '../../utils/url-matcher.ts';
 
 function diceSimilarity(a: Set<string>, b: Set<string>): number {
   let intersection = 0;
@@ -13,8 +14,8 @@ function diceSimilarity(a: Set<string>, b: Set<string>): number {
   return Math.round(((2 * intersection) / total) * 100);
 }
 
-parentPort!.on('message', (data: { html: string; statesDir: string; maxAgeMs: number; threshold: number }) => {
-  const { html, statesDir, maxAgeMs, threshold } = data;
+parentPort!.on('message', (data: FingerprintRequest) => {
+  const { html, statesDir, maxAgeMs, threshold, url } = data;
 
   if (!existsSync(statesDir)) {
     parentPort!.postMessage({ matchHash: null, similarity: 0 });
@@ -32,22 +33,39 @@ parentPort!.on('message', (data: { html: string; statesDir: string; maxAgeMs: nu
 
   let bestHash: string | null = null;
   let bestSimilarity = 0;
+  let bestUrl: string | undefined;
 
   for (const file of files) {
     const filePath = join(statesDir, file);
     const mtime = statSync(filePath).mtimeMs;
     if (now - mtime > maxAgeMs) continue;
 
-    const lines = readFileSync(filePath, 'utf8').split('\n').filter(Boolean);
-    const storedFingerprint = new Set(lines);
+    const record = readFingerprint(filePath);
+    if (url && record.url && !isSamePageFamily(url, record.url)) continue;
+    const storedFingerprint = new Set(record.entries);
     const similarity = diceSimilarity(currentFingerprint, storedFingerprint);
 
     if (similarity > bestSimilarity) {
       bestSimilarity = similarity;
       bestHash = file.replace('.fingerprint', '');
+      bestUrl = record.url;
     }
   }
 
   const matched = bestSimilarity >= threshold;
-  parentPort!.postMessage({ matchHash: matched ? bestHash : null, similarity: bestSimilarity });
+  parentPort!.postMessage({ matchHash: matched ? bestHash : null, similarity: bestSimilarity, url: matched ? bestUrl : undefined });
 });
+
+function readFingerprint(filePath: string): FingerprintRecord {
+  const content = readFileSync(filePath, 'utf8');
+  try {
+    const record = JSON.parse(content);
+    if (Array.isArray(record.entries)) return record;
+  } catch {
+    return { entries: content.split('\n').filter(Boolean) };
+  }
+  return { entries: content.split('\n').filter(Boolean) };
+}
+
+type FingerprintRecord = { entries: string[]; url?: string };
+type FingerprintRequest = { html: string; statesDir: string; maxAgeMs: number; threshold: number; url?: string };

--- a/src/config.ts
+++ b/src/config.ts
@@ -433,7 +433,7 @@ export class ConfigParser {
   public getOutputDir(): string {
     const config = this.getConfig();
     if (!this.configPath) throw new Error('Config path not found');
-    return path.join(this.getProjectRoot(), config.dirs?.output || 'output');
+    return this.resolveProjectDir(config.dirs?.output || 'output');
   }
 
   public getProjectRoot(): string {
@@ -444,6 +444,7 @@ export class ConfigParser {
   }
 
   public resolveProjectDir(relativeDir: string): string {
+    if (path.isAbsolute(relativeDir)) return relativeDir;
     if (!this.configPath) return relativeDir;
     return path.join(this.getProjectRoot(), relativeDir);
   }

--- a/src/utils/url-matcher.ts
+++ b/src/utils/url-matcher.ts
@@ -28,6 +28,21 @@ export function hasDynamicUrlSegment(url: string): boolean {
   return url.split('/').some((seg) => seg.length > 0 && isDynamicSegment(seg));
 }
 
+export function isSamePageFamily(urlA: string, urlB: string): boolean {
+  const partsA = extractStatePath(urlA).split('?')[0].split('#')[0].toLowerCase().split('/').filter(Boolean);
+  const partsB = extractStatePath(urlB).split('?')[0].split('#')[0].toLowerCase().split('/').filter(Boolean);
+  if (partsA.length !== partsB.length) return false;
+
+  let diffCount = 0;
+  for (let i = 0; i < partsA.length; i++) {
+    if (partsA[i] === partsB[i]) continue;
+    diffCount++;
+    if (diffCount > 1) return false;
+    if (!isDynamicSegment(partsA[i]) || !isDynamicSegment(partsB[i])) return false;
+  }
+  return true;
+}
+
 export function generalizeSegment(segment: string): string {
   if (/^\d+$/.test(segment)) return '\\d+';
   if (/^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$/i.test(segment)) return '[a-f0-9-]+';

--- a/src/utils/url-matcher.ts
+++ b/src/utils/url-matcher.ts
@@ -29,8 +29,8 @@ export function hasDynamicUrlSegment(url: string): boolean {
 }
 
 export function isSamePageFamily(urlA: string, urlB: string): boolean {
-  const partsA = extractStatePath(urlA).split('?')[0].split('#')[0].toLowerCase().split('/').filter(Boolean);
-  const partsB = extractStatePath(urlB).split('?')[0].split('#')[0].toLowerCase().split('/').filter(Boolean);
+  const partsA = new URL(urlA, 'http://localhost').pathname.toLowerCase().split('/').filter(Boolean);
+  const partsB = new URL(urlB, 'http://localhost').pathname.toLowerCase().split('/').filter(Boolean);
   if (partsA.length !== partsB.length) return false;
 
   let diffCount = 0;

--- a/tests/integration/researcher.test.ts
+++ b/tests/integration/researcher.test.ts
@@ -182,7 +182,7 @@ describe('Researcher with aimock', () => {
   });
 
   it('returns cached research verbatim and without an AI call', async () => {
-    saveResearch(fakeState.hash!, '## Cached Research\n\nPreviously analyzed page.');
+    saveResearch({ hash: fakeState.hash!, url: fakeState.url }, '## Cached Research\n\nPreviously analyzed page.');
 
     const result = await researcher.research(fakeState, { fix: false });
 
@@ -191,7 +191,7 @@ describe('Researcher with aimock', () => {
   });
 
   it('force flag bypasses cache', async () => {
-    saveResearch(fakeState.hash!, '## Cached Research\n\nOld cached content.');
+    saveResearch({ hash: fakeState.hash!, url: fakeState.url }, '## Cached Research\n\nOld cached content.');
 
     const result = await researcher.research(fakeState, { fix: false, force: true });
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -225,6 +225,16 @@ describe('ConfigParser environment mode', () => {
     expect(parser.getOutputDir()).toBe(scratchDir);
   });
 
+  it('keeps absolute project directories unchanged', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://example.com';
+    process.env.EXPLORBOT_OUTPUT = scratchDir;
+
+    await parser.loadConfig();
+
+    expect(parser.resolveProjectDir(scratchDir)).toBe(scratchDir);
+  });
+
   it('resolves optional vision and agentic models', async () => {
     process.env.EXPLORBOT_AI_MODEL = 'groq/openai/gpt-oss-20b';
     process.env.EXPLORBOT_VISION_MODEL = 'groq/meta-llama/llama-4-scout-17b-16e-instruct';

--- a/tests/unit/fisherman-tools.test.ts
+++ b/tests/unit/fisherman-tools.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'bun:test';
+import { createFishermanTools } from '../../src/ai/fisherman-tools.ts';
+
+describe('Fisherman tools', () => {
+  it('does not present a rejected capture as a request example', async () => {
+    const captured = { method: 'POST', path: '/plans', status: 400, requestBody: { plan: 'wrong' } };
+    const { tools } = createFishermanTools({} as any, store(captured), {});
+
+    const result: any = await tools.getEndpointSpec.execute({ method: 'POST', path: '/plans' }, {} as any);
+
+    expect(result.usable).toBe(false);
+    expect(result.rejectedRequestBody).toEqual({ plan: 'wrong' });
+    expect(result.requestBody).toBeUndefined();
+  });
+
+  it('prefers the specification when the captured request was rejected', async () => {
+    const captured = { method: 'POST', path: '/plans', status: 422, requestBody: { plan: 'wrong' } };
+    const spec = { paths: { '/plans': { post: { requestBody: { required: true } } } } };
+    const { tools } = createFishermanTools({} as any, store(captured), { spec });
+
+    const result: any = await tools.getEndpointSpec.execute({ method: 'POST', path: '/plans' }, {} as any);
+
+    expect(result.source).toBe('spec');
+    expect(result.definition).toContain('requestBody');
+    expect(result.rejectedCapture.status).toBe(422);
+  });
+
+  it('keeps a successful captured request as a usable example', async () => {
+    const captured = { method: 'POST', path: '/plans', status: 201, requestBody: { title: 'Plan' } };
+    const { tools } = createFishermanTools({} as any, store(captured), {});
+
+    const result: any = await tools.getEndpointSpec.execute({ method: 'POST', path: '/plans' }, {} as any);
+
+    expect(result.source).toBe('captured');
+    expect(result.requestBody).toEqual({ title: 'Plan' });
+    expect(result.usable).not.toBe(false);
+  });
+
+  it('classifies failures by HTTP semantics', async () => {
+    for (const [status, category] of [
+      [422, 'validation'],
+      [401, 'authorization'],
+      [404, 'not_found'],
+      [409, 'conflict'],
+      [429, 'temporary'],
+      [503, 'server'],
+    ] as const) {
+      const apiClient = {
+        request: async () => ({ status, statusText: String(status), rawResponseBody: '{}', responseBody: null }),
+      };
+      const { tools } = createFishermanTools(apiClient as any, store(), {});
+
+      const result: any = await tools.request.execute({ method: 'POST', path: '/plans' }, {} as any);
+
+      expect(result.category).toBe(category);
+    }
+  });
+});
+
+function store(captured?: any): any {
+  return {
+    findCapturedRequest: () => captured,
+    addMadeRequest: () => {},
+  };
+}

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { ModelMessage } from 'ai';
+import { tool } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
+import { z } from 'zod';
 import { AiError, Provider } from '../../src/ai/provider.js';
 import { ConfigParser } from '../../src/config.js';
 import type { AIConfig } from '../../src/config.js';
@@ -110,6 +112,64 @@ describe('Provider', () => {
       });
 
       expect(response.text).toBe('Response');
+    });
+
+    it('should repair tool names with channel markers instead of rejecting them', async () => {
+      const messages = [{ role: 'user', content: 'Use a tool' }];
+      let executed = '';
+      const tools = {
+        click: tool({
+          description: 'Click an element',
+          inputSchema: z.object({ commands: z.array(z.string()) }),
+          execute: async (input: any) => {
+            executed = input.commands?.[0] || 'clicked';
+            return { success: true };
+          },
+        }),
+      };
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'channel-marker-model',
+        doGenerate: async () => ({
+          text: undefined,
+          toolCalls: [{ toolCallId: 'call-1', toolName: 'click<|channel|>commentary', args: { commands: ['I.click("#btn")'] } }],
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 1, outputTokens: 1 },
+          content: [{ type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'click<|channel|>commentary', input: JSON.stringify({ commands: ['I.click("#btn")'] }) }],
+        }),
+      });
+
+      const response = await provider.generateWithTools(messages, model, tools);
+
+      expect(executed).toBe('I.click("#btn")');
+      expect(response.toolCalls?.[0]?.toolName).toBe('click');
+    });
+
+    it('should not repair tool names that match no tool', async () => {
+      const messages = [{ role: 'user', content: 'Use a tool' }];
+      const tools = {
+        click: tool({
+          description: 'Click an element',
+          inputSchema: z.object({ commands: z.array(z.string()) }),
+          execute: async () => ({ success: true }),
+        }),
+      };
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'channel-marker-model',
+        doGenerate: async () => ({
+          text: undefined,
+          toolCalls: [{ toolCallId: 'call-1', toolName: 'nonexistent<|channel|>commentary', args: {} }],
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 1, outputTokens: 1 },
+          content: [{ type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'nonexistent<|channel|>commentary', input: '{}' }],
+        }),
+      });
+
+      const response = await provider.generateWithTools(messages, model, tools);
+
+      expect(response.toolCalls?.[0]?.invalid).toBe(true);
+      expect(response.toolResults?.length ?? 0).toBe(0);
     });
   });
 

--- a/tests/unit/remote.test.ts
+++ b/tests/unit/remote.test.ts
@@ -148,7 +148,7 @@ describe('remote', () => {
     scenario.start();
     scenario.finish(TestResult.PASSED);
 
-    saveResearch('checkout_hash', '# Checkout');
+    saveResearch({ hash: 'checkout_hash' }, '# Checkout');
     new SessionAnalyst({} as any).writeReport('# Session Analysis');
 
     await waitFor(frameOf('report'));

--- a/tests/unit/research-cache-url.test.ts
+++ b/tests/unit/research-cache-url.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { clearResearchCache, getCachedResearch, saveResearch } from '../../src/ai/researcher/cache.ts';
+import { ConfigParser } from '../../src/config.ts';
+import { outputPath } from '../../src/config.ts';
+import { computeHtmlFingerprint } from '../../src/utils/html-diff.ts';
+import { isSamePageFamily } from '../../src/utils/url-matcher.ts';
+
+const html = '<html><body><button>Save</button><a href="/x">Plan row</a></body></html>';
+
+describe('research cache url provenance', () => {
+  beforeAll(() => {
+    ConfigParser.setupTestConfig();
+  });
+
+  afterAll(() => {
+    clearResearchCache();
+    for (const hash of ['provenance-hash', 'plan-detail-hash', 'legacy-hash', 'a-wrong-page-hash', 'z-compatible-page-hash']) {
+      rmSync(outputPath('research', `${hash}.md`), { force: true });
+      rmSync(outputPath('states', `${hash}.fingerprint`), { force: true });
+    }
+  });
+
+  it('keeps research unchanged and stores the url with its fingerprint', () => {
+    saveResearch('provenance-hash', '## Plans List', html, '/projects/p/plans');
+
+    const onDisk = readFileSync(outputPath('research', 'provenance-hash.md'), 'utf8');
+    const fingerprint = JSON.parse(readFileSync(outputPath('states', 'provenance-hash.fingerprint'), 'utf8'));
+
+    expect(onDisk).toBe('## Plans List');
+    expect(fingerprint.url).toBe('/projects/p/plans');
+    expect(fingerprint.entries.length).toBeGreaterThan(0);
+    expect(getCachedResearch('provenance-hash')).toBe('## Plans List');
+  });
+
+  it('allows reuse between pages of the same family', () => {
+    expect(isSamePageFamily('/projects/p/plans/aababeac', '/projects/p/plans/7a6c9c45')).toBe(true);
+  });
+
+  it('blocks reuse between different pages', () => {
+    expect(isSamePageFamily('/projects/p/plans/7a6c9c45', '/projects/p/plans')).toBe(false);
+    expect(isSamePageFamily('/projects/p/plans', '/projects/p/runs')).toBe(false);
+  });
+
+  it('findSimilarResearch rejects a fingerprint match recorded for a different page family', async () => {
+    const detailHtml = '<html><body><section>Unique plan detail content</section><button>Delete plan</button></body></html>';
+    saveResearch('plan-detail-hash', '## Plan Detail Research', detailHtml, '/projects/p/plans/7a6c9c45');
+    const { findSimilarResearch } = await import('../../src/ai/researcher/cache.ts');
+
+    const sameFamily = await findSimilarResearch(detailHtml, '/projects/p/plans/aababeac');
+    expect(sameFamily).toBe('## Plan Detail Research');
+
+    const differentPage = await findSimilarResearch(detailHtml, '/projects/p/plans');
+    expect(differentPage).toBeNull();
+  }, 20000);
+
+  it('selects the best match from the requested page family', async () => {
+    const matchingHtml = '<html><body><section>Unique matching content</section><button>Open item</button></body></html>';
+    saveResearch('a-wrong-page-hash', '## Wrong Page', matchingHtml, '/projects/p/runs/7a6c9c45');
+    saveResearch('z-compatible-page-hash', '## Compatible Page', matchingHtml, '/projects/p/plans/7a6c9c45');
+    const { findSimilarResearch, findSimilarStateHash } = await import('../../src/ai/researcher/cache.ts');
+
+    expect(await findSimilarResearch(matchingHtml, '/projects/p/plans/aababeac')).toBe('## Compatible Page');
+    expect(await findSimilarStateHash(matchingHtml, '/projects/p/plans/aababeac')).toBe('z-compatible-page-hash');
+  }, 20000);
+
+  it('continues to read legacy line-based fingerprints', async () => {
+    const legacyHtml = '<html><body><button>Legacy fingerprint</button></body></html>';
+    saveResearch('legacy-hash', '## Legacy Research');
+    writeFileSync(outputPath('states', 'legacy-hash.fingerprint'), computeHtmlFingerprint(legacyHtml).join('\n'));
+    const { findSimilarResearch } = await import('../../src/ai/researcher/cache.ts');
+
+    expect(await findSimilarResearch(legacyHtml, '/legacy')).toBe('## Legacy Research');
+  }, 20000);
+});

--- a/tests/unit/research-cache-url.test.ts
+++ b/tests/unit/research-cache-url.test.ts
@@ -22,7 +22,7 @@ describe('research cache url provenance', () => {
   });
 
   it('keeps research unchanged and stores the url with its fingerprint', () => {
-    saveResearch('provenance-hash', '## Plans List', html, '/projects/p/plans');
+    saveResearch({ hash: 'provenance-hash', url: '/projects/p/plans' }, '## Plans List', html);
 
     const onDisk = readFileSync(outputPath('research', 'provenance-hash.md'), 'utf8');
     const fingerprint = JSON.parse(readFileSync(outputPath('states', 'provenance-hash.fingerprint'), 'utf8'));
@@ -44,7 +44,7 @@ describe('research cache url provenance', () => {
 
   it('findSimilarResearch rejects a fingerprint match recorded for a different page family', async () => {
     const detailHtml = '<html><body><section>Unique plan detail content</section><button>Delete plan</button></body></html>';
-    saveResearch('plan-detail-hash', '## Plan Detail Research', detailHtml, '/projects/p/plans/7a6c9c45');
+    saveResearch({ hash: 'plan-detail-hash', url: '/projects/p/plans/7a6c9c45' }, '## Plan Detail Research', detailHtml);
     const { findSimilarResearch } = await import('../../src/ai/researcher/cache.ts');
 
     const sameFamily = await findSimilarResearch(detailHtml, '/projects/p/plans/aababeac');
@@ -56,8 +56,8 @@ describe('research cache url provenance', () => {
 
   it('selects the best match from the requested page family', async () => {
     const matchingHtml = '<html><body><section>Unique matching content</section><button>Open item</button></body></html>';
-    saveResearch('a-wrong-page-hash', '## Wrong Page', matchingHtml, '/projects/p/runs/7a6c9c45');
-    saveResearch('z-compatible-page-hash', '## Compatible Page', matchingHtml, '/projects/p/plans/7a6c9c45');
+    saveResearch({ hash: 'a-wrong-page-hash', url: '/projects/p/runs/7a6c9c45' }, '## Wrong Page', matchingHtml);
+    saveResearch({ hash: 'z-compatible-page-hash', url: '/projects/p/plans/7a6c9c45' }, '## Compatible Page', matchingHtml);
     const { findSimilarResearch, findSimilarStateHash } = await import('../../src/ai/researcher/cache.ts');
 
     expect(await findSimilarResearch(matchingHtml, '/projects/p/plans/aababeac')).toBe('## Compatible Page');
@@ -66,7 +66,7 @@ describe('research cache url provenance', () => {
 
   it('continues to read legacy line-based fingerprints', async () => {
     const legacyHtml = '<html><body><button>Legacy fingerprint</button></body></html>';
-    saveResearch('legacy-hash', '## Legacy Research');
+    saveResearch({ hash: 'legacy-hash' }, '## Legacy Research');
     writeFileSync(outputPath('states', 'legacy-hash.fingerprint'), computeHtmlFingerprint(legacyHtml).join('\n'));
     const { findSimilarResearch } = await import('../../src/ai/researcher/cache.ts');
 

--- a/tests/unit/url-matcher.test.ts
+++ b/tests/unit/url-matcher.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import { ConfigParser } from '../../src/config';
 import { normalizeUrl } from '../../src/state-manager';
-import { extractStatePath, generalizeSegment, generalizeUrl, hasDynamicUrlSegment, isDynamicSegment, matchesNavigationUrl, matchesUrl } from '../../src/utils/url-matcher';
+import { extractStatePath, generalizeSegment, generalizeUrl, hasDynamicUrlSegment, isDynamicSegment, isSamePageFamily, matchesNavigationUrl, matchesUrl } from '../../src/utils/url-matcher';
 
 describe('url-matcher', () => {
   beforeEach(() => {
@@ -215,6 +215,31 @@ describe('url-matcher', () => {
     it('treats repeated leading slashes as a relative path, not a protocol-relative URL', () => {
       expect(normalizeUrl('///series/page/57/')).toBe('series/page/57');
       expect(normalizeUrl('/series/page/57/')).toBe('series/page/57');
+    });
+  });
+
+  describe('isSamePageFamily', () => {
+    it('matches URLs differing only in a dynamic id segment', () => {
+      expect(isSamePageFamily('/plans/7a6c9c45', '/plans/aababeac')).toBe(true);
+      expect(isSamePageFamily('/suite/c05b7ef5', '/suite/95ef0c94-mobile')).toBe(true);
+    });
+
+    it('rejects URLs from different pages', () => {
+      expect(isSamePageFamily('/plans/7a6c9c45', '/plans')).toBe(false);
+      expect(isSamePageFamily('/plans/new/manual', '/plans/a57eab1a')).toBe(false);
+    });
+
+    it('rejects URLs differing in a static segment', () => {
+      expect(isSamePageFamily('/projects/alpha/plans', '/projects/beta/plans')).toBe(false);
+    });
+
+    it('matches identical URLs and ignores query and hash', () => {
+      expect(isSamePageFamily('/plans', '/plans/')).toBe(true);
+      expect(isSamePageFamily('/plans/123?tab=tests', '/plans/123#details')).toBe(true);
+    });
+
+    it('does not match a static route with a dynamic detail route', () => {
+      expect(isSamePageFamily('/plans/new', '/plans/a57eab1a')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

  - repair tool calls when reasoning models append internal channel markers to valid tool names
  - prevent rejected captured API requests from being presented as valid Fisherman examples
  - classify HTTP failures so Fisherman can choose an appropriate recovery strategy
  - store source URLs with research fingerprints and filter incompatible page families before similarity matching
  - apply the same URL-aware matching when Planner reuses state hashes
  - preserve compatibility with legacy fingerprint files
  - correctly resolve absolute output, knowledge, and experience directories on Windows
  - centralize page-family matching and remove duplicated Planner logic