### PR TITLE
Stop telling the Tester it has HTML it never receives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2026-08-23
+
+### Changes
+
+- [Tester] The prompt no longer promises page HTML that was never sent. The Tester was told to work
+  from a `<page_html>` section in four places, but nothing ever put one there — it only ever received
+  the accessibility tree and the UI map. It is now told what it actually has: the accessibility tree,
+  the page diffs that come back with each action, and HTML it asks for by calling a tool.
+- [Tester] When the accessibility tree is not enough, the Tester now knows to hand the step over
+  rather than guess. `interact()` is described as what it is — one step delegated to the Navigator,
+  which reads the whole page — and the Tester is reminded of it every turn, for the three cases it
+  helps with: the direct action tools failed, the step needs a sequence of actions, or the element is
+  missing from what the Tester can see.
+- [Tester] A test no longer stops early after a delegated step succeeded. A successful `interact()`
+  that left the page looking unchanged used to count as no progress at all, and three of them ended
+  the test.
+- [Pilot] The Pilot no longer pushes a full page of HTML into the Tester mid-test. It can still
+  attach the accessibility tree, a page summary, or the UI map when recent actions failed.
+
 ## 2026-08-21
 
 ### Changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -273,7 +273,7 @@ Pilot supervises test execution. It maintains a separate conversation from Teste
 
 **Why separate conversations:**
 
-- Tester conversation is heavy — full HTML/ARIA context every iteration
+- Tester conversation is heavy — ARIA context every iteration
 - Pilot conversation is light — only tool execution summaries
 - Pilot can use expensive models (Claude, GPT-4) without token cost explosion
 - Separation allows Pilot to see patterns without drowning in page details
@@ -281,7 +281,7 @@ Pilot supervises test execution. It maintains a separate conversation from Teste
 **What Pilot does:**
 
 - Detects stuck patterns (loops, repeated failures, no ariaDiff changes)
-- Decides what context Tester needs next (requests ATTACH_HTML, ATTACH_ARIA, ATTACH_UI_MAP)
+- Decides what context Tester needs next (requests ATTACH_ARIA, ATTACH_SUMMARY, ATTACH_UI_MAP)
 - Asks user for help when automated recovery fails (interactive mode)
 - Suggests alternative approaches, reset, or stop
 
@@ -289,7 +289,7 @@ Pilot supervises test execution. It maintains a separate conversation from Teste
 
 - Tester calls Pilot every N iterations
 - Pilot receives: current URL, goal, recent tool executions (success/fail + ariaDiff)
-- Pilot returns: guidance text + attached context (HTML/ARIA/UI map if requested)
+- Pilot returns: guidance text + attached context (ARIA/summary/UI map if requested)
 
 ## Tester Loop & Tools
 

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -871,15 +871,6 @@ export class Pilot implements Agent {
   private async fetchRequestedContext(text: string, currentState: ActionResult): Promise<string> {
     const parts: string[] = [];
 
-    if (text.includes('ATTACH_HTML')) {
-      const html = await currentState.simplifiedHtml();
-      parts.push(dedent`
-        <page_html>
-        ${html}
-        </page_html>
-      `);
-    }
-
     if (text.includes('ATTACH_ARIA')) {
       parts.push(dedent`
         <page_aria>
@@ -1117,10 +1108,10 @@ export class Pilot implements Agent {
       role, icon classes with "or" in one XPath. If empty, broaden (drop role filter). Pass discovered
       XPath into NEXT instruction.
 
-      To request more context, mention ATTACH_HTML, ATTACH_ARIA, or ATTACH_UI_MAP — only when recent actions show failures.
+      To request more context, mention ATTACH_ARIA, ATTACH_SUMMARY, or ATTACH_UI_MAP — only when recent actions show failures.
 
-      Tester tools: click, pressKey, form, see, verify, context, research, xpathCheck, visualClick,
-      back, getVisitedStates, reset, stop, finish, record.
+      Tester tools: click, pressKey, form, see, verify, interact, context, research, xpathCheck,
+      visualClick, back, getVisitedStates, reset, stop, finish, record.
       Use tool names exactly as listed. Do not invent combined names, aliases, or names with channel markers such as "commentary".
 
       ${capabilityGroundingRule}

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -76,7 +76,7 @@ const locatorStrategyRule = dedent`
 
   NEVER include \`eidx\` attribute in any locator (ARIA, CSS, XPath). It is an internal annotation.
 
-  If <aria> section is not present or element is not found there, fall back to CSS/XPath locators from <html> section.
+  If the element is not found in the ARIA snapshot, fall back to CSS/XPath locators from page HTML.
 
   Stick to semantic attributes like role, aria-*, id, class, name, data-id, etc.
   Avoid IDs that follow framework auto-generation patterns (these change on every page load):

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -42,6 +42,7 @@ const SAMPLE_FILES: Record<string, string> = {
 
 export class Tester extends TaskAgent implements Agent {
   protected readonly ACTION_TOOLS = ['click', 'hover', 'pressKey', 'form'];
+  protected readonly DELEGATED_ACTION_TOOLS = ['interact'];
   protected readonly SPECIAL_CONTEXT_ACTION_TOOLS = ['exitIframe'];
   emoji = '🧪';
   private requestStore: RequestStore;
@@ -276,7 +277,6 @@ export class Tester extends TaskAgent implements Agent {
           }
 
           conversation.cleanupTag('page_aria', '...cleaned aria snapshot...', 1);
-          conversation.cleanupTag('page_html', '...cleaned HTML snapshot...', 1);
           conversation.cleanupTag('experience', '...cleaned experience...', 1);
           conversation.cleanupTag('applied_experience', '...cleaned past experience...', 1);
           conversation.cleanupTag('page_ui_map', '...cleaned UI map...', 1);
@@ -415,7 +415,6 @@ export class Tester extends TaskAgent implements Agent {
       this.stalledIterations = 0;
       tag('info').log(`Pilot extending test (${extensions}/${this.MAX_EXTENSIONS})`);
       conversation.cleanupTag('page_aria', '...trimmed...', 1);
-      conversation.cleanupTag('page_html', '...trimmed...', 0);
       conversation.cleanupTag('experience', '...trimmed...', 0);
       conversation.cleanupTag('page_ui_map', '...trimmed...', 0);
       conversation.cleanupTag('page_ui_map_overlay', '...trimmed...', 0);
@@ -456,7 +455,7 @@ export class Tester extends TaskAgent implements Agent {
 
     const currentState = this.getCurrentState();
     const stateChanged = previousState.url !== currentState.url || previousState.hash !== currentState.hash;
-    const actionTools = [...this.ACTION_TOOLS, ...this.SPECIAL_CONTEXT_ACTION_TOOLS];
+    const actionTools = [...this.ACTION_TOOLS, ...this.DELEGATED_ACTION_TOOLS, ...this.SPECIAL_CONTEXT_ACTION_TOOLS];
     const hasSuccessfulAction = toolExecutions.some((execution) => execution.wasSuccessful && actionTools.includes(execution.toolName));
     const hasSuccessfulAssertion = toolExecutions.some((execution) => execution.wasSuccessful && this.ASSERTION_TOOLS.includes(execution.toolName));
 
@@ -483,6 +482,7 @@ export class Tester extends TaskAgent implements Agent {
   
       <rules>
       Use tools ${this.ACTION_TOOLS.join(', ')} to interact with the page.
+      Fall back to interact() when those fail, when the step needs a sequence of actions, or when your context is not enough to locate the element.
       Use tool names exactly as listed in this prompt. Do not invent combined tool names, aliases, or names with channel markers such as "commentary".
       Match each tool input schema exactly. Do not invent parameter names or pass extra fields.
       Do not do unsuccesful clicks again.
@@ -608,8 +608,8 @@ export class Tester extends TaskAgent implements Agent {
         ${uiMapSection}
 
         Use <page_ui_map> to understand the page structure and its main elements.
-        However, <page_ui_map> is not always up to date, use <page_aria> and <page_html> to understand the ACTUAL state of the page
-        Do not interact with elements that are not listed in <page_aria> and <page_html>
+        However, <page_ui_map> is not always up to date, use <page_aria> to understand the ACTUAL state of the page
+        Do not interact with elements that are not listed in <page_aria> or in HTML returned by tools
         Refer to information on page sections in <page_ui_map> and use container CSS locators to interact with elements inside sections
       `;
       return context;
@@ -714,7 +714,7 @@ export class Tester extends TaskAgent implements Agent {
 
     <rules>
     - Refer to UI Map from <page_ui_map> to understand the page structure and its main elements
-    - Use only elements that exist in the provided ARIA tree or HTML, <page_aria> and <page_html>
+    - Use only elements that exist in <page_aria> or in HTML returned by tools
     - Use tool input schemas exactly as documented. Do not invent parameter names or add fields not listed by the tool schema.
     - Use click() for buttons, links, and clickable elements ONLY - do NOT include I.fillField() or I.type() commands in click() tool
     - click() commands array is for FALLBACK LOCATORS of the SAME element, NOT for clicking different elements in sequence. If you need to click two different elements, make two separate click() calls.
@@ -737,7 +737,8 @@ export class Tester extends TaskAgent implements Agent {
     - Check for error messages to understand if there are issues
     - Verify if data was correctly saved and changes are reflected on the page
     - By default, you receive accessibility tree data which shows interactive elements and page structure
-    - Understand current context by following <page_html>, <page_aria>, and <page_ui_map>
+    - Full page HTML is never injected automatically. When ARIA is not enough, delegate to the tools that read it: verify() to assert, interact() to act
+    - Understand current context by following <page_aria> and <page_ui_map>
     - Before submitting form, check all inputs were filled in correctly using see() tool
     - When you interact with form with inputs, ensure that you click corresponding button to save its data
     - Follow <locator_priority> rules when selecting locators for all tools

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -626,7 +626,7 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
         
         DO NOT call this if:
         - You just performed an action (pageDiff already provided in response)
-        - You already have recent <page_html>/<page_aria> in context
+        - You already have a recent <page_aria> snapshot in context
         - You're about to perform an action (you'll get pageDiff after)
         
         Call ONLY when:
@@ -781,12 +781,18 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
 
     interact: tool({
       description: dedent`
-        Execute an action on the current page using AI-powered interaction.
-        Use this to perform actions like clicking buttons, selecting options, filling forms, etc.
-        The AI will generate and try multiple CodeceptJS code strategies to accomplish the instruction.
+        Delegate one step to the Navigator, which reads the full page HTML and tries multiple CodeceptJS strategies.
+        Slower than the direct action tools — use it as a fallback, not as the default.
+
+        Use when:
+        - direct action tools failed and you have no better locator to try
+        - the step needs a sequence of actions to complete
+        - the element is not in the context you have
+
+        Describe the outcome to reach, not the locator to use.
       `,
       inputSchema: z.object({
-        instruction: z.string().describe('What action to perform on the page, e.g. "select new suite option", "click the Submit button"'),
+        instruction: z.string().describe('The step to perform on the page, described by its intent'),
       }),
       execute: async ({ instruction }) => {
         try {
@@ -1375,7 +1381,7 @@ function getNotFoundSuggestion(errorMessage: string): string | null {
     Element was not found. The locator does not exist on this page.
     1. Use see() to visually analyze what elements are actually on the page
     2. Use context() to get fresh HTML and ARIA snapshot
-    3. Use ONLY locators from <page_aria> or <page_html>
+    3. Use ONLY locators from <page_aria> or from HTML returned by context()
     4. Prefer ARIA locators: { "role": "button", "text": "visible text" }
   `;
 }


### PR DESCRIPTION
## What

The Tester's prompt referenced a `<page_html>` section in four places, but nothing ever injected one. Its per-iteration context (`reinjectContextIfNeeded`) is the accessibility tree plus the Researcher's UI map — HTML reaches it only through tool results (the page diffs returned with each action) or when it calls `context()` / `xpathCheck()` itself.

The one path that did inject full page HTML unasked was Pilot's `ATTACH_HTML`, which pushed `simplifiedHtml()` straight into the Tester's conversation. Removed. `ATTACH_ARIA`, `ATTACH_SUMMARY` and `ATTACH_UI_MAP` are unchanged.

## Boundary this settles

- **Tester** — works from the accessibility tree, keeps a light loop, sees only the HTML it asked for or that came back in a diff.
- **Navigator** — reads the whole page, performs one step.

With the invariant real, the Tester needs somewhere to send work the accessibility tree cannot express. That is `interact()`, which delegates to the Navigator. It already existed but was effectively invisible: its description read as a generic `click()` alternative, and the instruction injected every turn listed only the four direct action tools. It now states its purpose and the three cases it covers — direct actions failed, the step needs a sequence of actions, or the element is not in the Tester's context — and the Tester is pointed at it each iteration.

## Changes

- `src/ai/tester.ts` — `<page_html>` removed from the context block and two system rules; new rule pairing `verify()` and `interact()` as the tools that read full HTML; per-iteration fallback line for `interact()`; two dead `cleanupTag('page_html')` calls dropped.
- `src/ai/tools.ts` — `interact()` description rewritten around its role; `context()` and the not-found suggestion no longer reference a `<page_html>` section.
- `src/ai/pilot.ts` — `ATTACH_HTML` branch and its prompt mention removed; `interact` added to the Tester tool list Pilot validates against, which was missing it.
- `src/ai/rules.ts` — `locatorStrategyRule` referenced `<aria>` / `<html>` sections that exist under neither name; reworded, still true for Navigator.
- `CLAUDE.md` — Pilot section corrected.

## Behavior change worth a look

`DELEGATED_ACTION_TOOLS = ['interact']` now feeds `shouldStopForStalledExecution`. Previously a successful `interact()` that left the state hash unchanged counted as no browser progress, and three of those ended the test. Now that the prompt actively pushes the Tester toward `interact()`, that was a trap worth closing — but it is the one change here that alters runtime behavior rather than prompt text.

## Not fixed here

A failed `interact()` never lands in `task` notes: the note loop keys on `execution.input?.explanation` and `interact`'s input field is `instruction`. Pre-existing, and Pilot still sees the failure through `formatActions`.

## Testing

`bun test tests/integration/` 80 pass / 0 fail, `bun test tests/unit/` 1043 pass / 0 fail, format and lint clean. Prompt-level change — worth regression coverage before merge, your call on the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)