### PR TITLE
Accept a collection URL answered with one of its records

### DIFF
--- a/src/utils/url-matcher.ts
+++ b/src/utils/url-matcher.ts
@@ -118,6 +118,16 @@ export function matchesNavigationUrl(expected: string, current: string): boolean
   if (!expectedPath.includes('?')) {
     currentPath = currentPath.split('?')[0];
   }
-  const normalize = (value: string) => value.replace(/^\/+|\/+$/g, '').toLowerCase();
-  return normalize(expectedPath) === normalize(currentPath);
+  const normalize = (value: string) => value.replace(/^\/+|\/+$/g, '');
+  const expectedNormalized = normalize(expectedPath);
+  const currentNormalized = normalize(currentPath);
+  const expectedKey = expectedNormalized.toLowerCase();
+  const currentKey = currentNormalized.toLowerCase();
+  if (expectedKey === currentKey) return true;
+  if (!currentKey.startsWith(`${expectedKey}/`)) return false;
+  const recordSegments = currentNormalized
+    .slice(expectedKey.length + 1)
+    .split('/')
+    .filter(Boolean);
+  return recordSegments.length > 0 && recordSegments.every(isDynamicSegment);
 }

--- a/tests/unit/url-matcher.test.ts
+++ b/tests/unit/url-matcher.test.ts
@@ -209,6 +209,23 @@ describe('url-matcher', () => {
     it('requires an explicitly requested query', () => {
       expect(matchesNavigationUrl('/search?q=shoes', '/search?q=hats')).toBe(false);
     });
+
+    it('accepts a record the application redirected to from its collection', () => {
+      expect(matchesNavigationUrl('/#/orders', '/#/orders/01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(true);
+      expect(matchesNavigationUrl('/users', '/users/42')).toBe(true);
+    });
+
+    it('rejects a named child that is not a record', () => {
+      expect(matchesNavigationUrl('/users', '/users/settings')).toBe(false);
+    });
+
+    it('rejects a record of a different collection', () => {
+      expect(matchesNavigationUrl('/#/orders', '/#/invoices/01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(false);
+    });
+
+    it('requires the exact record when one was named', () => {
+      expect(matchesNavigationUrl('/#/orders/01ARZ3NDEKTSV4RRFFQ69G5FAV', '/#/orders/01BX5ZZKBKACTAV9WEVGEMMVRZ')).toBe(false);
+    });
   });
 
   describe('normalizeUrl', () => {


### PR DESCRIPTION
**Problem**

Our app uses pattern https://example.com/#/[page]/[ulid_inside_the_page] which is not supported in explorebot now:

/#/chats    ->  /#/chats/01ARZ3NDEKTSV4RRFFQ69G5FAV   false
/#/chats/   ->  /#/chats/01ARZ3NDEKTSV4RRFFQ69G5FAV   false
/#/chats/*  ->  /#/chats/01ARZ3NDEKTSV4RRFFQ69G5FAV   false
/           ->  /#/chats/01ARZ3NDEKTSV4RRFFQ69G5FAV   true

Only / passes, through the branch that drops the fragment when none was requested -- it checks nothing. Otherwise the Navigator retries eight times and fails. In one run it tried to force the match by renaming a record.

**Change**

After the equality test, accept the current path when it is the expected path plus one or more segments isDynamicSegment recognises:

/#/chats  ->  /#/chats/01ARZ3NDEKTSV4RRFFQ69G5FAV    true
/users    ->  /users/42                              true
/users    ->  /users/settings                        false
/#/chats  ->  /#/agents/01ARZ3NDEKTSV4RRFFQ69G5FAV   false

normalize() no longer lowercases; the comparison folds case instead. The ULID pattern is uppercase-only, so lowercasing a segment before classifying it stopped it being recognised.

**Tests**

Four added to tests/unit/url-matcher.test.ts, one using a canonical uppercase ULID. The seven existing matchesNavigationUrl assertions are unchanged.