### PR TITLE
Install the provider package init writes an import for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-08-24
+
+### Changes
+
+- `explorbot init` now tells you to install the AI provider package the config it just wrote
+  imports. Without that step the very next command failed with "Cannot find package
+  '@openrouter/ai-sdk-provider'" — under npm it happened to work because explorbot's own copy got
+  hoisted, but under pnpm or bun it never did.
+- The model ids in the generated config are taken from the recommendations shipped with the
+  release, so a fresh config no longer starts out with stale ones.
+- A config that imports a package you have not installed now says which package is missing, gives
+  the `npm i` line for it, and points at the providers documentation, instead of printing the raw
+  module resolution error.
+- Documentation: the install step covers the provider package, and the providers page documents
+  writing models as `'provider/model-id'` to use a provider explorbot already ships, with no
+  install at all.
+
 ## 2026-08-23
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -106,8 +106,12 @@ If your CI runs Playwright, it runs Explorbot. No GPUs, no special runners.
 
 ```bash
 npm i explorbot --save
+npm i @openrouter/ai-sdk-provider
 npx playwright install
 ```
+
+The second line installs the AI provider package the generated config imports. To use a different
+provider, install that one instead — see [Providers](docs/basics/providers.md).
 
 **2. Initialize config**
 

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -8,8 +8,11 @@ The path is short: install, configure, tell it how to log in, then point it at o
 
 ```bash
 npm i explorbot --save
+npm i @openrouter/ai-sdk-provider
 npx playwright install
 ```
+
+The second line installs the AI provider package the generated config imports. To use a different provider, install that one instead — see [Providers](./providers.md).
 
 You need Node.js 24+ (or Bun), an AI provider key, and a modern terminal — iTerm2, WARP, Kitty, Ghostty, or Windows Terminal with WSL. For the full compatibility checklist, see [Prerequisites](./prerequisites.md).
 
@@ -44,8 +47,8 @@ export default {
   },
   ai: {
     model: openrouter('openai/gpt-oss-20b:nitro'),
-    visionModel: openrouter('google/gemma-4-31b-it'),
-    agenticModel: openrouter('minimax/minimax-m2.5:nitro'),
+    visionModel: openrouter('openai/gpt-5.6-luna'),
+    agenticModel: openrouter('openai/gpt-5.6-luna'),
   },
 };
 ```
@@ -55,7 +58,7 @@ Explorbot uses three models. Pick each one for speed and cost:
 | Model | Config key | Used by | Pick |
 |-------|-----------|---------|------|
 | `model` | `ai.model` | Tester, Navigator, Researcher — they read HTML and ARIA on every step | a fast, cheap model (e.g. `openai/gpt-oss-20b:nitro`) |
-| `visionModel` | `ai.visionModel` | screenshot analysis | a vision model (e.g. `google/gemma-4-31b-it`) |
+| `visionModel` | `ai.visionModel` | screenshot analysis | a vision model (e.g. `openai/gpt-5.6-luna`) |
 | `agenticModel` | `ai.agenticModel` | Captain and Pilot — they read short action logs and make the big decisions | a smarter model (e.g. MiniMax 2.5, Grok Fast) |
 
 Captain and Pilot barely use tokens, so a smarter `agenticModel` improves results for almost no extra cost. OpenRouter is the simplest start — one key, many models. To use OpenAI, Anthropic, Groq, or others, see [Providers](./providers.md). For every config option, see [Configuration](../reference/configuration.md).

--- a/docs/basics/providers.md
+++ b/docs/basics/providers.md
@@ -4,6 +4,20 @@ Explorbot connects to AI providers through the [Vercel AI SDK](https://sdk.verce
 
 > The `export default` config block inside each `<!-- START/END provider -->` marker is generated from [`models.json`](../../models.json). After editing that file, run `bunosh docs:sync`. Everything else — including the import blocks — is hand-written.
 
+## Bundled Providers
+
+Writing a model as `'provider/model-id'` uses the provider package Explorbot already ships, so nothing extra is installed:
+
+```javascript
+export default {
+  ai: {
+    model: 'openrouter/openai/gpt-oss-20b:nitro',
+  },
+};
+```
+
+This is what `explorbot init --global` writes, and it is the way out if an install is inconvenient. Bundled providers: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`. Anything else — a provider not in that list, a custom `baseURL`, extra client options — needs the import form documented below.
+
 ## Requirements
 
 Your model must support:

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -8,12 +8,15 @@ import { getCliName } from '../utils/cli-name.ts';
 import { log, tag } from '../utils/logger.js';
 import { relativeToCwd } from '../utils/next-steps.ts';
 
-const DEFAULT_CONFIG_TEMPLATE = `import { createOpenRouter } from '@openrouter/ai-sdk-provider';
+const PROVIDER_PACKAGE = '@openrouter/ai-sdk-provider';
+
+function defaultConfigTemplate(): string {
+  return `import { createOpenRouter } from '${PROVIDER_PACKAGE}';
 // import { '<your provider here>' } from '<your provider package here>';
 
 // Vercel AI SDK is used to connect to AI providers.
 // Bring your own provider or use OpenRouter (one API key, many providers).
-// https://github.com/testomatio/explorbot/blob/main/docs/providers.md
+// https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 const openrouter = createOpenRouter({
   apiKey: process.env.OPENROUTER_API_KEY,
 });
@@ -25,12 +28,7 @@ const config = {
   },
 
   ai: {
-    // fast model with tool calling capabilities
-    model: openrouter('openai/gpt-oss-20b:nitro'),
-    // vision model for screenshot analysis
-    visionModel: openrouter('meta-llama/llama-4-scout-17b-16e-instruct'),
-    // agentic model for decision making
-    agenticModel: openrouter('minimax/minimax-m2.5:nitro'),
+${modelLines('openrouter', (modelId) => `openrouter('${modelId}')`)}
   },
 
   reporter: {
@@ -45,6 +43,7 @@ const config = {
 
 export default config;
 `;
+}
 
 const DEFAULT_ENV_TEMPLATE = dedent`
 # AI provider API keys
@@ -141,7 +140,7 @@ export function runInitCommand(options: InitCommandOptions): void {
       process.exit(1);
     }
 
-    writeFileSync(outPath, DEFAULT_CONFIG_TEMPLATE, 'utf8');
+    writeFileSync(outPath, defaultConfigTemplate(), 'utf8');
     log(`Created config file: ${relativeToCwd(outPath)}`);
 
     const envPath = resolve(process.cwd(), '.env');
@@ -154,14 +153,16 @@ export function runInitCommand(options: InitCommandOptions): void {
 
     log('');
     log('Next steps:');
-    log('1. Configure AI provider in .env');
-    log('2. Set AI models config file');
-    log('3. Set web application URL in the config file');
-    log('4. Add initial knowledge (how to authorize to the application, etc.)');
+    log('1. Install the provider package the config imports');
+    tag('substep').log(chalk.yellow(`npm i ${PROVIDER_PACKAGE}`));
+    log('2. Configure AI provider in .env');
+    log('3. Set AI models config file');
+    log('4. Set web application URL in the config file');
+    log('5. Add initial knowledge (how to authorize to the application, etc.)');
     tag('substep').log(chalk.yellow(`${getCliName()} learn * 'to aurhorize use these credentials: admin@example.com / secret123'`));
     tag('substep').log('You can use ${env.LOGIN} and ${env.PASSWORD} to reference environment variables.');
 
-    log('5. Launch application on a relative URL');
+    log('6. Launch application on a relative URL');
     tag('substep').log(chalk.yellow(`${getCliName()} start /dashboard`));
 
     if (!existsSync('./output')) {
@@ -222,8 +223,7 @@ async function renderInitWizard(mode: 'choose' | 'global'): Promise<'local' | 'g
   });
 }
 
-function globalConfigTemplate(provider: string): string {
-  const { envKey } = PROVIDERS[provider];
+function modelLines(provider: string, model: (modelId: string) => string): string {
   const recommended = ConfigParser.recommendedModels()[provider] || {};
   const roles: Array<[ModelRoleName, string]> = [
     ['model', 'fast model with tool calling capabilities'],
@@ -231,7 +231,11 @@ function globalConfigTemplate(provider: string): string {
     ['agenticModel', 'agentic model for decision making'],
   ];
 
-  const models = roles.map(([role, comment]) => `    // ${comment}\n    ${role}: '${provider}/${recommended[role] || '<model-id>'}',`).join('\n');
+  return roles.map(([role, comment]) => `    // ${comment}\n    ${role}: ${model(recommended[role] || '<model-id>')},`).join('\n');
+}
+
+function globalConfigTemplate(provider: string): string {
+  const { envKey } = PROVIDERS[provider];
 
   return `// Global Explorbot configuration — used by every directory without its own explorbot.config.js.
 // Models are written as 'provider/model-id' so they resolve without a local node_modules.
@@ -240,7 +244,7 @@ function globalConfigTemplate(provider: string): string {
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 const config = {
   ai: {
-${models}
+${modelLines(provider, (modelId) => `'${provider}/${modelId}'`)}
   },
 
   reporter: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -415,6 +415,8 @@ export class ConfigParser {
         process.chdir(originalCwd);
       }
       if (error instanceof ConfigMissingError) throw error;
+      const missingPackage = missingPackageMessage(error);
+      if (missingPackage) throw new Error(missingPackage);
       throw new Error(`Failed to load configuration: ${error}`);
     }
   }
@@ -773,6 +775,28 @@ export function missingConfigMessage(configFile = 'explorbot.config.js'): string
         EXPLORBOT_AI_PROVIDER=openrouter EXPLORBOT_URL=https://your-app.example.com ${cli} ...
 
     Providers: ${Object.keys(PROVIDERS).join(', ')}
+  `;
+}
+
+function missingPackageMessage(error: any): string | null {
+  if (error?.code !== 'ERR_MODULE_NOT_FOUND') return null;
+
+  const specifier = error.specifier || `${error.message}`.split("'")[1];
+  if (!specifier || specifier.startsWith('.') || specifier.startsWith('/')) return null;
+
+  let segments = 1;
+  if (specifier.startsWith('@')) segments = 2;
+  const pkg = specifier.split('/').slice(0, segments).join('/');
+
+  return dedent`
+    Configuration imports "${specifier}", which is not installed.
+
+    Install it:
+      npm i ${pkg}
+
+    Or drop the import and write the model as "provider/model-id" for a provider Explorbot ships: ${Object.keys(PROVIDERS).join(', ')}
+
+    Providers: https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
   `;
 }
 

--- a/tests/unit/global-config.test.ts
+++ b/tests/unit/global-config.test.ts
@@ -6,7 +6,7 @@ import { render } from 'ink-testing-library';
 import React from 'react';
 import InitWizard from '../../src/components/InitWizard.tsx';
 import { ApibotConfigParser } from '../../boat/api-tester/src/config.ts';
-import { runInit } from '../../src/commands/init-command.ts';
+import { runInit, runInitCommand } from '../../src/commands/init-command.ts';
 import { ConfigParser } from '../../src/config.ts';
 import { listSites, registerSite, resolveSiteTarget, siteFolderName } from '../../src/global-config.ts';
 
@@ -409,5 +409,28 @@ describe('explorbot init', () => {
       process.chdir(originalCwd);
       Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
     }
+  });
+
+  it('scaffolds a local config with the recommended models of this release', () => {
+    runInitCommand({ path: workDir });
+
+    const body = readFileSync(join(workDir, 'explorbot.config.js'), 'utf8');
+    const recommended = ConfigParser.recommendedModels().openrouter;
+
+    expect(body).toContain("import { createOpenRouter } from '@openrouter/ai-sdk-provider';");
+    expect(body).toContain(`model: openrouter('${recommended.model}')`);
+    expect(body).toContain(`visionModel: openrouter('${recommended.visionModel}')`);
+    expect(body).toContain(`agenticModel: openrouter('${recommended.agenticModel}')`);
+  });
+});
+
+describe('missing provider package', () => {
+  it('names the package and how to install it', async () => {
+    writeFileSync(join(workDir, 'explorbot.config.js'), "import { createFoo } from '@absent-scope/absent-provider/client';\nexport default { ai: { model: createFoo() } };\n", 'utf8');
+
+    const load = ConfigParser.getInstance().loadConfig({ path: workDir });
+
+    await expect(load).rejects.toThrow(/@absent-scope\/absent-provider\/client/);
+    await expect(load).rejects.toThrow(/npm i @absent-scope\/absent-provider$/m);
   });
 });


### PR DESCRIPTION
Closes #134.

`explorbot init` scaffolds a config that imports `@openrouter/ai-sdk-provider`, but nothing installs it. Under npm the import resolves only because explorbot's own copy gets hoisted to the project's top level; under pnpm or bun it never does, and `npx explorbot init` in a clean directory leaves nothing to resolve at all. The next command then fails with a bare `ERR_MODULE_NOT_FOUND`.

Confirmed the hoisting difference directly, with a package that has transitive deps:

```
npm:   node_modules/ = gray-matter, js-yaml, argparse, …   → require('js-yaml') OK
pnpm:  node_modules/ = gray-matter -> .pnpm/…              → require('js-yaml') MODULE_NOT_FOUND
```

### init names the package to install

```
Next steps:
1. Install the provider package the config imports
   > npm i @openrouter/ai-sdk-provider
2. Configure AI provider in .env
...
```

The issue offered "installs (or prints the install command for)" — this prints, which keeps package-manager detection and a network call out of `init`. The package name is a single const feeding both the template's import and the printed line, so the two cannot drift. The README and getting-started install steps cover it too.

### Config loading explains a missing import

```
Configuration imports "@openrouter/ai-sdk-provider", which is not installed.

Install it:
  npm i @openrouter/ai-sdk-provider

Or drop the import and write the model as "provider/model-id" for a provider Explorbot ships: openai, anthropic, google, groq, mistral, openrouter, sambanova

Providers: https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
```

Node and bun both report `ERR_MODULE_NOT_FOUND`, and the `.ts` require fallback surfaces it the same way, so one branch in `loadConfig`'s existing catch covers every path. Subpath specifiers are trimmed for the install line (`zod/v4` → `npm i zod`) — a missing module is often transitive, so the message names the specifier that actually failed rather than assuming it is the provider. Relative specifiers fall through to the generic message, and `ConfigMissingError` still short-circuits ahead of it.

### Rode along

The scaffolded model ids now come from `models.json` through the helper `init --global` already used, so both commands recommend the same models — the template had drifted to a `visionModel` that is no longer recommended. `providers.md` gains a short section on the `'provider/model-id'` form, since the new error message points at it as the way out.

### Verified

Fresh `init` in a clean directory prints the install step and writes the recommended ids; `init --global` still writes the string form; the missing-package message renders for both `.js` and `.ts` configs. Two unit tests added — the scaffold imports the provider package and carries this release's recommendations, and a config importing an absent package fails with the package name and install line.

Format, lint, unit (1078) and integration (81) pass on the merged tree. `bun run build` fails locally, identically at `main` — a `node_modules` issue with `playwright-core` needing `chromium-bidi`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)