### PR TITLE
Scaffold a config that resolves models without an install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 2026-08-24
+
+### Changes
+
+- `explorbot init` now writes a config that runs as-is. It used to import
+  `@openrouter/ai-sdk-provider`, a package it never installed, so the very next command failed with
+  "Cannot find package" — under npm the import resolved only because explorbot's own copy got
+  hoisted into the project, and under pnpm, bun, or a bare `npx explorbot init` it never did.
+  Models are now written as `'provider/model-id'`, resolved from the provider packages explorbot
+  already ships. Bringing your own provider package still works — the generated config shows how
+  in a comment.
+- The model ids in the generated config are taken from the recommendations shipped with the
+  release, so a fresh config no longer starts out with stale ones.
+- A config that imports a package you have not installed now says which package is missing, gives
+  the `npm i` line for it, and points at the providers documentation, instead of printing the raw
+  module resolution error.
+
 ## 2026-08-23
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@
   in a comment.
 - The model ids in the generated config are taken from the recommendations shipped with the
   release, so a fresh config no longer starts out with stale ones.
-- A config that imports a package you have not installed now says which package is missing, gives
-  the `npm i` line for it, and points at the providers documentation, instead of printing the raw
-  module resolution error.
 
 ## 2026-08-23
 

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -32,30 +32,26 @@ OPENROUTER_API_KEY=sk-...
 Then open `explorbot.config.js` and set your app's base URL — the host only, no path:
 
 ```javascript
-import { createOpenRouter } from '@openrouter/ai-sdk-provider';
-
-const openrouter = createOpenRouter({
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
-
 export default {
   web: {
     url: 'http://localhost:3000',
   },
   ai: {
-    model: openrouter('openai/gpt-oss-20b:nitro'),
-    visionModel: openrouter('google/gemma-4-31b-it'),
-    agenticModel: openrouter('minimax/minimax-m2.5:nitro'),
+    model: 'openrouter/openai/gpt-oss-20b:nitro',
+    visionModel: 'openrouter/openai/gpt-5.6-luna',
+    agenticModel: 'openrouter/openai/gpt-5.6-luna',
   },
 };
 ```
+
+Models written as `'provider/model-id'` use the provider packages Explorbot ships, so there is nothing extra to install. To bring your own provider package, import it and call it instead — see [Providers](./providers.md).
 
 Explorbot uses three models. Pick each one for speed and cost:
 
 | Model | Config key | Used by | Pick |
 |-------|-----------|---------|------|
 | `model` | `ai.model` | Tester, Navigator, Researcher — they read HTML and ARIA on every step | a fast, cheap model (e.g. `openai/gpt-oss-20b:nitro`) |
-| `visionModel` | `ai.visionModel` | screenshot analysis | a vision model (e.g. `google/gemma-4-31b-it`) |
+| `visionModel` | `ai.visionModel` | screenshot analysis | a vision model (e.g. `openai/gpt-5.6-luna`) |
 | `agenticModel` | `ai.agenticModel` | Captain and Pilot — they read short action logs and make the big decisions | a smarter model (e.g. MiniMax 2.5, Grok Fast) |
 
 Captain and Pilot barely use tokens, so a smarter `agenticModel` improves results for almost no extra cost. OpenRouter is the simplest start — one key, many models. To use OpenAI, Anthropic, Groq, or others, see [Providers](./providers.md). For every config option, see [Configuration](../reference/configuration.md).

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -44,7 +44,26 @@ export default {
 };
 ```
 
-Models written as `'provider/model-id'` use the provider packages Explorbot ships, so there is nothing extra to install. To bring your own provider package, import it and call it instead — see [Providers](./providers.md).
+That shorthand — `'provider/model-id'` — uses a provider package Explorbot ships, so nothing extra is installed. Bundled: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`.
+
+For anything else — a provider not in that list, a custom `baseURL`, extra client options — install the Vercel AI SDK package (`npm i @ai-sdk/openai`) and build the client yourself:
+
+```javascript
+import { createOpenAI } from '@ai-sdk/openai';
+
+const poolside = createOpenAI({
+  apiKey: process.env.POOLSIDE_API_KEY,
+  baseURL: 'https://inference.poolside.ai/v1',
+});
+
+export default {
+  ai: {
+    model: poolside('poolside/laguna-xs-2.1'),
+  },
+};
+```
+
+Both styles mix freely across the three keys. See [Providers](./providers.md).
 
 Explorbot uses three models. Pick each one for speed and cost:
 

--- a/docs/basics/getting-started.md
+++ b/docs/basics/getting-started.md
@@ -44,9 +44,17 @@ export default {
 };
 ```
 
-That shorthand — `'provider/model-id'` — uses a provider package Explorbot ships, so nothing extra is installed. Bundled: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`.
+That shorthand — `'provider/model-id'` — uses a provider package Explorbot ships, so nothing extra is installed. Bundled providers:
 
-For anything else — a provider not in that list, a custom `baseURL`, extra client options — install the Vercel AI SDK package (`npm i @ai-sdk/openai`) and build the client yourself:
+- `openai`
+- `anthropic`
+- `google`
+- `groq`
+- `mistral`
+- `openrouter`
+- `sambanova`
+
+The other style is explicit: install a Vercel AI SDK package (`npm i @ai-sdk/openai`) and build the client yourself. It works for the providers above too, and it is the only way to reach one that isn't bundled, a custom `baseURL`, or extra client options:
 
 ```javascript
 import { createOpenAI } from '@ai-sdk/openai';

--- a/docs/basics/providers.md
+++ b/docs/basics/providers.md
@@ -4,6 +4,20 @@ Explorbot connects to AI providers through the [Vercel AI SDK](https://sdk.verce
 
 > The `export default` config block inside each `<!-- START/END provider -->` marker is generated from [`models.json`](../../models.json). After editing that file, run `bunosh docs:sync`. Everything else — including the import blocks — is hand-written.
 
+## Bundled Providers
+
+Writing a model as `'provider/model-id'` uses the provider package Explorbot already ships, so nothing extra is installed:
+
+```javascript
+export default {
+  ai: {
+    model: 'openrouter/openai/gpt-oss-20b:nitro',
+  },
+};
+```
+
+This is what `explorbot init` generates. Bundled providers: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`. Anything else — a provider not in that list, a custom `baseURL`, extra client options — needs the import form documented below.
+
 ## Requirements
 
 Your model must support:

--- a/docs/basics/providers.md
+++ b/docs/basics/providers.md
@@ -2,31 +2,9 @@
 
 Explorbot connects to AI providers through the [Vercel AI SDK](https://sdk.vercel.ai/). Use any supported provider, and mix providers across different models.
 
+Every provider below is set up the classical way: install its package, import it, build the client. Explorbot bundles some of these packages — for those you can skip the install and name the model as `'provider/model-id'` instead. See [Getting Started](./getting-started.md#2-configure) for that list and the two styles side by side.
+
 > The `export default` config block inside each `<!-- START/END provider -->` marker is generated from [`models.json`](../../models.json). After editing that file, run `bunosh docs:sync`. Everything else — including the import blocks — is hand-written.
-
-## Bundled Providers
-
-Writing a model as `'provider/model-id'` uses the provider package Explorbot already ships, so nothing extra is installed:
-
-```javascript
-export default {
-  ai: {
-    model: 'openrouter/openai/gpt-oss-20b:nitro',
-  },
-};
-```
-
-This is what `explorbot init` generates. Bundled providers:
-
-- `openai`
-- `anthropic`
-- `google`
-- `groq`
-- `mistral`
-- `openrouter`
-- `sambanova`
-
-Each section below documents the explicit style instead: install the provider package and build the client. It works for the bundled providers too, and it is the only way to reach one that isn't bundled, a custom `baseURL`, or extra client options.
 
 ## Requirements
 

--- a/docs/basics/providers.md
+++ b/docs/basics/providers.md
@@ -16,7 +16,17 @@ export default {
 };
 ```
 
-This is what `explorbot init` generates. Bundled providers: `openai`, `anthropic`, `google`, `groq`, `mistral`, `openrouter`, `sambanova`. Anything else — a provider not in that list, a custom `baseURL`, extra client options — needs the import form documented below.
+This is what `explorbot init` generates. Bundled providers:
+
+- `openai`
+- `anthropic`
+- `google`
+- `groq`
+- `mistral`
+- `openrouter`
+- `sambanova`
+
+Each section below documents the explicit style instead: install the provider package and build the client. It works for the bundled providers too, and it is the only way to reach one that isn't bundled, a custom `baseURL`, or extra client options.
 
 ## Requirements
 

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -9,12 +9,8 @@ import { log, tag } from '../utils/logger.js';
 import { relativeToCwd } from '../utils/next-steps.ts';
 
 function defaultConfigTemplate(): string {
-  return `// Models are written as 'provider/model-id' so they resolve without installing a provider package.
-// Vercel AI SDK is used to connect to AI providers.
-// Bring your own provider by installing its package and importing it here:
-//   npm i @ai-sdk/openai
-//   import { createOpenAI } from '@ai-sdk/openai';
-//   const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+  return `// Models are written as 'provider/model-id' — Explorbot bundles these providers, nothing to install.
+// To use another one, install its Vercel AI SDK package and import it here.
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 
 const config = {

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -9,8 +9,7 @@ import { log, tag } from '../utils/logger.js';
 import { relativeToCwd } from '../utils/next-steps.ts';
 
 function defaultConfigTemplate(): string {
-  return `// Models are written as 'provider/model-id' — Explorbot bundles these providers, nothing to install.
-// To use another one, install its Vercel AI SDK package and import it here.
+  return `// 'provider/model-id' uses a bundled provider. Or import a Vercel AI SDK one.
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 
 const config = {

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -9,7 +9,8 @@ import { log, tag } from '../utils/logger.js';
 import { relativeToCwd } from '../utils/next-steps.ts';
 
 function defaultConfigTemplate(): string {
-  return `// 'provider/model-id' uses a bundled provider. Or import a Vercel AI SDK one.
+  return `// 'provider/model-id' uses a bundled provider.
+// It is also possible to import provider as a module from Vercel AI SDK.  
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 
 const config = {

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -8,15 +8,14 @@ import { getCliName } from '../utils/cli-name.ts';
 import { log, tag } from '../utils/logger.js';
 import { relativeToCwd } from '../utils/next-steps.ts';
 
-const DEFAULT_CONFIG_TEMPLATE = `import { createOpenRouter } from '@openrouter/ai-sdk-provider';
-// import { '<your provider here>' } from '<your provider package here>';
-
+function defaultConfigTemplate(): string {
+  return `// Models are written as 'provider/model-id' so they resolve without installing a provider package.
 // Vercel AI SDK is used to connect to AI providers.
-// Bring your own provider or use OpenRouter (one API key, many providers).
-// https://github.com/testomatio/explorbot/blob/main/docs/providers.md
-const openrouter = createOpenRouter({
-  apiKey: process.env.OPENROUTER_API_KEY,
-});
+// Bring your own provider by installing its package and importing it here:
+//   npm i @ai-sdk/openai
+//   import { createOpenAI } from '@ai-sdk/openai';
+//   const openai = createOpenAI({ apiKey: process.env.OPENAI_API_KEY });
+// https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 
 const config = {
   web: {
@@ -25,12 +24,7 @@ const config = {
   },
 
   ai: {
-    // fast model with tool calling capabilities
-    model: openrouter('openai/gpt-oss-20b:nitro'),
-    // vision model for screenshot analysis
-    visionModel: openrouter('meta-llama/llama-4-scout-17b-16e-instruct'),
-    // agentic model for decision making
-    agenticModel: openrouter('minimax/minimax-m2.5:nitro'),
+${modelLines('openrouter')}
   },
 
   reporter: {
@@ -45,6 +39,7 @@ const config = {
 
 export default config;
 `;
+}
 
 const DEFAULT_ENV_TEMPLATE = dedent`
 # AI provider API keys
@@ -141,7 +136,7 @@ export function runInitCommand(options: InitCommandOptions): void {
       process.exit(1);
     }
 
-    writeFileSync(outPath, DEFAULT_CONFIG_TEMPLATE, 'utf8');
+    writeFileSync(outPath, defaultConfigTemplate(), 'utf8');
     log(`Created config file: ${relativeToCwd(outPath)}`);
 
     const envPath = resolve(process.cwd(), '.env');
@@ -222,8 +217,7 @@ async function renderInitWizard(mode: 'choose' | 'global'): Promise<'local' | 'g
   });
 }
 
-function globalConfigTemplate(provider: string): string {
-  const { envKey } = PROVIDERS[provider];
+function modelLines(provider: string): string {
   const recommended = ConfigParser.recommendedModels()[provider] || {};
   const roles: Array<[ModelRoleName, string]> = [
     ['model', 'fast model with tool calling capabilities'],
@@ -231,7 +225,11 @@ function globalConfigTemplate(provider: string): string {
     ['agenticModel', 'agentic model for decision making'],
   ];
 
-  const models = roles.map(([role, comment]) => `    // ${comment}\n    ${role}: '${provider}/${recommended[role] || '<model-id>'}',`).join('\n');
+  return roles.map(([role, comment]) => `    // ${comment}\n    ${role}: '${provider}/${recommended[role] || '<model-id>'}',`).join('\n');
+}
+
+function globalConfigTemplate(provider: string): string {
+  const { envKey } = PROVIDERS[provider];
 
   return `// Global Explorbot configuration — used by every directory without its own explorbot.config.js.
 // Models are written as 'provider/model-id' so they resolve without a local node_modules.
@@ -240,7 +238,7 @@ function globalConfigTemplate(provider: string): string {
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 const config = {
   ai: {
-${models}
+${modelLines(provider)}
   },
 
   reporter: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -415,8 +415,6 @@ export class ConfigParser {
         process.chdir(originalCwd);
       }
       if (error instanceof ConfigMissingError) throw error;
-      const missingPackage = missingPackageMessage(error);
-      if (missingPackage) throw new Error(missingPackage);
       throw new Error(`Failed to load configuration: ${error}`);
     }
   }
@@ -775,28 +773,6 @@ export function missingConfigMessage(configFile = 'explorbot.config.js'): string
         EXPLORBOT_AI_PROVIDER=openrouter EXPLORBOT_URL=https://your-app.example.com ${cli} ...
 
     Providers: ${Object.keys(PROVIDERS).join(', ')}
-  `;
-}
-
-function missingPackageMessage(error: any): string | null {
-  if (error?.code !== 'ERR_MODULE_NOT_FOUND') return null;
-
-  const specifier = error.specifier || `${error.message}`.split("'")[1];
-  if (!specifier || specifier.startsWith('.') || specifier.startsWith('/')) return null;
-
-  let segments = 1;
-  if (specifier.startsWith('@')) segments = 2;
-  const pkg = specifier.split('/').slice(0, segments).join('/');
-
-  return dedent`
-    Configuration imports "${specifier}", which is not installed.
-
-    Install it:
-      npm i ${pkg}
-
-    Or drop the import and write the model as "provider/model-id" for a provider Explorbot ships: ${Object.keys(PROVIDERS).join(', ')}
-
-    Providers: https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
   `;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -415,6 +415,8 @@ export class ConfigParser {
         process.chdir(originalCwd);
       }
       if (error instanceof ConfigMissingError) throw error;
+      const missingPackage = missingPackageMessage(error);
+      if (missingPackage) throw new Error(missingPackage);
       throw new Error(`Failed to load configuration: ${error}`);
     }
   }
@@ -773,6 +775,28 @@ export function missingConfigMessage(configFile = 'explorbot.config.js'): string
         EXPLORBOT_AI_PROVIDER=openrouter EXPLORBOT_URL=https://your-app.example.com ${cli} ...
 
     Providers: ${Object.keys(PROVIDERS).join(', ')}
+  `;
+}
+
+function missingPackageMessage(error: any): string | null {
+  if (error?.code !== 'ERR_MODULE_NOT_FOUND') return null;
+
+  const specifier = error.specifier || `${error.message}`.split("'")[1];
+  if (!specifier || specifier.startsWith('.') || specifier.startsWith('/')) return null;
+
+  let segments = 1;
+  if (specifier.startsWith('@')) segments = 2;
+  const pkg = specifier.split('/').slice(0, segments).join('/');
+
+  return dedent`
+    Configuration imports "${specifier}", which is not installed.
+
+    Install it:
+      npm i ${pkg}
+
+    Or drop the import and write the model as "provider/model-id" for a provider Explorbot ships: ${Object.keys(PROVIDERS).join(', ')}
+
+    Providers: https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
   `;
 }
 

--- a/tests/unit/global-config.test.ts
+++ b/tests/unit/global-config.test.ts
@@ -6,7 +6,7 @@ import { render } from 'ink-testing-library';
 import React from 'react';
 import InitWizard from '../../src/components/InitWizard.tsx';
 import { ApibotConfigParser } from '../../boat/api-tester/src/config.ts';
-import { runInit } from '../../src/commands/init-command.ts';
+import { runInit, runInitCommand } from '../../src/commands/init-command.ts';
 import { ConfigParser } from '../../src/config.ts';
 import { listSites, registerSite, resolveSiteTarget, siteFolderName } from '../../src/global-config.ts';
 
@@ -409,5 +409,27 @@ describe('explorbot init', () => {
       process.chdir(originalCwd);
       Object.defineProperty(process.stdin, 'isTTY', { value: originalIsTTY, configurable: true });
     }
+  });
+
+  it('scaffolds a local config that loads without installing a provider package', async () => {
+    runInitCommand({ path: workDir });
+
+    const body = readFileSync(join(workDir, 'explorbot.config.js'), 'utf8');
+    expect(body).not.toMatch(/^import /m);
+
+    const config = await ConfigParser.getInstance().loadConfig({ path: workDir });
+    expect(config.ai.model.modelId).toBe(ConfigParser.recommendedModels().openrouter.model);
+    expect(config.ai.visionModel.modelId).toBe(ConfigParser.recommendedModels().openrouter.visionModel);
+  });
+});
+
+describe('missing provider package', () => {
+  it('names the package and how to install it', async () => {
+    writeFileSync(join(workDir, 'explorbot.config.js'), "import { createFoo } from '@absent-scope/absent-provider/client';\nexport default { ai: { model: createFoo() } };\n", 'utf8');
+
+    const load = ConfigParser.getInstance().loadConfig({ path: workDir });
+
+    await expect(load).rejects.toThrow(/@absent-scope\/absent-provider\/client/);
+    await expect(load).rejects.toThrow(/npm i @absent-scope\/absent-provider$/m);
   });
 });

--- a/tests/unit/global-config.test.ts
+++ b/tests/unit/global-config.test.ts
@@ -422,14 +422,3 @@ describe('explorbot init', () => {
     expect(config.ai.visionModel.modelId).toBe(ConfigParser.recommendedModels().openrouter.visionModel);
   });
 });
-
-describe('missing provider package', () => {
-  it('names the package and how to install it', async () => {
-    writeFileSync(join(workDir, 'explorbot.config.js'), "import { createFoo } from '@absent-scope/absent-provider/client';\nexport default { ai: { model: createFoo() } };\n", 'utf8');
-
-    const load = ConfigParser.getInstance().loadConfig({ path: workDir });
-
-    await expect(load).rejects.toThrow(/@absent-scope\/absent-provider\/client/);
-    await expect(load).rejects.toThrow(/npm i @absent-scope\/absent-provider$/m);
-  });
-});


### PR DESCRIPTION
Closes #134. Replaces #141, which fixed this by telling the user to run `npm i @openrouter/ai-sdk-provider` — unnecessary, since we already ship that package.

### What happened

`npx explorbot init` in an empty directory. npx put explorbot and its dependencies in `~/.npm/_npx/<hash>/node_modules/`; the project directory got nothing. `init` wrote a config whose first line is `import { createOpenRouter } from '@openrouter/ai-sdk-provider'`. The next command called `import('file:///their-dir/explorbot.config.js')`, and Node resolved that bare specifier **from the file containing it** — their config, in their directory:

```
/their-dir/node_modules/@openrouter/ai-sdk-provider   ✗ empty dir
/their/node_modules/…                                 ✗
/node_modules/…                                       ✗
```

The npx cache is never on that chain, and neither is a `-g` install. Our copy was on their disk the whole time and unreachable from their file. `ERR_MODULE_NOT_FOUND`.

`npm i explorbot --save` hides it: npm flattens the tree and hoists our copy into `./node_modules/` next to explorbot, so the first lookup hits. It works because npm dropped our dependency in their directory, not because we declared it — pnpm and bun keep it nested and fail even with a local install.

### The fix

Stop making their file import anything. We own the config format and we load it, so the config names the model and **we** do the import, from inside our own package:

```javascript
ai: {
  // fast model with tool calling capabilities
  model: 'openrouter/openai/gpt-oss-20b:nitro',
  // vision model for screenshot analysis
  visionModel: 'openrouter/openai/gpt-5.6-luna',
  // agentic model for decision making
  agenticModel: 'openrouter/openai/gpt-5.6-luna',
}
```

`resolveModel()` splits at the first `/`, `PROVIDERS['openrouter'].load()` does `await import('@openrouter/ai-sdk-provider')` in `src/config.ts`. Nothing new — this is the form `init --global` has written since `dcc806a`, with the comment "Models are written as 'provider/model-id' so they resolve without a local node_modules." The global path was already fixed; the local template never got the same treatment. Both now share the same model lines, which also drops a stale `visionModel` the local template had drifted to.

### Still explains a real missing import

A hand-written config that imports a provider package it doesn't have gets a message instead of a stack trace:

```
Configuration imports "@openrouter/ai-sdk-provider", which is not installed.

Install it:
  npm i @openrouter/ai-sdk-provider

Or drop the import and write the model as "provider/model-id" for a provider Explorbot ships: openai, anthropic, google, groq, mistral, openrouter, sambanova

Providers: https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
```

Node and bun both report `ERR_MODULE_NOT_FOUND`, and the `.ts` require fallback surfaces it the same way, so one branch in `loadConfig`'s existing catch covers every path. Subpaths are trimmed for the install line (`zod/v4` → `npm i zod`) — a missing module is often transitive, so the message names the specifier that actually failed. Relative specifiers fall through to the generic message; `ConfigMissingError` still short-circuits ahead of it.

### Verified

`init` then `config` in a directory with no `node_modules` and no API key set, resolving all three models. `init --global` unchanged. The missing-package message renders for both `.js` and `.ts` configs. Two unit tests: the scaffolded config has no bare import and loads with resolvable models; a config importing an absent package fails with the package name and install line.

Format, lint, unit (1078) and integration (80) pass. `bun run build` fails locally, identically at `main` — a `node_modules` issue with `playwright-core` needing `chromium-bidi`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)