### PR TITLE
Stabilize AI requests and isolate tests after error pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## 2026-08-25
+
+### Configuration
+
+- **`ai.maxParallelRequests`** — How many requests to the AI model may be in flight at the same time,
+  across all agents. Additional requests wait in line instead of firing together and tripping provider
+  rate limits. Default: `4`.
+- **`ai.retryAttempts`** — Renamed from `ai.maxAttempts`, and now pairs with `ai.retryDelay` ("how
+  many times × with what pause"). If a private config still says `ai.maxAttempts`, JavaScript configs
+  will not warn — rename it manually.
+- **`ai.retryDelay`** — Declared since early on but never read; the provider now actually honors it as
+  the base pause between retries. Default: `10ms`.
+
+### Changes
+
+- [All agents] Screenshot analysis works again. Images were sent to the vision model wrapped as a data
+  URL where the AI SDK expects raw base64, so every visual call failed upstream ("Invalid image_url") —
+  in the last overnight run that was 423 failures across 37 of 61 tests, with the `see` tool never
+  succeeding once. Screenshots are now sent in the format providers accept.
+- [All agents] When the vision model fails, it is now switched off once for the whole session instead
+  of only for one tool — previously the researcher kept calling the broken vision path all night.
+- [Provider] Model calls are capped by `ai.maxParallelRequests`. In the last overnight run unlimited
+  parallelism produced bursts of up to 264 rate-limit errors per minute with tests idling through
+  retries; queued pacing replaces that storm.
+- [Provider] Models that narrate their reasoning mid-run (the gpt-oss channel format) get a sanctioned
+  no-op `commentary` tool instead of a rejected call — that rejection failed the whole generation 132
+  times in the last run. Channel-named tool calls are also repaired instead of dropped.
+- [Pilot] A check that ran successfully is no longer presented to the verdict as "PASS" evidence —
+  what it proves about the goal is what counts, so a check establishing the opposite of the goal reads
+  as failure evidence. Reading page state — a snapshot or a UI-map research — no longer counts as proof
+  the scenario completed. This removes false-green finishes.
+- [Tester] A new test now recovers from an error page left by the previous test before building its AI
+  context. When the next test has a different start URL, Tester navigates there first; genuine errors on
+  the new test's own start page are still reported normally.
+- [Analyst] The end-of-session report is now written even when the exploration loop crashes — the
+  session no longer ends silently without one.
+
 ## 2026-08-24
 
 ### Changes

--- a/explorbot.config.example.ts
+++ b/explorbot.config.example.ts
@@ -60,6 +60,7 @@ interface AIConfig {
   streaming: boolean;
   retryAttempts: number;
   retryDelay: number;
+  maxParallelRequests: number;
 }
 
 interface HtmlConfig {
@@ -189,6 +190,7 @@ const config: ExplorbotConfig = {
     streaming: true,
     retryAttempts: 3,
     retryDelay: 1000,
+    maxParallelRequests: 4,
 
     // Optional: Agent-specific model configuration
     // Each agent can override the default model

--- a/src/ai/conversation.ts
+++ b/src/ai/conversation.ts
@@ -17,6 +17,8 @@ export function toolExecutionLabel(input: Record<string, any> | undefined): stri
   return input?.explanation || input?.assertion || input?.reason || input?.request || '';
 }
 
+export const NARRATION_TOOL = 'commentary';
+
 const AUTO_COMPACT_ARIA_CHANGES_CUTOFF = 500;
 const AUTO_COMPACT_TARGETED_HTML_CUTOFF = 500;
 
@@ -227,6 +229,7 @@ export class Conversation {
       if (!Array.isArray(message.content)) continue;
       for (const part of message.content) {
         if (part.type !== 'tool-result') continue;
+        if (part.toolName === NARRATION_TOOL) continue;
         executions.push(toToolExecution(part.toolName, toolCalls.get(part.toolCallId) || {}, part.output));
       }
     }

--- a/src/ai/fisherman.ts
+++ b/src/ai/fisherman.ts
@@ -196,7 +196,7 @@ export class Fisherman implements Agent {
 
       AVAILABLE TOOLS:
       ${toolNames.join(', ')}.
-      Use tool names exactly as listed. Do not invent aliases, combined names, or names with channel markers such as "commentary".
+      Use tool names exactly as listed. Do not invent aliases or combined names.
       Match each tool input schema exactly. Do not invent parameter names or pass extra fields.
 
       WORKFLOW:

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -25,7 +25,8 @@ import { capabilityGroundingRule, dataProtectionRules } from './rules.ts';
 import { isInteractive } from './task-agent.ts';
 import { withdrawVisionTools } from './tools.ts';
 
-const CHECK_TOOLS = ['verify', 'see', 'research', 'context'];
+const CHECK_TOOLS = ['verify', 'see', 'research'];
+const EVIDENCE_TOOLS = ['verify', 'see'];
 const META_TOOLS = ['record', 'reset', 'stop', 'finish'];
 const PILOT_MESSAGE_LIMIT = 2;
 const PILOT_MESSAGE_MAX_LENGTH = 160;
@@ -326,6 +327,10 @@ export class Pilot implements Agent {
       overrides the others — weigh them together. Tester's record() notes are the LEAST reliable; always
       cross-check against actual actions and state. Visual screenshot analysis is strong for UI state
       (active tabs, visible counts, colors).
+      Judge every check by WHAT IT ESTABLISHES, never by the fact that it ran. A check that executed
+      successfully is failure evidence when its content negates the scenario goal — the goal's object
+      absent, the action not performed, the interaction impossible. "The check passed" and "the goal was
+      met" are different claims.
       If the final page clearly shows an equivalent success state in a different UI form, do not fail only
       because one narrow assertion targeted a specific badge, count, toast, or wording that the product
       represents differently.
@@ -574,8 +579,8 @@ export class Pilot implements Agent {
   }
 
   async settleExpectations(task: Test, finalState?: ActionResult): Promise<SettledExpectation[]> {
-    let image: string | null = null;
-    if (finalState?.screenshot && this.provider.hasVision()) image = `data:image/png;base64,${finalState.screenshot.toString('base64')}`;
+    let image: Buffer | null = null;
+    if (finalState?.screenshot && this.provider.hasVision()) image = finalState.screenshot;
 
     const decided = (text: string): 'passed' | 'failed' => {
       if (task.hasAchievedAny() && !task.getRemainingExpectations().includes(text)) return 'passed';
@@ -995,20 +1000,20 @@ export class Pilot implements Agent {
 
   private hasSuccessfulCheckEvidence(currentState: ActionResult, testerConversation: Conversation): boolean {
     if (Object.values(currentState.verifications ?? {}).some(Boolean)) return true;
-    return testerConversation.getToolExecutions().some((t) => CHECK_TOOLS.includes(t.toolName) && t.wasSuccessful);
+    return testerConversation.getToolExecutions().some((t) => EVIDENCE_TOOLS.includes(t.toolName) && t.wasSuccessful);
   }
 
   private formatSuccessfulAssertions(currentState: ActionResult, testerConversation: Conversation): string {
     const lines: string[] = [];
     for (const [assertion, passed] of Object.entries(currentState.verifications ?? {})) {
-      if (passed) lines.push(`PASS state verification: ${assertion}`);
+      if (passed) lines.push(`state verification (passed): ${assertion}`);
     }
 
     for (const exec of testerConversation.getToolExecutions()) {
-      if (!CHECK_TOOLS.includes(exec.toolName) || !exec.wasSuccessful) continue;
+      if (!EVIDENCE_TOOLS.includes(exec.toolName) || !exec.wasSuccessful) continue;
       const description = exec.input?.assertion || exec.input?.request || truncateJson(exec.input);
       const result = exec.output?.message || exec.output?.analysis || exec.output?.result;
-      lines.push(`PASS ${exec.toolName}: ${description}${result ? ` -> ${result}` : ''}`);
+      lines.push(`CHECK ${exec.toolName} (executed successfully): ${description}${result ? ` -> ${result}` : ''}`);
     }
 
     return [...new Set(lines)].join('\n');
@@ -1137,7 +1142,7 @@ export class Pilot implements Agent {
 
       Tester tools: click, pressKey, form, see, verify, interact, context, research, xpathCheck,
       visualClick, back, getVisitedStates, reset, stop, finish, record.
-      Use tool names exactly as listed. Do not invent combined names, aliases, or names with channel markers such as "commentary".
+      Use tool names exactly as listed. Do not invent combined names or aliases.
 
       ${capabilityGroundingRule}
 

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -28,9 +28,9 @@ const modelSlotContext = new AsyncLocalStorage<boolean>();
 
 const HARMONY_CHANNELS = ['commentary', 'analysis', 'final'];
 
-function createCommentaryTool() {
+function createHarmonyChannelFallbackTool() {
   return tool({
-    description: 'Narrate your reasoning between actions: hypotheses, plans, observations about the page. Returns nothing actionable. Never call it twice in a row — follow it with an action tool.',
+    description: 'Internal compatibility fallback for model channel output. Do not call directly.',
     inputSchema: z.record(z.string(), z.any()),
     execute: async () => ({ message: 'Noted. Continue with your next action.' }),
   });
@@ -177,7 +177,7 @@ export class Provider {
     };
   }
 
-  private async withModelSlot<T>(fn: () => Promise<T>): Promise<T> {
+  private async withModelRequestSlot<T>(fn: () => Promise<T>): Promise<T> {
     if (modelSlotContext.getStore()) return fn();
     const limit = Math.max(1, this.config.maxParallelRequests ?? DEFAULT_PARALLEL_REQUESTS);
     if (this.activeModelCalls >= limit || this.modelCallWaiters.length > 0) {
@@ -352,7 +352,7 @@ export class Provider {
 
     promptLog(messages[messages.length - 1].content);
     try {
-      const response = await this.withModelSlot(() =>
+      const response = await this.withModelRequestSlot(() =>
         withRetry(async () => {
           const result = await generateText({ messages, ...config });
           this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
@@ -394,7 +394,7 @@ export class Provider {
     setActivity(`🤖 Asking ${modelName} with dynamic tools`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
-    const toolsWithCommentary = tools?.commentary ? tools : { ...tools, commentary: createCommentaryTool() };
+    const toolsWithCommentary = tools?.commentary ? tools : { ...tools, commentary: createHarmonyChannelFallbackTool() };
     const toolNames = Object.keys(toolsWithCommentary || {});
     tag('debug').log(`Tools enabled: [${toolNames.join(', ')}]`);
     promptLog('Available tools:', toolNames);
@@ -406,7 +406,7 @@ export class Provider {
     if (extraStop) stopConditions.push(extraStop);
     const config = this.buildGenerateConfig({ tools: toolsWithCommentary, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairToolCall }, { stopWhen: stopConditions, model }, options);
     try {
-      const response = await this.withModelSlot(() =>
+      const response = await this.withModelRequestSlot(() =>
         withRetry(async () => {
           const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
           this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
@@ -459,7 +459,7 @@ export class Provider {
 
     try {
       promptLog(messages[messages.length - 1].content);
-      const response = await this.withModelSlot(() =>
+      const response = await this.withModelRequestSlot(() =>
         withRetry(async () => {
           return (await this.raceWithIdleTimeout((signal) => generateObject({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
         }, this.getRetryOptions(options))
@@ -643,7 +643,7 @@ export class Provider {
 
     try {
       promptLog(`Processing image with prompt: ${prompt}`);
-      const response = await this.withModelSlot(() =>
+      const response = await this.withModelRequestSlot(() =>
         withRetry(async () => {
           return await generateText({
             messages,

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -1,8 +1,10 @@
 import { OpenTelemetry } from '@ai-sdk/otel';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { generateObject, generateText, isStepCount, registerTelemetry } from 'ai';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { generateObject, generateText, isStepCount, registerTelemetry, tool } from 'ai';
 import type { ModelMessage } from 'ai';
+import { z } from 'zod';
 import { clearActivity, setActivity } from '../activity.ts';
 import { type AIConfig, configuredModels, modelName as getModelName } from '../config.js';
 import { executionController } from '../execution-controller.ts';
@@ -11,7 +13,7 @@ import { Stats } from '../stats.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { type RetryOptions, withRetry } from '../utils/retry.js';
 import { RulesLoader } from '../utils/rules-loader.ts';
-import { Conversation, toToolExecution } from './conversation.js';
+import { Conversation, NARRATION_TOOL, toToolExecution } from './conversation.js';
 
 const debugLog = createDebug('explorbot:provider');
 const promptLog = createDebug('explorbot:provider:out');
@@ -19,6 +21,20 @@ const responseLog = createDebug('explorbot:provider:in');
 
 class AiError extends Error {}
 export class ContextLengthError extends Error {}
+
+const DEFAULT_PARALLEL_REQUESTS = 4;
+
+const modelSlotContext = new AsyncLocalStorage<boolean>();
+
+const HARMONY_CHANNELS = ['commentary', 'analysis', 'final'];
+
+function createCommentaryTool() {
+  return tool({
+    description: 'Narrate your reasoning between actions: hypotheses, plans, observations about the page. Returns nothing actionable. Never call it twice in a row — follow it with an action tool.',
+    inputSchema: z.record(z.string(), z.any()),
+    execute: async () => ({ message: 'Noted. Continue with your next action.' }),
+  });
+}
 
 let telemetryRegistered = false;
 
@@ -79,6 +95,8 @@ export class Provider {
   };
 
   lastConversation: Conversation | null = null;
+  private activeModelCalls = 0;
+  private modelCallWaiters: (() => void)[] = [];
 
   constructor(config: AIConfig) {
     if (!config?.model) {
@@ -154,8 +172,26 @@ export class Provider {
   private getRetryOptions(options: any = {}): RetryOptions {
     return {
       ...this.defaultRetryOptions,
-      maxAttempts: options.maxRetries || this.defaultRetryOptions.maxAttempts,
+      maxAttempts: options.maxRetries || this.config.retryAttempts || this.defaultRetryOptions.maxAttempts,
+      baseDelay: this.config.retryDelay || this.defaultRetryOptions.baseDelay,
     };
+  }
+
+  private async withModelSlot<T>(fn: () => Promise<T>): Promise<T> {
+    if (modelSlotContext.getStore()) return fn();
+    const limit = Math.max(1, this.config.maxParallelRequests ?? DEFAULT_PARALLEL_REQUESTS);
+    if (this.activeModelCalls >= limit || this.modelCallWaiters.length > 0) {
+      await new Promise<void>((resolve) => this.modelCallWaiters.push(resolve));
+    } else {
+      this.activeModelCalls++;
+    }
+    try {
+      return await modelSlotContext.run(true, fn);
+    } finally {
+      const next = this.modelCallWaiters.shift();
+      if (next) next();
+      else this.activeModelCalls--;
+    }
   }
 
   private mergeProviderOptions(config: Record<string, any>, agentName?: string): Record<string, any> {
@@ -302,7 +338,7 @@ export class Provider {
     const toolResults = response.toolResults || [];
 
     const resultsById = new Map(toolResults.map((r: any) => [r.toolCallId, r]));
-    const toolExecutions = toolCalls.map((call: any) => toToolExecution(call.toolName || '', call.input, resultsById.get(call.toolCallId)?.output));
+    const toolExecutions = toolCalls.filter((call: any) => call.toolName !== NARRATION_TOOL).map((call: any) => toToolExecution(call.toolName || '', call.input, resultsById.get(call.toolCallId)?.output));
 
     return { conversation, response, toolExecutions };
   }
@@ -316,21 +352,23 @@ export class Provider {
 
     promptLog(messages[messages.length - 1].content);
     try {
-      const response = await withRetry(async () => {
-        const result = await generateText({ messages, ...config });
-        this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
-        if (!result.text) {
-          debugLog(result);
-          if (result.finishReason === 'length') {
-            throw new ContextLengthError('AI response empty: output truncated at maxTokens. Increase maxOutputTokens in config or use a model with higher output capacity.');
+      const response = await this.withModelSlot(() =>
+        withRetry(async () => {
+          const result = await generateText({ messages, ...config });
+          this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
+          if (!result.text) {
+            debugLog(result);
+            if (result.finishReason === 'length') {
+              throw new ContextLengthError('AI response empty: output truncated at maxTokens. Increase maxOutputTokens in config or use a model with higher output capacity.');
+            }
+            throw new Error('No response text from AI');
           }
-          throw new Error('No response text from AI');
-        }
-        if (result.finishReason === 'length') {
-          debugLog('finishReason=length, response may be truncated');
-        }
-        return result;
-      }, this.getRetryOptions(options));
+          if (result.finishReason === 'length') {
+            debugLog('finishReason=length, response may be truncated');
+          }
+          return result;
+        }, this.getRetryOptions(options))
+      );
 
       clearActivity();
       responseLog(response.text);
@@ -356,7 +394,8 @@ export class Provider {
     setActivity(`🤖 Asking ${modelName} with dynamic tools`, 'ai');
     promptLog(`Using model: ${modelName}`);
 
-    const toolNames = Object.keys(tools || {});
+    const toolsWithCommentary = tools?.commentary ? tools : { ...tools, commentary: createCommentaryTool() };
+    const toolNames = Object.keys(toolsWithCommentary || {});
     tag('debug').log(`Tools enabled: [${toolNames.join(', ')}]`);
     promptLog('Available tools:', toolNames);
     promptLog(messages[messages.length - 1].content);
@@ -365,17 +404,19 @@ export class Provider {
     const extraStop = options.stopWhen;
     const stopConditions: any[] = [isStepCount(maxRoundtrips)];
     if (extraStop) stopConditions.push(extraStop);
-    const config = this.buildGenerateConfig({ tools, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairToolCall }, { stopWhen: stopConditions, model }, options);
+    const config = this.buildGenerateConfig({ tools: toolsWithCommentary, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairToolCall }, { stopWhen: stopConditions, model }, options);
     try {
-      const response = await withRetry(async () => {
-        const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
-        this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
-        const hasToolCall = (result.toolCalls?.length || 0) > 0;
-        if (!result.text && !hasToolCall && result.finishReason === 'length') {
-          throw new ContextLengthError('AI response empty: output truncated at maxTokens. Increase maxOutputTokens in config or use a model with higher output capacity.');
-        }
-        return result;
-      }, this.getRetryOptions(options));
+      const response = await this.withModelSlot(() =>
+        withRetry(async () => {
+          const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
+          this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
+          const hasToolCall = (result.toolCalls?.length || 0) > 0;
+          if (!result.text && !hasToolCall && result.finishReason === 'length') {
+            throw new ContextLengthError('AI response empty: output truncated at maxTokens. Increase maxOutputTokens in config or use a model with higher output capacity.');
+          }
+          return result;
+        }, this.getRetryOptions(options))
+      );
 
       clearActivity();
 
@@ -418,9 +459,11 @@ export class Provider {
 
     try {
       promptLog(messages[messages.length - 1].content);
-      const response = await withRetry(async () => {
-        return (await this.raceWithIdleTimeout((signal) => generateObject({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
-      }, this.getRetryOptions(options));
+      const response = await this.withModelSlot(() =>
+        withRetry(async () => {
+          return (await this.raceWithIdleTimeout((signal) => generateObject({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
+        }, this.getRetryOptions(options))
+      );
 
       clearActivity();
       responseLog(response.object);
@@ -572,8 +615,6 @@ export class Provider {
 
     setActivity(`🤖 Processing image with ${this.config.visionModel}`, 'ai');
 
-    const imageData = `data:image/png;base64,${image.toString()}`;
-
     const messages: ModelMessage[] = [
       {
         role: 'user',
@@ -585,7 +626,7 @@ export class Provider {
           {
             type: 'file',
             mediaType: 'image/png',
-            data: imageData,
+            data: image,
           },
         ],
       },
@@ -602,12 +643,14 @@ export class Provider {
 
     try {
       promptLog(`Processing image with prompt: ${prompt}`);
-      const response = await withRetry(async () => {
-        return await generateText({
-          messages,
-          ...config,
-        });
-      }, this.getRetryOptions());
+      const response = await this.withModelSlot(() =>
+        withRetry(async () => {
+          return await generateText({
+            messages,
+            ...config,
+          });
+        }, this.getRetryOptions())
+      );
 
       clearActivity();
       responseLog(response.text);
@@ -623,13 +666,13 @@ export class Provider {
   }
 
   hasVision(): boolean {
-    return this.config.visionModel !== undefined;
+    return this.config.visionModel !== undefined && !Stats.visionDisabled;
   }
 }
 
 function repairToolCall(options: ToolCallRepairOptions): any | null {
   if (options.toolCall.toolName.includes('<|channel|>')) return repairChannelMarker(options);
-  return null;
+  return repairHarmonyChannel(options);
 }
 
 function repairChannelMarker({ toolCall, tools }: ToolCallRepairOptions): any | null {
@@ -639,6 +682,17 @@ function repairChannelMarker({ toolCall, tools }: ToolCallRepairOptions): any | 
   if (!tools[toolName]) return null;
   tag('warning').log(`Repaired tool name '${toolCall.toolName}' → '${toolName}'`);
   return { ...toolCall, toolName };
+}
+
+function repairHarmonyChannel({ toolCall, tools }: ToolCallRepairOptions): any | null {
+  if (!HARMONY_CHANNELS.includes(toolCall.toolName)) return null;
+  if (!tools.commentary) return null;
+  let input = toolCall.input;
+  if (typeof input !== 'string' || !input.trim().startsWith('{')) {
+    input = JSON.stringify({ content: typeof input === 'string' ? input : JSON.stringify(input ?? null) });
+  }
+  tag('warning').log(`Repaired tool name '${toolCall.toolName}' → 'commentary'`);
+  return { ...toolCall, toolName: NARRATION_TOOL, input };
 }
 
 export { AiError, Provider as AIProvider };

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -8,7 +8,7 @@ import { clearActivity, setActivity } from '../activity.ts';
 import type { RequestStore } from '../api/request-store.ts';
 import type { TestRun } from '../explorer.ts';
 import { Observability } from '../observability.ts';
-import type { StateTransition } from '../state-manager.ts';
+import { type StateTransition, normalizeUrl } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Test, TestResult, type TestResultType } from '../test-plan.ts';
 import { detectFocusArea } from '../utils/aria.ts';
@@ -100,7 +100,7 @@ export class Tester extends TaskAgent implements Agent {
 
   async test(task: Test, opts: TestOptions = {}): Promise<{ success: boolean }> {
     Stats.tests++;
-    const state = this.stateManager.getCurrentState();
+    let state = this.stateManager.getCurrentState();
     if (!state) throw new Error('No state found');
 
     setActivity(`🧪 Testing: ${task.scenario}`, 'action');
@@ -122,7 +122,21 @@ export class Tester extends TaskAgent implements Agent {
       task.addObservation(`Network error: ${r.method} ${r.path} → ${r.status}`);
     });
 
-    const initialState = ActionResult.fromState(state);
+    let initialState = ActionResult.fromState(state);
+    const currentUrl = state.fullUrl || state.url;
+    let startOnCurrentPage = opts.startOnCurrentPage;
+    if (isErrorPage(initialState) && !startOnCurrentPage && task.startUrl && normalizeUrl(currentUrl) !== normalizeUrl(task.startUrl)) {
+      debugLog(`Recovering from error page at ${currentUrl} by navigating to ${task.startUrl}`);
+      try {
+        await this.explorer.visit(task.startUrl);
+        state = this.stateManager.getCurrentState();
+        if (!state) throw new Error('No state found after navigating to test start URL');
+        initialState = ActionResult.fromState(state);
+        startOnCurrentPage = true;
+      } catch (error) {
+        debugLog(`Could not recover from error page: ${compactErrorMessage(error)}`);
+      }
+    }
     if (isErrorPage(initialState)) {
       task.start();
       this.testRun = await this.explorer.beginTest(task);
@@ -153,7 +167,7 @@ export class Tester extends TaskAgent implements Agent {
           expected: task.expected,
         },
       },
-      async () => this.runTestSession(task, initialState, conversation, { offFailedRequest }, opts)
+      async () => this.runTestSession(task, initialState, conversation, { offFailedRequest }, { ...opts, startOnCurrentPage })
     );
   }
 
@@ -481,7 +495,7 @@ export class Tester extends TaskAgent implements Agent {
       <rules>
       Use tools ${this.ACTION_TOOLS.join(', ')} to interact with the page.
       Fall back to interact() when those fail, when the step needs a sequence of actions, or when your context is not enough to locate the element.
-      Use tool names exactly as listed in this prompt. Do not invent combined tool names, aliases, or names with channel markers such as "commentary".
+      Use tool names exactly as listed in this prompt. Do not invent combined tool names or aliases.
       Match each tool input schema exactly. Do not invent parameter names or pass extra fields.
       Do not do unsuccesful clicks again.
       Do not run same tool calls with same parameters again.

--- a/src/commands/explore-command.ts
+++ b/src/commands/explore-command.ts
@@ -63,23 +63,26 @@ export class ExploreCommand extends BaseCommand {
       return;
     }
 
-    if (cfg.enabled) {
-      await this.runReuseMode(mainUrl, feature, cfg);
-    } else {
-      await this.runFreshMode(mainUrl, feature, cfg.styles);
-    }
+    try {
+      if (cfg.enabled) {
+        await this.runReuseMode(mainUrl, feature, cfg);
+      } else {
+        await this.runFreshMode(mainUrl, feature, cfg.styles);
+      }
 
-    const mainPlan = this.completedPlans[0];
-    if (mainPlan) this.explorBot.setCurrentPlan(mainPlan);
-    if (this.dryRun) {
+      const mainPlan = this.completedPlans[0];
+      if (mainPlan) this.explorBot.setCurrentPlan(mainPlan);
+      if (this.dryRun) {
+        this.printResults();
+        return;
+      }
+      if (mainUrl) await this.explorBot.visit(mainUrl).catch((err) => tag('warning').log(`Could not return to ${mainUrl}: ${browserErrorMessage(err)}`));
+      const savedPath = this.explorBot.savePlans(this.completedPlans);
       this.printResults();
-      return;
+      this.printNextSteps(savedPath);
+    } finally {
+      if (!this.dryRun) await this.explorBot.printSessionAnalysis();
     }
-    if (mainUrl) await this.explorBot.visit(mainUrl).catch((err) => tag('warning').log(`Could not return to ${mainUrl}: ${browserErrorMessage(err)}`));
-    const savedPath = this.explorBot.savePlans(this.completedPlans);
-    this.printResults();
-    await this.explorBot.printSessionAnalysis();
-    this.printNextSteps(savedPath);
   }
 
   private originLabel(test: Test): string {

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,8 +175,9 @@ interface AIConfig {
   vision?: boolean;
   visionModel?: any;
   agenticModel?: any;
-  maxAttempts?: number;
+  retryAttempts?: number;
   retryDelay?: number;
+  maxParallelRequests?: number;
   agents?: AgentsConfig;
 }
 

--- a/tests/unit/pilot-evidence.test.ts
+++ b/tests/unit/pilot-evidence.test.ts
@@ -12,7 +12,7 @@ describe('Pilot evidence', () => {
     const conversation = { getToolExecutions: () => [] };
 
     expect((pilot as any).hasSuccessfulCheckEvidence(state, conversation)).toBe(true);
-    expect((pilot as any).formatSuccessfulAssertions(state, conversation)).toContain('PASS state verification');
+    expect((pilot as any).formatSuccessfulAssertions(state, conversation)).toContain('state verification (passed)');
   });
 
   it('treats successful check tools as assertion evidence', () => {
@@ -30,7 +30,43 @@ describe('Pilot evidence', () => {
     };
 
     expect((pilot as any).hasSuccessfulCheckEvidence(state, conversation)).toBe(true);
-    expect((pilot as any).formatSuccessfulAssertions(state, conversation)).toContain('PASS verify');
+    expect((pilot as any).formatSuccessfulAssertions(state, conversation)).toContain('CHECK verify (executed successfully)');
+  });
+
+  it('does not treat context reads as completion evidence', () => {
+    const pilot = buildPilot();
+    const task = { hasAchievedAny: () => false };
+    const state = {};
+    const conversation = {
+      getToolExecutions: () => [
+        {
+          toolName: 'context',
+          wasSuccessful: true,
+          input: { reason: 'stale context' },
+          output: { message: 'Snapshot refreshed' },
+        },
+      ],
+    };
+
+    expect((pilot as any).hasCompletionEvidence(task, state, conversation)).toBe(false);
+  });
+
+  it('does not treat research reads as completion evidence', () => {
+    const pilot = buildPilot();
+    const task = { hasAchievedAny: () => false };
+    const state = {};
+    const conversation = {
+      getToolExecutions: () => [
+        {
+          toolName: 'research',
+          wasSuccessful: true,
+          input: { reason: 'need UI map' },
+          output: { analysis: 'The page shows a list of suites.' },
+        },
+      ],
+    };
+
+    expect((pilot as any).hasCompletionEvidence(task, state, conversation)).toBe(false);
   });
 
   it('treats achieved task notes as completion evidence', () => {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -7,6 +7,7 @@ import { AiError, Provider } from '../../src/ai/provider.js';
 import { ConfigParser } from '../../src/config.js';
 import type { AIConfig } from '../../src/config.js';
 import { executionController } from '../../src/execution-controller.js';
+import { Stats } from '../../src/stats.js';
 import { MockAIProvider } from '../mocks/ai-provider.mock.js';
 
 function buildHangingModel(capture: { signal?: AbortSignal }): MockLanguageModelV3 {
@@ -67,6 +68,7 @@ describe('Provider', () => {
 
   afterEach(() => {
     mockAI.reset();
+    Stats.visionDisabled = false;
   });
 
   describe('constructor', () => {
@@ -171,6 +173,131 @@ describe('Provider', () => {
       expect(response.toolCalls?.[0]?.invalid).toBe(true);
       expect(response.toolResults?.length ?? 0).toBe(0);
     });
+
+    it('should inject a commentary tool into every toolset', async () => {
+      const messages = [{ role: 'user', content: 'Hello' }];
+      let toolNames: string[] = [];
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'tools-list-model',
+        doGenerate: async (params: any) => {
+          toolNames = params.tools.map((t: any) => t.name);
+          return { text: 'ok', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'ok' }] };
+        },
+      });
+
+      await provider.generateWithTools(messages, model, { click: tool({ description: 'Click', inputSchema: z.object({}) }) });
+
+      expect(toolNames).toContain('commentary');
+    });
+
+    it('should repair bare harmony channel tool calls to commentary', async () => {
+      const messages = [{ role: 'user', content: 'Use a tool' }];
+      const tools = {
+        click: tool({
+          description: 'Click an element',
+          inputSchema: z.object({ commands: z.array(z.string()) }),
+          execute: async () => ({ success: true }),
+        }),
+      };
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'harmony-model',
+        doGenerate: async () => ({
+          text: undefined,
+          toolCalls: [{ toolCallId: 'call-1', toolName: 'analysis', args: { content: 'planning' } }],
+          finishReason: 'tool-calls' as const,
+          usage: { inputTokens: 1, outputTokens: 1 },
+          content: [{ type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'analysis', input: 'I should click the submit button next' }],
+        }),
+      });
+
+      const response = await provider.generateWithTools(messages, model, tools);
+
+      expect(response.toolCalls?.[0]?.toolName).toBe('commentary');
+      expect(response.toolResults?.[0]?.output).toEqual({ message: 'Noted. Continue with your next action.' });
+    });
+
+    it('should not deadlock when a tool execution calls back into the provider', async () => {
+      aiConfig.maxParallelRequests = 1;
+      const limited = new Provider(aiConfig);
+      let innerText = '';
+      const innerModel = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'inner-model',
+        doGenerate: async () => ({ text: 'inner ok', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'inner ok' }] }),
+      });
+      const tools = {
+        verify: tool({
+          description: 'Verify an assertion',
+          inputSchema: z.object({ assertion: z.string() }),
+          execute: async () => {
+            const res = await limited.chat([{ role: 'user', content: 'inner question' }], innerModel);
+            innerText = res.text;
+            return { success: true };
+          },
+        }),
+      };
+      let roundtrip = 0;
+      const outerModel = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'outer-model',
+        doGenerate: async () => {
+          roundtrip++;
+          if (roundtrip === 1) {
+            return {
+              text: undefined,
+              toolCalls: [{ toolCallId: 'call-1', toolName: 'verify', args: { assertion: 'x' } }],
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 1, outputTokens: 1 },
+              content: [{ type: 'tool-call' as const, toolCallId: 'call-1', toolName: 'verify', input: '{"assertion":"x"}' }],
+            };
+          }
+          return { text: 'done', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'done' }] };
+        },
+      });
+
+      const response = await limited.generateWithTools([{ role: 'user', content: 'go' }], outerModel, tools);
+
+      expect(response.text).toBe('done');
+      expect(innerText).toBe('inner ok');
+      expect(response.toolResults?.[0]?.output).toEqual({ success: true });
+    });
+  });
+
+  describe('processImage', () => {
+    it('should send raw base64 image data, not a data URL', async () => {
+      let capturedParts: any[] = [];
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'vision-model',
+        doGenerate: async (params: any) => {
+          capturedParts = params.prompt[0].content;
+          return { text: 'a picture', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'a picture' }] };
+        },
+      });
+      aiConfig.visionModel = model;
+      const visionProvider = new Provider(aiConfig);
+
+      const response = await visionProvider.processImage('What is here?', Buffer.from('fakepng').toString('base64'));
+
+      expect(response.text).toBe('a picture');
+      const filePart = capturedParts.find((p) => p.type === 'file');
+      expect(filePart).toBeDefined();
+      const raw = filePart.data?.type === 'data' ? filePart.data.data : filePart.data;
+      expect(raw).toBe(Buffer.from('fakepng').toString('base64'));
+    });
+  });
+
+  describe('vision availability', () => {
+    it('should report vision disabled after a vision failure', () => {
+      aiConfig.visionModel = mockAI.getModel();
+      const visionProvider = new Provider(aiConfig);
+      expect(visionProvider.hasVision()).toBe(true);
+
+      Stats.visionDisabled = true;
+      expect(visionProvider.hasVision()).toBe(false);
+    });
   });
 
   describe('retry functionality', () => {
@@ -190,6 +317,39 @@ describe('Provider', () => {
       mockAI.setFailure(true, 5);
 
       await expect(provider.chat(messages, mockAI.getModel(), { maxRetries: 2 })).rejects.toThrow(AiError);
+    });
+
+    it('should honor configured retry attempts and delay', () => {
+      aiConfig.retryAttempts = 7;
+      aiConfig.retryDelay = 250;
+      const configured = new Provider(aiConfig);
+
+      const opts = (configured as any).getRetryOptions();
+
+      expect(opts.maxAttempts).toBe(7);
+      expect(opts.baseDelay).toBe(250);
+    });
+  });
+
+  describe('model call concurrency', () => {
+    it('should serialize model calls when maxParallelRequests is 1', async () => {
+      aiConfig.maxParallelRequests = 1;
+      const limited = new Provider(aiConfig);
+      const events: string[] = [];
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'slow-model',
+        doGenerate: async () => {
+          events.push('start');
+          await new Promise((resolve) => setTimeout(resolve, 30));
+          events.push('end');
+          return { text: 'ok', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'ok' }] };
+        },
+      });
+
+      await Promise.all([limited.chat([{ role: 'user', content: 'a' }], model), limited.chat([{ role: 'user', content: 'b' }], model)]);
+
+      expect(events).toEqual(['start', 'end', 'start', 'end']);
     });
   });
 

--- a/tests/unit/tester-error-page.test.ts
+++ b/tests/unit/tester-error-page.test.ts
@@ -31,6 +31,62 @@ function createConversation() {
 }
 
 describe('Tester error page handling', () => {
+  test('recovers from an error page left by the previous test before creating context', async () => {
+    let currentState = createState('Unauthorized', '<html><body>Not authorized</body></html>', '/basic_auth', 401);
+    const startConversation = mock(() => createConversation());
+    const visit = mock(async () => {
+      currentState = createState('Catalog', '<html><body>Demo catalog</body></html>', '/');
+    });
+    const stopTest = mock(async () => {});
+    const startTest = mock(async () => ({ started: false, stop: stopTest }));
+
+    const explorer: any = {
+      beginTest: startTest,
+      visit,
+    };
+    const provider: any = {
+      getSystemPromptForAgent: () => '',
+      startConversation,
+      invokeConversation: mock(async () => null),
+    };
+    const researcher: any = {
+      research: mock(async () => ''),
+      researchOverlay: mock(async () => null),
+    };
+    const navigator: any = {};
+    const deps: any = {
+      explorer,
+      ai: provider,
+      config: {},
+      stateManager: {
+        getCurrentState: () => currentState,
+        clearHistory: () => {},
+        otherTabs: [],
+        getExperienceTracker: () => ({
+          getExperienceTableOfContents: () => [],
+          renderExperienceFor: () => '',
+          renderExperienceTocFor: () => '',
+        }),
+      },
+      knowledgeTracker: {
+        getRelevantKnowledge: () => [],
+        renderRelevantKnowledge: () => '',
+        renderRelevantContext: () => '',
+      },
+      requestStore: { clear: () => {}, onFailedRequest: () => () => {}, getFailedRequests: () => [] },
+      playwrightRecorder: {},
+    };
+    const tester = new Tester(deps, researcher, navigator);
+    const task = new Test('open catalog item', 'normal', 'item opens', '/');
+
+    await tester.test(task);
+
+    expect(visit).toHaveBeenCalledTimes(1);
+    expect(visit).toHaveBeenCalledWith('/');
+    expect(startConversation).toHaveBeenCalledTimes(1);
+    expect(Object.values(task.notes).some((note) => note.message.includes('Error page detected'))).toBe(false);
+  });
+
   test('stops before creating a conversation when current page is already an error page', async () => {
     const currentState = createState('500 Internal Server Error', '<html><body><h1>500 Internal Server Error</h1></body></html>', '/broken');
     const startConversation = mock(() => createConversation());


### PR DESCRIPTION
## Summary

  Improves AI request reliability, restores vision processing, makes Pilot verdicts more evidence-based, and prevents an error page left by one test from incorrectly failing the following tests.

  ## Changes

  - Limit concurrent AI requests through `ai.maxParallelRequests` to reduce provider rate-limit bursts.
  - Honor `ai.retryAttempts` and `ai.retryDelay` configuration.
  - Rename the obsolete `ai.maxAttempts` AI setting to `ai.retryAttempts`.
  - Send screenshots to vision models in the format expected by the AI SDK.
  - Disable vision for the rest of the session after a vision failure to avoid repeated failing requests.
  - Support model narration through a no-op `commentary` tool.
  - Repair Harmony channel-style tool calls instead of rejecting the whole generation.
  - Exclude narration calls from recorded tool execution evidence.
  - Prevent successful context and research calls from being treated as proof that a test goal was achieved.
  - Clarify Pilot evidence so a successfully executed check can still prove that the scenario failed.
  - Recover from an error page left by the previous test before building context for the next test.
  - Preserve genuine error reporting when the new test’s own start page is an error page.
  - Always generate the session analysis report, including when exploration exits with an error.