### PR TITLE
Keep every step of a tool turn in the conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-08-26
+
+### Changes
+
+- [Tester] The Tester now remembers every action it took, not only the last one of each turn. When it
+  did several things in one turn — click, click, then check — everything but the final action was
+  dropped from its memory straight afterwards, so it re-clicked buttons it had already clicked and
+  re-checked things it had already confirmed.
+- [Pilot] The Pilot now sees the full list of actions and checks when it decides whether a test
+  passed. Because most of the Tester's steps were being lost, it often had two lines of activity to
+  judge from and failed tests that had in fact succeeded, or kept sending the Tester back to prove
+  something it had already proven.
+- [Historian] Generated test files now contain every recorded step instead of one step per turn.
+
 ## 2026-08-23
 
 ### Changes

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -288,7 +288,7 @@ export class Provider {
   async invokeConversation(conversation: Conversation, tools?: any, options: any = {}): Promise<{ conversation: Conversation; response: any; toolExecutions?: any[] } | null> {
     const response = tools ? await this.generateWithTools(conversation.messages, conversation.model, tools, options) : await this.chat(conversation.messages, conversation.model, options);
 
-    const responseMessages = response.response?.messages || [];
+    const responseMessages = response.responseMessages || [];
     if (responseMessages.length > 0) {
       conversation.messages.push(...responseMessages);
       tag('debug').log('Added', responseMessages.length, 'messages from response');


### PR DESCRIPTION
## What went wrong

Session [`LivingReliablePlum672`](https://cloud.langfuse.com) — scenario *"Star the visible ExportSuite suite and verify it is included by the Starred quick filter"* — **actually succeeded**: the star was clicked, the Starred tab rendered `Starred 1`, and `verify('ExportSuite appears in the filtered suite tree')` passed. The Pilot rejected `finish` three times and then voted `fail`, burning ~4 minutes on 6 `click`, 8 `verify` and 4 `finish` calls.

At every verdict the Pilot's `<session_log>` was two lines long and `<successful_assertions>` held a single entry, while `<notes>` — written straight to the Test by the tools — clearly recorded `PASSED Verification passed: ExportSuite appears in the filtered suite tree`. The Pilot was right on the evidence it had; it just never got the evidence.

## Root cause

`invokeConversation` appended `response.response?.messages` back into the conversation. In AI SDK 7 that getter is `finalStep.response` — **the last step only**:

```js
get response() { return this.finalStep.response; }
get responseMessages() { return [...this.initialResponseMessages, ...this.steps.flatMap(s => s.response.messages)]; }
```

So a turn that called three tools kept only the third one's messages. The trace matches with no anomalies:

| turn | steps | survived in the conversation |
|---|---|---|
| 00:32:07 | click, click, hover | `hover` |
| 00:32:31 | click, click, record | `record` (meta tool, filtered from the log) |
| 00:33:25 | click, verify(tree), verify(tab) | `verify(tab)` |

That is exactly the two-line session log the Pilot saw.

## Fix

One line in `src/ai/provider.ts:291`:

```diff
-    const responseMessages = response.response?.messages || [];
+    const responseMessages = response.responseMessages || [];
```

`responseMessages` is chronological, so the conversation tail is unchanged. The `Tool choice is required` fallback at `provider.ts:396` has neither key, so it still yields `[]`.

## Why one line is enough

Everything downstream reads `conversation.getToolExecutions()`, so the same amnesia produced three separate symptoms:

- **Tester** re-clicked buttons and re-verified claims because its own earlier steps were gone from its context.
- **Pilot** built `session_log`, `successful_assertions` and `analyzeProgress` from one tool per turn, so it read genuine success as missing evidence.
- **Historian** generates the CodeceptJS file from the same source, so recorded tests were losing most of their steps.

No prompt change could fix this — the evidence was physically absent from the conversation.

## Trade-off

Conversations grow faster: every intermediate tool result now stays in context instead of one per turn, so tokens per test rise and `compactToolResults(2)` / `cleanupTag` carry more of the load.

## Testing

- `bun test tests/unit/` — 1076 pass, 0 fail
- `bun test tests/integration/` — 80 pass, 1 skip, 0 fail
- `bun run format`, `bun run lint` — clean

Worth a regression run before merge, since the effect is on live agent behaviour rather than anything a unit test observes.

## Follow-up, not in this PR

`CHECKED: none` persisted through every verdict of that session: `Test.getCheckedExpectations()` (`src/test-plan.ts:299`) matches a note only when `note.message` equals the expectation string verbatim, and `record()` notes are free-form. Separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)