### PR TITLE
make run endings visible in Langfuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-26
+
+### Changes
+
+- [Provider] Langfuse traces now survive the end of a run. The telemetry batch was never flushed
+  on exit, so every session looked abruptly cut off in Langfuse — final actions and the
+  session-analysis traces never arrived, and a clean shutdown was indistinguishable from a crash.
+  All exit paths (CLI commands and their error branches, TUI `/exit`, Ctrl+C, SIGTERM) now flush
+  pending traces before the process exits.
+
 ## 2026-08-25
 
 ### Configuration

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -9,6 +9,7 @@ import { render } from 'ink';
 import React from 'react';
 import { App } from '../src/components/App.js';
 import { StatusPane } from '../src/components/StatusPane.js';
+import { flushTelemetry } from '../src/ai/provider.js';
 import { ConfigParser, EXPLORBOT_ENV_VARS, PROVIDERS } from '../src/config.js';
 import { ExplorBot, type ExplorBotOptions } from '../src/explorbot.js';
 import { remote } from '../src/remote.js';
@@ -103,9 +104,7 @@ async function startTUI(explorBot: ExplorBot): Promise<void> {
 async function showStatsAndExit(code: number): Promise<never> {
   if (remote.isAttached()) {
     await remote.close(code);
-    process.exit(code);
-  }
-  if (Stats.hasActivity()) {
+  } else if (Stats.hasActivity()) {
     await new Promise<void>((resolve) => {
       const { unmount } = render(
         React.createElement(StatusPane, {
@@ -121,6 +120,7 @@ async function showStatsAndExit(code: number): Promise<never> {
       );
     });
   }
+  await flushTelemetry();
   process.exit(code);
 }
 

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -37,6 +37,15 @@ function createHarmonyChannelFallbackTool() {
 }
 
 let telemetryRegistered = false;
+let beforeExitFlushHooked = false;
+let activeOtelSdk: NodeSDK | null = null;
+
+export async function flushTelemetry(): Promise<void> {
+  const sdk = activeOtelSdk;
+  activeOtelSdk = null;
+  if (!sdk) return;
+  await sdk.shutdown().catch((error) => debugLog(`Telemetry flush failed: ${error instanceof Error ? error.message : error}`));
+}
 
 const CONTEXT_LENGTH_PATTERNS = ['reduce the length', 'context length', 'maximum context', 'token limit', 'too many tokens', 'max_tokens', 'context_length_exceeded', 'output truncated at maxtokens'];
 
@@ -115,6 +124,10 @@ export class Provider {
     } catch (error: any) {
       throw new AiError(`AI connection failed: ${error.message}`);
     }
+  }
+
+  async stop(): Promise<void> {
+    await flushTelemetry();
   }
 
   getModelForAgent(agentName?: string): any {
@@ -270,7 +283,12 @@ export class Provider {
       spanProcessors: [processor],
       instrumentations: [],
     });
+    activeOtelSdk = this.otelSdk;
     void this.otelSdk.start();
+    if (!beforeExitFlushHooked) {
+      process.on('beforeExit', () => void flushTelemetry());
+      beforeExitFlushHooked = true;
+    }
     if (!telemetryRegistered) {
       registerTelemetry(new OpenTelemetry());
       telemetryRegistered = true;

--- a/src/commands/exit-command.ts
+++ b/src/commands/exit-command.ts
@@ -11,7 +11,7 @@ export class ExitCommand extends BaseCommand {
 
   async execute(_args: string): Promise<void> {
     await this.explorBot.printSessionAnalysis();
-    await this.explorBot.getExplorer().stop();
+    await this.explorBot.stop();
 
     if (Stats.hasActivity()) {
       await new Promise<void>((resolve) => {

--- a/src/explorbot.ts
+++ b/src/explorbot.ts
@@ -142,6 +142,7 @@ export class ExplorBot {
   async stop(): Promise<void> {
     this.agents.quartermaster?.stop();
     await this.explorer?.stop();
+    await this.provider?.stop();
   }
 
   async visitInitialState(): Promise<void> {


### PR DESCRIPTION
 ## Problem

Runs ended abruptly in Langfuse — no final traces, no way to tell a clean exit from a crash. The OTEL telemetry batch was never flushed on process exit.

  ## Change

  Flush the telemetry batch before exit, wired into every exit path (CLI success and error branches, TUI `/exit`, Ctrl+C, SIGTERM, plus a `beforeExit` safety net). No AI/retry/prompt logic touched; flush failures cannot block exit.