### PR TITLE
Detect unmarked modals at capture so the Tester scopes interactions i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-26
+
+### Changes
+
+- [Tester] Unmarked modals are now detected at capture time. Apps whose dialogs carry no
+  `role="dialog"`/`aria-modal` markup were invisible to focus-area detection, so the Tester never
+  learned it was inside a modal and interacted with the page behind it. Each state capture now
+  probes the live DOM for overlays the way the Driller does, and the state carries a modal
+  descriptor (`overlay`) that the Tester, Pilot and Researcher read instead of re-deriving it.
+  Class-name matches are only trusted when the element is truly floating (`fixed`/`absolute`/z-index),
+  so a sticky header named "overlay" does not become a false focus scope, and the expensive
+  full-page geometry scan is not run on every action — it stays in the Driller, where it belongs.
+
 ## 2026-08-25
 
 ### Configuration

--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -2,11 +2,12 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { ConfigParser, type HtmlConfig, outputPath } from './config.ts';
 import type { Link, WebPageState } from './state-manager.ts';
-import { type FocusAreaResult, LARGE_ARIA_CHANGE_THRESHOLD, compactAriaSnapshot, detectFocusArea, diffAriaSnapshots } from './utils/aria.ts';
+import { LARGE_ARIA_CHANGE_THRESHOLD, compactAriaSnapshot, diffAriaSnapshots } from './utils/aria.ts';
 import { TTLCache } from './utils/cache.ts';
 import { type HtmlDiffPart, type HtmlDiffResult, htmlDiff, liveRegionMessages } from './utils/html-diff.ts';
 import { extractHeadings, extractLinks, extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, minifyHtml } from './utils/html.ts';
 import { createDebug } from './utils/logger.ts';
+import { Overlay } from './utils/overlay.ts';
 import { slugify } from './utils/strings.ts';
 import { extractStatePath, matchesUrl } from './utils/url-matcher.ts';
 
@@ -87,7 +88,7 @@ export class ActionResult implements ActionResultData {
   notes: string[] = [];
   public links: Link[] = [];
   public verifications?: Record<string, boolean>;
-  public overlay: FocusAreaResult = { detected: false, type: null, name: null };
+  public overlay: Overlay = new Overlay();
 
   constructor(data: ActionResultData) {
     this.id = data.id;
@@ -133,13 +134,7 @@ export class ActionResult implements ActionResultData {
       this._ariaSnapshot = data.ariaSnapshot;
     }
 
-    if (data.overlayHtml) {
-      const headings = extractHeadings(data.overlayHtml);
-      const name = [headings.h1, headings.h2, headings.h3, headings.h4].filter(Boolean).join(' ');
-      this.overlay = { detected: true, type: 'modal', name: name || null };
-    } else {
-      this.overlay = data.overlay ?? detectFocusArea(data.ariaSnapshot ?? null);
-    }
+    this.overlay = Overlay.resolve(data);
 
     if (!this.fullUrl && this.url) {
       this.fullUrl = this.url;

--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import { join } from 'node:path';
 import { ConfigParser, type HtmlConfig, outputPath } from './config.ts';
 import type { Link, WebPageState } from './state-manager.ts';
-import { LARGE_ARIA_CHANGE_THRESHOLD, compactAriaSnapshot, diffAriaSnapshots } from './utils/aria.ts';
+import { type FocusAreaResult, LARGE_ARIA_CHANGE_THRESHOLD, compactAriaSnapshot, detectFocusArea, diffAriaSnapshots } from './utils/aria.ts';
 import { TTLCache } from './utils/cache.ts';
 import { type HtmlDiffPart, type HtmlDiffResult, htmlDiff, liveRegionMessages } from './utils/html-diff.ts';
 import { extractHeadings, extractLinks, extractTargetedHtml, htmlCombinedSnapshot, htmlMinimalUISnapshot, htmlTextSnapshot, minifyHtml } from './utils/html.ts';
@@ -34,6 +34,7 @@ interface ActionResultData extends WebPageState {
   focusedElement?: FocusedElement | null;
   iframeURL?: string;
   links?: Link[];
+  overlayHtml?: string;
 }
 
 export interface PageDiff {
@@ -86,6 +87,7 @@ export class ActionResult implements ActionResultData {
   notes: string[] = [];
   public links: Link[] = [];
   public verifications?: Record<string, boolean>;
+  public overlay: FocusAreaResult = { detected: false, type: null, name: null };
 
   constructor(data: ActionResultData) {
     this.id = data.id;
@@ -129,6 +131,14 @@ export class ActionResult implements ActionResultData {
     }
     if (data.ariaSnapshot !== undefined) {
       this._ariaSnapshot = data.ariaSnapshot;
+    }
+
+    if (data.overlayHtml) {
+      const headings = extractHeadings(data.overlayHtml);
+      const name = [headings.h1, headings.h2, headings.h3, headings.h4].filter(Boolean).join(' ');
+      this.overlay = { detected: true, type: 'modal', name: name || null };
+    } else {
+      this.overlay = data.overlay ?? detectFocusArea(data.ariaSnapshot ?? null);
     }
 
     if (!this.fullUrl && this.url) {

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,7 +11,7 @@ import { Observability } from './observability.ts';
 import type { PlaywrightRecorder } from './playwright-recorder.ts';
 import type { StateManager } from './state-manager.js';
 import { browserErrorMessage, isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
-import { captureHtmlForSnapshot, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
+import { HTML_EXTRACTION_LIMITS, HTML_SELECTORS, HTML_VISIBILITY_LIMITS, captureHtmlForSnapshot, getVisibleOverlayHtmlExtractorSource, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
 import { createDebug, setStepSpanParent, tag } from './utils/logger.js';
 import { sleep, waitForPageReadiness } from './utils/page-readiness.ts';
 import { safeFilename } from './utils/strings.ts';
@@ -144,11 +144,31 @@ class Action {
       let ariaSnapshot: string | null = null;
       let ariaSnapshotFile: string | undefined = undefined;
       let focusedElement: FocusedElement | null = null;
+      let overlayHtml = '';
 
       try {
         const page = this.playwrightHelper.page;
         ariaSnapshot = await page.locator('body').ariaSnapshot();
         focusedElement = await page.evaluate(readFocusedElement);
+        if (!frame) {
+          overlayHtml = await page.evaluate(
+            ({ extractorSource, config }) => {
+              const extract = new Function(`return ${extractorSource}`)() as (config: any) => string;
+              return extract(config);
+            },
+            {
+              extractorSource: getVisibleOverlayHtmlExtractorSource(),
+              config: {
+                interactiveContentSelector: HTML_SELECTORS.interactiveContent,
+                limits: HTML_EXTRACTION_LIMITS,
+                overlaySelectors: HTML_SELECTORS.modalOverlays,
+                overlaySemanticSelector: HTML_SELECTORS.overlaySemanticSelector,
+                visibilityLimits: HTML_VISIBILITY_LIMITS,
+                geometryFallback: false,
+              },
+            }
+          );
+        }
       } catch (err) {
         debugLog('ARIA snapshot failed:', err instanceof Error ? `${err.message}\n${err.stack}` : err);
       }
@@ -177,6 +197,7 @@ class Action {
         ariaSnapshot,
         ariaSnapshotFile,
         focusedElement,
+        overlayHtml: overlayHtml || undefined,
         iframeURL: frame ? frame.url?.() || 'iframe' : undefined,
       });
       this.stateManager.updateState(result, codeBlock);

--- a/src/action.ts
+++ b/src/action.ts
@@ -11,8 +11,9 @@ import { Observability } from './observability.ts';
 import type { PlaywrightRecorder } from './playwright-recorder.ts';
 import type { StateManager } from './state-manager.js';
 import { browserErrorMessage, isFatalBrowserError, isNavigationTransitionError } from './utils/browser-errors.ts';
-import { HTML_EXTRACTION_LIMITS, HTML_SELECTORS, HTML_VISIBILITY_LIMITS, captureHtmlForSnapshot, getVisibleOverlayHtmlExtractorSource, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
+import { captureHtmlForSnapshot, getVisibleOverlayHtmlExtractorSource, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
 import { createDebug, setStepSpanParent, tag } from './utils/logger.js';
+import { Overlay } from './utils/overlay.js';
 import { sleep, waitForPageReadiness } from './utils/page-readiness.ts';
 import { safeFilename } from './utils/strings.ts';
 import { codeceptJSSandbox, hasPlaywrightCommands, playwrightSandbox, sanitizeCodeBlock } from './utils/web-sandbox.ts';
@@ -150,25 +151,7 @@ class Action {
         const page = this.playwrightHelper.page;
         ariaSnapshot = await page.locator('body').ariaSnapshot();
         focusedElement = await page.evaluate(readFocusedElement);
-        if (!frame) {
-          overlayHtml = await page.evaluate(
-            ({ extractorSource, config }) => {
-              const extract = new Function(`return ${extractorSource}`)() as (config: any) => string;
-              return extract(config);
-            },
-            {
-              extractorSource: getVisibleOverlayHtmlExtractorSource(),
-              config: {
-                interactiveContentSelector: HTML_SELECTORS.interactiveContent,
-                limits: HTML_EXTRACTION_LIMITS,
-                overlaySelectors: HTML_SELECTORS.modalOverlays,
-                overlaySemanticSelector: HTML_SELECTORS.overlaySemanticSelector,
-                visibilityLimits: HTML_VISIBILITY_LIMITS,
-                geometryFallback: false,
-              },
-            }
-          );
-        }
+        if (!frame) overlayHtml = await this.captureOverlayHtml();
       } catch (err) {
         debugLog('ARIA snapshot failed:', err instanceof Error ? `${err.message}\n${err.stack}` : err);
       }
@@ -209,6 +192,16 @@ class Action {
       const url = this.playwrightHelper.page?.url?.() || '';
       return new ActionResult({ url, error: msg });
     }
+  }
+
+  private async captureOverlayHtml(): Promise<string> {
+    return this.playwrightHelper.page.evaluate(
+      ({ extractorSource, config }: { extractorSource: string; config: any }) => {
+        const extract = new Function(`return ${extractorSource}`)() as (config: any) => string;
+        return extract(config);
+      },
+      { extractorSource: getVisibleOverlayHtmlExtractorSource(), config: Overlay.captureConfig() }
+    );
   }
 
   private async captureMainDocumentStatus(): Promise<number | undefined> {

--- a/src/ai/driller.ts
+++ b/src/ai/driller.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/html.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop, pause } from '../utils/loop.ts';
+import { OVERLAY_SELECTORS } from '../utils/overlay.ts';
 import { annotatePageElements } from '../utils/web-annotate.ts';
 import { eidxInContainer } from '../utils/web-eidx.ts';
 import { WebElement } from '../utils/web-element.ts';
@@ -682,8 +683,8 @@ export class Driller extends TaskAgent implements Agent {
           config: {
             interactiveContentSelector: HTML_SELECTORS.interactiveContent,
             limits: HTML_EXTRACTION_LIMITS,
-            overlaySelectors: HTML_SELECTORS.semanticOverlays,
-            overlaySemanticSelector: HTML_SELECTORS.overlaySemanticSelector,
+            overlaySelectors: OVERLAY_SELECTORS.semanticOverlays,
+            overlaySemanticSelector: OVERLAY_SELECTORS.overlaySemanticSelector,
             visibilityLimits: HTML_VISIBILITY_LIMITS,
           },
         }

--- a/src/ai/driller.ts
+++ b/src/ai/driller.ts
@@ -683,6 +683,7 @@ export class Driller extends TaskAgent implements Agent {
             interactiveContentSelector: HTML_SELECTORS.interactiveContent,
             limits: HTML_EXTRACTION_LIMITS,
             overlaySelectors: HTML_SELECTORS.semanticOverlays,
+            overlaySemanticSelector: HTML_SELECTORS.overlaySemanticSelector,
             visibilityLimits: HTML_VISIBILITY_LIMITS,
           },
         }

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -9,7 +9,7 @@ import type { PlaywrightRecorder } from '../playwright-recorder.ts';
 import type { StateManager } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Test, TestResult } from '../test-plan.ts';
-import { collectInteractiveNodes, detectFocusArea } from '../utils/aria.ts';
+import { collectInteractiveNodes } from '../utils/aria.ts';
 import { ErrorPageError } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 
@@ -824,7 +824,7 @@ export class Pilot implements Agent {
     lines.push(`h3: ${state.h3 || ''}`);
     lines.push(`h4: ${state.h4 || ''}`);
 
-    const focusArea = detectFocusArea(state.ariaSnapshot);
+    const focusArea = state.overlay;
     if (focusArea.detected) {
       lines.push(`modal: ${focusArea.name || focusArea.type}`);
     } else {

--- a/src/ai/researcher/deep-analysis.ts
+++ b/src/ai/researcher/deep-analysis.ts
@@ -5,7 +5,7 @@ import { executionController } from '../../execution-controller.ts';
 import type Explorer from '../../explorer.ts';
 import type { StateManager } from '../../state-manager.js';
 import { WebPageState } from '../../state-manager.js';
-import { detectFocusArea, diffAriaSnapshots } from '../../utils/aria.ts';
+import { diffAriaSnapshots } from '../../utils/aria.ts';
 import { extractCodeBlocks } from '../../utils/code-extractor.ts';
 import { tag } from '../../utils/logger.js';
 import { mdq } from '../../utils/markdown-query.ts';
@@ -86,7 +86,7 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
     }
 
     async researchOverlay(current: ActionResult, previous: ActionResult, pageStateHash: string): Promise<string | null> {
-      const focusArea = detectFocusArea(current.ariaSnapshot);
+      const focusArea = current.overlay;
       if (!focusArea.detected || !focusArea.name) return null;
       if (focusArea.type !== 'dialog' && focusArea.type !== 'modal') return null;
 

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -11,7 +11,6 @@ import { Observability } from '../observability.ts';
 import { type StateTransition, normalizeUrl } from '../state-manager.ts';
 import { Stats } from '../stats.ts';
 import { type Test, TestResult, type TestResultType } from '../test-plan.ts';
-import { detectFocusArea } from '../utils/aria.ts';
 import { ErrorPageError, isErrorPage } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.ts';
 import { loop } from '../utils/loop.ts';
@@ -531,7 +530,7 @@ export class Tester extends TaskAgent implements Agent {
 
     let context = '';
 
-    const focusArea = detectFocusArea(currentState.ariaSnapshot);
+    const focusArea = currentState.overlay;
 
     const focusedElement = currentState.focusedElement;
     if (focusedElement) {

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -1,8 +1,8 @@
 import { ActionResult, type FocusedElement } from './action-result.js';
 import type { ExperienceTracker } from './experience-tracker.js';
 import type { Knowledge, KnowledgeTracker } from './knowledge-tracker.js';
-import { type FocusAreaResult, detectFocusArea } from './utils/aria.js';
 import { createDebug, tag } from './utils/logger.js';
+import { Overlay } from './utils/overlay.js';
 import { slugify } from './utils/strings.js';
 import { extractStatePath } from './utils/url-matcher.js';
 
@@ -49,7 +49,7 @@ export interface WebPageState {
   focusedElement?: FocusedElement | null;
   links?: Link[];
   verifications?: Record<string, boolean>;
-  overlay?: FocusAreaResult;
+  overlay?: Overlay;
 }
 
 export interface StateTransition {
@@ -207,8 +207,8 @@ export class StateManager {
   }
 
   private hasDialogAppeared(previousState: WebPageState | null, newState: WebPageState): boolean {
-    const prevFocus = previousState?.overlay ?? detectFocusArea(previousState?.ariaSnapshot ?? null);
-    const newFocus = newState.overlay ?? detectFocusArea(newState.ariaSnapshot ?? null);
+    const prevFocus = previousState?.overlay ?? Overlay.fromAria(previousState?.ariaSnapshot ?? null);
+    const newFocus = newState.overlay ?? Overlay.fromAria(newState.ariaSnapshot ?? null);
     return !prevFocus.detected && newFocus.detected;
   }
 

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -1,7 +1,7 @@
 import { ActionResult, type FocusedElement } from './action-result.js';
 import type { ExperienceTracker } from './experience-tracker.js';
 import type { Knowledge, KnowledgeTracker } from './knowledge-tracker.js';
-import { detectFocusArea } from './utils/aria.js';
+import { type FocusAreaResult, detectFocusArea } from './utils/aria.js';
 import { createDebug, tag } from './utils/logger.js';
 import { slugify } from './utils/strings.js';
 import { extractStatePath } from './utils/url-matcher.js';
@@ -49,6 +49,7 @@ export interface WebPageState {
   focusedElement?: FocusedElement | null;
   links?: Link[];
   verifications?: Record<string, boolean>;
+  overlay?: FocusAreaResult;
 }
 
 export interface StateTransition {
@@ -206,8 +207,8 @@ export class StateManager {
   }
 
   private hasDialogAppeared(previousState: WebPageState | null, newState: WebPageState): boolean {
-    const prevFocus = detectFocusArea(previousState?.ariaSnapshot ?? null);
-    const newFocus = detectFocusArea(newState.ariaSnapshot ?? null);
+    const prevFocus = previousState?.overlay ?? detectFocusArea(previousState?.ariaSnapshot ?? null);
+    const newFocus = newState.overlay ?? detectFocusArea(newState.ariaSnapshot ?? null);
     return !prevFocus.detected && newFocus.detected;
   }
 

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -98,7 +98,9 @@ export const HTML_SELECTORS = {
   interactiveControl: 'button, a[href], input, select, textarea, [role="button"], [role="link"], [role="checkbox"], [role="radio"], [role="switch"], [role="tab"], [role="menuitem"]',
   labelLike: 'h1, h2, h3, h4, h5, h6, legend, caption, label, [role="heading"], [class*="title"], [class*="label"], [class*="header"], [class*="name"]',
   semanticContextContainer: 'section, article, form, fieldset, li, tr, td, th, [role="group"], [role="tabpanel"], [role="region"], [class*="card"], [class*="panel"], [class*="item"], [class*="usage"], [class*="group"]',
-  semanticOverlays: ['[role="dialog"]', '[role="listbox"]', '[role="menu"]', '[role="tooltip"]:not([style*="display: none"]):not([style*="visibility: hidden"])'],
+  semanticOverlays: ['[role="dialog"]', '[role="listbox"]', '[role="menu"]', '[role="tooltip"]:not([style*="display: none"]):not([style*="visibility: hidden"])', '[class*="modal"]', '[class*="dialog"]', '[class*="overlay"]', '[class*="popup"]', '[class*="drawer"]', '[class*="lightbox"]'],
+  modalOverlays: ['[role="dialog"]', '[role="alertdialog"]', '[aria-modal="true"]', '[class*="modal"]', '[class*="dialog"]', '[class*="overlay"]', '[class*="popup"]', '[class*="drawer"]', '[class*="lightbox"]'],
+  overlaySemanticSelector: '[role="dialog"], [role="alertdialog"], [aria-modal="true"], [role="listbox"], [role="menu"], [role="tooltip"]',
 } as const;
 
 export const HTML_VISIBILITY_LIMITS = {
@@ -163,7 +165,9 @@ export type VisibleOverlayExtractionConfig = {
   interactiveContentSelector: string;
   limits: typeof HTML_EXTRACTION_LIMITS;
   overlaySelectors: readonly string[];
+  overlaySemanticSelector: string;
   visibilityLimits: typeof HTML_VISIBILITY_LIMITS;
+  geometryFallback?: boolean;
 };
 export type ComponentScopeExtractionConfig = {
   eidxAttr: string;
@@ -479,20 +483,28 @@ export function extractVisibleOverlayHtml(config: VisibleOverlayExtractionConfig
     return interactiveCount > 0 || text.length > 0;
   }
 
-  const overlays: string[] = [];
+  function isFloatingOverlay(element: Element): boolean {
+    const style = window.getComputedStyle(element as HTMLElement);
+    return style.position === 'fixed' || style.position === 'absolute' || Number.parseInt(style.zIndex || '0', 10) > 0;
+  }
+
   const seen = new Set<Element>();
+  const collected: Element[] = [];
   for (const selector of config.overlaySelectors) {
     for (const element of Array.from(document.querySelectorAll(selector))) {
       if (seen.has(element)) continue;
       seen.add(element);
       if (!isVisible(element)) continue;
+      if (!element.matches(config.overlaySemanticSelector) && !isFloatingOverlay(element)) continue;
       const { interactiveCount, text } = getUsefulContent(element);
       if (interactiveCount === 0 && text.length === 0) continue;
-      overlays.push((element as HTMLElement).outerHTML.slice(0, config.limits.overlayHtmlLength));
+      collected.push(element);
     }
   }
 
-  if (overlays.length === 0) {
+  const overlays = collected.filter((element) => !collected.some((other) => other !== element && element.contains(other))).map((element) => (element as HTMLElement).outerHTML.slice(0, config.limits.overlayHtmlLength));
+
+  if (overlays.length === 0 && config.geometryFallback !== false) {
     const floatingCandidates = Array.from(document.body.querySelectorAll('*'))
       .filter((element) => !seen.has(element) && isVisible(element) && isLikelyFloatingOverlay(element))
       .sort((left, right) => {

--- a/src/utils/html.ts
+++ b/src/utils/html.ts
@@ -98,9 +98,6 @@ export const HTML_SELECTORS = {
   interactiveControl: 'button, a[href], input, select, textarea, [role="button"], [role="link"], [role="checkbox"], [role="radio"], [role="switch"], [role="tab"], [role="menuitem"]',
   labelLike: 'h1, h2, h3, h4, h5, h6, legend, caption, label, [role="heading"], [class*="title"], [class*="label"], [class*="header"], [class*="name"]',
   semanticContextContainer: 'section, article, form, fieldset, li, tr, td, th, [role="group"], [role="tabpanel"], [role="region"], [class*="card"], [class*="panel"], [class*="item"], [class*="usage"], [class*="group"]',
-  semanticOverlays: ['[role="dialog"]', '[role="listbox"]', '[role="menu"]', '[role="tooltip"]:not([style*="display: none"]):not([style*="visibility: hidden"])', '[class*="modal"]', '[class*="dialog"]', '[class*="overlay"]', '[class*="popup"]', '[class*="drawer"]', '[class*="lightbox"]'],
-  modalOverlays: ['[role="dialog"]', '[role="alertdialog"]', '[aria-modal="true"]', '[class*="modal"]', '[class*="dialog"]', '[class*="overlay"]', '[class*="popup"]', '[class*="drawer"]', '[class*="lightbox"]'],
-  overlaySemanticSelector: '[role="dialog"], [role="alertdialog"], [aria-modal="true"], [role="listbox"], [role="menu"], [role="tooltip"]',
 } as const;
 
 export const HTML_VISIBILITY_LIMITS = {

--- a/src/utils/overlay.ts
+++ b/src/utils/overlay.ts
@@ -1,0 +1,51 @@
+import { detectFocusArea } from './aria.js';
+import { HTML_EXTRACTION_LIMITS, HTML_SELECTORS, HTML_VISIBILITY_LIMITS, type VisibleOverlayExtractionConfig, extractHeadings } from './html.js';
+
+export const OVERLAY_SELECTORS = {
+  semanticOverlays: ['[role="dialog"]', '[role="listbox"]', '[role="menu"]', '[role="tooltip"]:not([style*="display: none"]):not([style*="visibility: hidden"])', '[class*="modal"]', '[class*="dialog"]', '[class*="overlay"]', '[class*="popup"]', '[class*="drawer"]', '[class*="lightbox"]'],
+  modalOverlays: ['[role="dialog"]', '[role="alertdialog"]', '[aria-modal="true"]', '[class*="modal"]', '[class*="dialog"]', '[class*="overlay"]', '[class*="popup"]', '[class*="drawer"]', '[class*="lightbox"]'],
+  overlaySemanticSelector: '[role="dialog"], [role="alertdialog"], [aria-modal="true"], [role="listbox"], [role="menu"], [role="tooltip"]',
+} as const;
+
+export type OverlayData = { type?: 'dialog' | 'modal' | null; name?: string | null };
+
+export class Overlay {
+  readonly type: 'dialog' | 'modal' | null;
+  readonly name: string | null;
+
+  constructor(data: OverlayData = {}) {
+    this.type = data.type ?? null;
+    this.name = data.name ?? null;
+  }
+
+  get detected(): boolean {
+    return this.type !== null;
+  }
+
+  static fromHtml(html: string): Overlay {
+    const headings = extractHeadings(html);
+    const name = [headings.h1, headings.h2, headings.h3, headings.h4].filter(Boolean).join(' ');
+    return new Overlay({ type: 'modal', name: name || null });
+  }
+
+  static fromAria(snapshot: string | null): Overlay {
+    return new Overlay(detectFocusArea(snapshot));
+  }
+
+  static resolve(data: { overlayHtml?: string; overlay?: OverlayData | null; ariaSnapshot?: string | null }): Overlay {
+    if (data.overlayHtml) return Overlay.fromHtml(data.overlayHtml);
+    if (data.overlay) return new Overlay(data.overlay);
+    return Overlay.fromAria(data.ariaSnapshot ?? null);
+  }
+
+  static captureConfig(): VisibleOverlayExtractionConfig {
+    return {
+      interactiveContentSelector: HTML_SELECTORS.interactiveContent,
+      limits: HTML_EXTRACTION_LIMITS,
+      overlaySelectors: OVERLAY_SELECTORS.modalOverlays,
+      overlaySemanticSelector: OVERLAY_SELECTORS.overlaySemanticSelector,
+      visibilityLimits: HTML_VISIBILITY_LIMITS,
+      geometryFallback: false,
+    };
+  }
+}

--- a/tests/unit/overlay-detection.test.ts
+++ b/tests/unit/overlay-detection.test.ts
@@ -3,13 +3,14 @@ import { JSDOM } from 'jsdom';
 import { describe, expect, it } from 'vitest';
 import { ActionResult } from '../../src/action-result.ts';
 import { HTML_EXTRACTION_LIMITS, HTML_SELECTORS, HTML_VISIBILITY_LIMITS, type VisibleOverlayExtractionConfig, extractVisibleOverlayHtml } from '../../src/utils/html.ts';
+import { OVERLAY_SELECTORS, Overlay } from '../../src/utils/overlay.ts';
 
 function overlayConfig(overrides: Partial<VisibleOverlayExtractionConfig> = {}): VisibleOverlayExtractionConfig {
   return {
     interactiveContentSelector: HTML_SELECTORS.interactiveContent,
     limits: HTML_EXTRACTION_LIMITS,
-    overlaySelectors: HTML_SELECTORS.modalOverlays,
-    overlaySemanticSelector: HTML_SELECTORS.overlaySemanticSelector,
+    overlaySelectors: OVERLAY_SELECTORS.modalOverlays,
+    overlaySemanticSelector: OVERLAY_SELECTORS.overlaySemanticSelector,
     visibilityLimits: HTML_VISIBILITY_LIMITS,
     ...overrides,
   };
@@ -140,8 +141,22 @@ describe('ActionResult overlay', () => {
   });
 
   it('prefers the stored descriptor of a restored state', () => {
-    const stored = { detected: true, type: 'dialog' as const, name: 'Saved filter' };
-    const result = new ActionResult({ url: '/', overlay: stored });
-    expect(result.overlay).toBe(stored);
+    const result = new ActionResult({ url: '/', overlay: new Overlay({ type: 'dialog', name: 'Saved filter' }) });
+    expect(result.overlay.type).toBe('dialog');
+    expect(result.overlay.name).toBe('Saved filter');
+  });
+});
+
+describe('Overlay', () => {
+  it('resolves captured html first, stored descriptor second, aria last', () => {
+    const aria = '- dialog "From aria"';
+    expect(Overlay.resolve({ overlayHtml: '<h3>From html</h3>', overlay: { type: 'modal', name: 'Stored' }, ariaSnapshot: aria }).name).toBe('From html');
+    expect(Overlay.resolve({ overlay: { type: 'modal', name: 'Stored' }, ariaSnapshot: aria }).name).toBe('Stored');
+    expect(Overlay.resolve({ ariaSnapshot: aria }).name).toBe('From aria');
+  });
+
+  it('rehydrates from a plain persisted descriptor', () => {
+    expect(new Overlay({ type: 'modal', name: 'Copy report' }).detected).toBe(true);
+    expect(new Overlay().detected).toBe(false);
   });
 });

--- a/tests/unit/overlay-detection.test.ts
+++ b/tests/unit/overlay-detection.test.ts
@@ -1,0 +1,147 @@
+import 'parse5';
+import { JSDOM } from 'jsdom';
+import { describe, expect, it } from 'vitest';
+import { ActionResult } from '../../src/action-result.ts';
+import { HTML_EXTRACTION_LIMITS, HTML_SELECTORS, HTML_VISIBILITY_LIMITS, type VisibleOverlayExtractionConfig, extractVisibleOverlayHtml } from '../../src/utils/html.ts';
+
+function overlayConfig(overrides: Partial<VisibleOverlayExtractionConfig> = {}): VisibleOverlayExtractionConfig {
+  return {
+    interactiveContentSelector: HTML_SELECTORS.interactiveContent,
+    limits: HTML_EXTRACTION_LIMITS,
+    overlaySelectors: HTML_SELECTORS.modalOverlays,
+    overlaySemanticSelector: HTML_SELECTORS.overlaySemanticSelector,
+    visibilityLimits: HTML_VISIBILITY_LIMITS,
+    ...overrides,
+  };
+}
+
+function withDom(html: string, run: () => void) {
+  const dom = new JSDOM(html);
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  (dom.window.Element.prototype as any).getBoundingClientRect = () => ({ width: 480, height: 320, top: 40, left: 40, bottom: 360, right: 520, x: 40, y: 40, toJSON: () => ({}) });
+  try {
+    run();
+  } finally {
+    (globalThis as any).window = previousWindow;
+    (globalThis as any).document = previousDocument;
+  }
+}
+
+describe('extractVisibleOverlayHtml', () => {
+  it('keeps only the innermost overlay when wrapper and dialog are both floating', () => {
+    withDom(
+      `
+      <html><body>
+        <div class="nebula-modal-root" style="position: absolute; z-index: 40">
+          <div class="nebula-modal-dialog" style="position: absolute">
+            <h3>Copy report</h3>
+            <button>Copy</button>
+          </div>
+        </div>
+      </body></html>
+      `,
+      () => {
+        const html = extractVisibleOverlayHtml(overlayConfig());
+        expect(html).toContain('nebula-modal-dialog');
+        expect(html).not.toContain('nebula-modal-root');
+      }
+    );
+  });
+
+  it('collects the floating wrapper when nested elements only carry the class token', () => {
+    withDom(
+      `
+      <html><body>
+        <div class="nebula-modal-root" style="position: fixed; z-index: 40">
+          <div class="nebula-modal-backdrop">
+            <div class="nebula-modal-dialog">
+              <h3>Copy report</h3>
+              <button>Copy</button>
+            </div>
+          </div>
+        </div>
+      </body></html>
+      `,
+      () => {
+        const html = extractVisibleOverlayHtml(overlayConfig());
+        expect(html).toContain('Copy report');
+        expect(html.split('--- overlay ---')).toHaveLength(1);
+      }
+    );
+  });
+
+  it('ignores a class token on a sticky header', () => {
+    withDom(
+      `
+      <html><body>
+        <header class="site-overlay-bar" style="position: sticky">
+          <button>Menu</button>
+          <h2>Reports</h2>
+        </header>
+      </body></html>
+      `,
+      () => {
+        expect(extractVisibleOverlayHtml(overlayConfig({ geometryFallback: false }))).toBe('');
+      }
+    );
+  });
+
+  it('trusts semantic markup without requiring floating geometry', () => {
+    withDom(
+      `
+      <html><body>
+        <section role="dialog">
+          <h2>Confirm launch</h2>
+          <button>Go</button>
+        </section>
+      </body></html>
+      `,
+      () => {
+        const html = extractVisibleOverlayHtml(overlayConfig({ geometryFallback: false }));
+        expect(html).toContain('Confirm launch');
+      }
+    );
+  });
+
+  it('skips the geometry fallback at capture and keeps it for driller', () => {
+    const markup = `
+      <html><body>
+        <div class="toast-panel" style="position: fixed; z-index: 30">Saved</div>
+      </body></html>
+      `;
+    withDom(markup, () => {
+      expect(extractVisibleOverlayHtml(overlayConfig({ geometryFallback: false }))).toBe('');
+    });
+    withDom(markup, () => {
+      expect(extractVisibleOverlayHtml(overlayConfig())).toContain('toast-panel');
+    });
+  });
+});
+
+describe('ActionResult overlay', () => {
+  it('derives the modal descriptor from captured overlay html', () => {
+    const result = new ActionResult({
+      url: '/',
+      overlayHtml: '<div><h3>Copy report</h3><h4>to Nebula space</h4></div>',
+    });
+    expect(result.overlay.detected).toBe(true);
+    expect(result.overlay.type).toBe('modal');
+    expect(result.overlay.name).toBe('Copy report to Nebula space');
+  });
+
+  it('falls back to the aria snapshot when no overlay html was captured', () => {
+    const result = new ActionResult({ url: '/', ariaSnapshot: '- dialog "Delete confirmation"' });
+    expect(result.overlay.detected).toBe(true);
+    expect(result.overlay.type).toBe('dialog');
+    expect(result.overlay.name).toBe('Delete confirmation');
+  });
+
+  it('prefers the stored descriptor of a restored state', () => {
+    const stored = { detected: true, type: 'dialog' as const, name: 'Saved filter' };
+    const result = new ActionResult({ url: '/', overlay: stored });
+    expect(result.overlay).toBe(stored);
+  });
+});


### PR DESCRIPTION
## Summary

Modals without `role="dialog"`/`aria-modal` were invisible to focus-area detection, so with a dialog open the Tester kept interacting with the page behind it (session `YtterbicRunningTeal168`: `focus_scope=0` all night). Now every state capture probes the live DOM for open overlays using the Driller's existing extractor, and the state carries a resolved `overlay` descriptor that the Tester, Pilot and deep analysis read directly instead of re-deriving it from ARIA.

  Class-name matches only count when the element is truly floating (`fixed`/`absolute`/z-index), so a sticky header named "overlay" can't become a false modal; the expensive full-page geometry scan is not run on every action — it stays in the Driller, which also gains the class tokens and the nested-overlay dedup through the shared extractor. Covered by 8 new unit tests; unit suite at 1093 pass with only the pre-existing flaky `remote` failures.