### PR TITLE
Keep overnight runs from dying silently on stray rejections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-27
+
+### Changes
+
+- [CLI] Overnight runs no longer die silently. An uncaught exception now logs the full stack,
+  flushes telemetry and exits with code 1; an unhandled promise rejection — which kills the whole
+  process in Bun — is logged loudly and the run continues. Nightly runs were dying mid-test after
+  ~3.5 hours with no error anywhere; next occurrence will leave a named cause in the log instead
+  of a bare cut-off.
+
 ## 2026-08-26
 
 ### Changes

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -7,16 +7,16 @@ import { Command } from 'commander';
 import figureSet from 'figures';
 import { render } from 'ink';
 import React from 'react';
+import { flushTelemetry } from '../src/ai/provider.js';
 import { App } from '../src/components/App.js';
 import { StatusPane } from '../src/components/StatusPane.js';
-import { flushTelemetry } from '../src/ai/provider.js';
 import { ConfigParser, EXPLORBOT_ENV_VARS, PROVIDERS } from '../src/config.js';
 import { ExplorBot, type ExplorBotOptions } from '../src/explorbot.js';
 import { remote } from '../src/remote.js';
 import { Stats } from '../src/stats.js';
 import { Plan } from '../src/test-plan.js';
 import { getCliName } from '../src/utils/cli-name.ts';
-import { isVerboseMode, log, setPreserveConsoleLogs, setQuietMode } from '../src/utils/logger.js';
+import { isVerboseMode, log, setPreserveConsoleLogs, setQuietMode, tag } from '../src/utils/logger.js';
 import { jsonToTable } from '../src/utils/markdown-parser.js';
 import { parseMarkdownToTerminal } from '../src/utils/markdown-terminal.js';
 import { type NextStepSection, printNextSteps, relativeToCwd } from '../src/utils/next-steps.ts';
@@ -29,6 +29,16 @@ const pkgVersion = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version as stri
 
 program.name(cli).description('AI-powered web exploration tool').version(pkgVersion, '-V, --version');
 remote.registerOption(program);
+
+process.on('uncaughtException', async (error) => {
+  tag('error').log(`Uncaught exception: ${error instanceof Error ? `${error.message}\n${error.stack}` : String(error)}`);
+  await flushTelemetry();
+  process.exit(1);
+});
+
+process.on('unhandledRejection', (reason) => {
+  tag('error').log(`Unhandled rejection: ${reason instanceof Error ? `${reason.message}\n${reason.stack}` : String(reason)}`);
+});
 
 if (!process.env.EXPLORBOT_NO_BANNER && !process.argv.includes('prima')) {
   console.log(`⛵ ${chalk.yellow.bold(`Explorbot v${pkgVersion}`)} ${chalk.dim('Autonomous Testing Agent')}`);


### PR DESCRIPTION
## Summary

Nightly runs were dying mid-test after ~3.5 hours with no error anywhere. Telemetry flush fix proved the process just stops between steps. In Bun an unhandled promise rejection kills the whole process, which fits the evidence perfectly, so those are now logged loudly (full stack) and the run continues; an uncaught exception logs its stack, flushes telemetry and exits with code 1 instead of dying bare. If the killer turns out to be external (OOM/SIGKILL), the absence of any handler trace is itself the diagnosis.