### PR TITLE
Fix fresh install and local setup blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 2026-08-27
+
+### Changes
+
+- [Navigator] Arriving somewhere you already are is no longer a failure. Navigating to the URL the
+  browser is already on used to be structurally unresolvable — the state hash could never change —
+  so `start /` on a landing-page site burned the whole retry budget (one user lost 27 minutes)
+  while being told "URL verification failed: expected /, got /", and that wrong diagnosis was fed
+  back into the AI retry prompt. Same-URL targets now resolve instantly, and a URL mismatch is
+  reported separately from a page that did not react.
+- [CLI] `init` now writes a CommonJS `explorbot.config.js` in default npm projects and an ESM
+  config in projects whose `package.json` says `"type": "module"`. Generated configs keep the
+  documented filename and load regardless of the package type.
+- [CLI] Local `init` now asks which AI provider to use and writes the config and `.env` for that
+  provider, instead of silently hard-wiring OpenRouter. Anthropic gained recommended `model` and
+  `visionModel` entries, so its scaffold no longer contains placeholders.
+- [CLI] `learn --replace` rewrites the knowledge for a URL instead of appending with a `---`
+  separator, so a mistaken entry no longer requires hand-editing the file.
+- [Explorer] The CodeceptJS module is pinned into `global.codeceptjs` at startup, making explorbot
+  immune to npm hoisting layouts where the Playwright helper cannot resolve `codeceptjs` after an
+  upgrade.
+- Fixed a typo in the init "Next steps" output (`aurhorize`).
+
 ## 2026-08-26
 
 ### Changes

--- a/bin/explorbot-cli.ts
+++ b/bin/explorbot-cli.ts
@@ -7,9 +7,9 @@ import { Command } from 'commander';
 import figureSet from 'figures';
 import { render } from 'ink';
 import React from 'react';
+import { flushTelemetry } from '../src/ai/provider.js';
 import { App } from '../src/components/App.js';
 import { StatusPane } from '../src/components/StatusPane.js';
-import { flushTelemetry } from '../src/ai/provider.js';
 import { ConfigParser, EXPLORBOT_ENV_VARS, PROVIDERS } from '../src/config.js';
 import { ExplorBot, type ExplorBotOptions } from '../src/explorbot.js';
 import { remote } from '../src/remote.js';
@@ -546,6 +546,7 @@ program
   .command('learn [url] [description]')
   .description('Add knowledge for URLs')
   .option('-p, --path <path>', 'Working directory path')
+  .option('--replace', 'Replace existing knowledge for this URL instead of appending')
   .action(async (url, description, options) => {
     try {
       await ConfigParser.getInstance().loadConfig({
@@ -556,7 +557,7 @@ program
       const tracker = new KnowledgeTracker();
 
       if (url && description) {
-        const result = tracker.addKnowledge(url, description);
+        const result = tracker.addKnowledge(url, description, { replace: options.replace });
         const action = result.isNewFile ? 'Created' : 'Updated';
         console.log(`Knowledge ${action} in: ${result.filename}`);
         return;

--- a/models.json
+++ b/models.json
@@ -18,6 +18,8 @@
     "agenticModel": "gpt-5.6-luna"
   },
   "anthropic": {
+    "model": "claude-haiku-4-5-20251001",
+    "visionModel": "claude-haiku-4-5-20251001",
     "agenticModel": "claude-haiku-4-5-20251001"
   },
   "mistral": {

--- a/src/ai/navigator.ts
+++ b/src/ai/navigator.ts
@@ -7,8 +7,8 @@ import type { ExplorbotConfig } from '../config.ts';
 import type { ExperienceTracker } from '../experience-tracker.js';
 import Explorer from '../explorer.ts';
 import type { KnowledgeTracker } from '../knowledge-tracker.js';
-import { type StateManager, normalizeUrl } from '../state-manager.js';
 import { renderAssertion } from '../playwright-recorder.ts';
+import { type StateManager, normalizeUrl } from '../state-manager.js';
 import { isFatalBrowserError } from '../utils/browser-errors.ts';
 import { getCliName } from '../utils/cli-name.ts';
 import { extractCodeBlocks } from '../utils/code-extractor.js';
@@ -223,6 +223,11 @@ class Navigator implements Agent {
     const action = opts?.action ?? this.explorer.action();
     const expectedUrl = opts?.expectedUrl;
 
+    if (expectedUrl && this.targetUrlReached(action, expectedUrl, actionResult)) {
+      tag('success').log(`Already at ${expectedUrl} — navigation resolved`);
+      return true;
+    }
+
     const knowledge = this.knowledgeTracker.renderRelevantContext(actionResult);
 
     const conversation = this.provider.startConversation(this.systemPrompt, 'navigator');
@@ -313,14 +318,19 @@ class Navigator implements Agent {
           resolved = check.urlMatches && freshHash !== actionResult.getStateHash();
 
           if (!resolved && attempt.ok) {
-            lastFailure = `URL did not change (still ${check.freshState.url})`;
+            if (check.urlMatches) {
+              lastFailure = `Reached ${check.freshState.url} but the page state did not change`;
+              tag('warning').log(`Page state did not change at ${check.freshState.url}`);
+            } else {
+              lastFailure = `Reached ${check.freshState.url}, expected ${expectedUrl}`;
+              tag('warning').log(`URL verification failed: expected ${expectedUrl}, got ${check.freshState.url}`);
+            }
             batchFailures.push({
               code: codeBlock,
               error: lastFailure,
               ariaChanges: await this.ariaDiff(check.freshState, prevActionResult),
               urlAfter: check.freshState.url,
             });
-            tag('warning').log(`URL verification failed: expected ${expectedUrl}, got ${check.freshState.url}`);
           }
           if (freshHash !== prevHash && (attempt.ok || check.urlMatches)) {
             progressBlocks.push(codeBlock);
@@ -484,9 +494,13 @@ class Navigator implements Agent {
     }
 
     const freshState = await this.explorer.capture();
-    const urlMatches = this.isSameExpectedOrigin(expectedUrl, action.stateManager) && matchesNavigationUrl(expectedUrl, this.comparableUrl(freshState, expectedUrl));
+    const urlMatches = this.targetUrlReached(action, expectedUrl, freshState);
 
     return { freshState, urlMatches };
+  }
+
+  private targetUrlReached(action: Action, expectedUrl: string, state: ActionResult): boolean {
+    return this.isSameExpectedOrigin(expectedUrl, action.stateManager) && matchesNavigationUrl(expectedUrl, this.comparableUrl(state, expectedUrl));
   }
 
   private async ariaDiff(freshState: ActionResult, previous: ActionResult): Promise<string | null> {

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -1,16 +1,18 @@
 import { existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, extname, join, resolve } from 'node:path';
 import chalk from 'chalk';
-import dedent from 'dedent';
 import { ConfigParser, PROVIDERS } from '../config.ts';
 import { findGlobalConfig, globalConfigPath, globalDir, globalEnvPath } from '../global-config.ts';
 import { getCliName } from '../utils/cli-name.ts';
 import { log, tag } from '../utils/logger.js';
 import { relativeToCwd } from '../utils/next-steps.ts';
 
-function defaultConfigTemplate(): string {
+function defaultConfigTemplate(provider: string, esm: boolean): string {
+  let moduleExport = 'module.exports = config;';
+  if (esm) moduleExport = 'export default config;';
+
   return `// 'provider/model-id' uses a bundled provider.
-// It is also possible to import provider as a module from Vercel AI SDK.  
+// It is also possible to import provider as a module from Vercel AI SDK.
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 
 const config = {
@@ -20,7 +22,7 @@ const config = {
   },
 
   ai: {
-${modelLines('openrouter')}
+${modelLines(provider)}
   },
 
   reporter: {
@@ -33,17 +35,18 @@ ${modelLines('openrouter')}
   },
 };
 
-export default config;
+${moduleExport}
 `;
 }
 
-const DEFAULT_ENV_TEMPLATE = dedent`
-# AI provider API keys
-OPENROUTER_API_KEY=
+function envTemplate(provider: string): string {
+  const keyLines = Object.entries(PROVIDERS).map(([name, { envKey }]) => {
+    if (name === provider) return `${envKey}=`;
+    return `# ${envKey}=`;
+  });
 
-# OPENAI_API_KEY=
-# ANTHROPIC_API_KEY=
-# GROQ_API_KEY=
+  return `# AI provider API keys
+${keyLines.join('\n')}
 
 # Langfuse Tracing
 LANGFUSE_SECRET_KEY=
@@ -51,11 +54,12 @@ LANGFUSE_PUBLIC_KEY=
 LANGFUSE_BASE_URL=
 
 # Testomat.io API key to publish run results
-TESTOMATIO=
-`;
+TESTOMATIO=`;
+}
 
 export async function runInit(options: InitCommandOptions): Promise<void> {
-  if (options.global || options.provider) {
+  const localRequested = !!(options.configPath || options.path);
+  if (options.global || (options.provider && !localRequested)) {
     await runGlobalInit(options);
     return;
   }
@@ -66,7 +70,12 @@ export async function runInit(options: InitCommandOptions): Promise<void> {
   }
 
   const choice = await renderInitWizard('choose');
-  if (choice === 'local') runInitCommand(options);
+  if (choice !== 'local') return;
+
+  const provider = await renderLocalProviderWizard();
+  if (!provider) return;
+
+  runInitCommand({ ...options, provider });
 }
 
 export function writeGlobalConfig(provider: string, apiKey?: string): void {
@@ -97,7 +106,7 @@ export function writeGlobalConfig(provider: string, apiKey?: string): void {
 }
 
 export function runInitCommand(options: InitCommandOptions): void {
-  const configPath = options.configPath ?? './explorbot.config.js';
+  const provider = options.provider || 'openrouter';
   const force = options.force ?? false;
   const customPath = options.path;
   const originalCwd = process.cwd();
@@ -112,12 +121,15 @@ export function runInitCommand(options: InitCommandOptions): void {
     log(`Working in directory: ${relativeToCwd(dir)}`);
   }
 
+  const configName = 'explorbot.config.js';
+  const configPath = options.configPath ?? `./${configName}`;
+
   try {
     let outPath = resolve(configPath);
     if (existsSync(outPath) && statSync(outPath).isDirectory()) {
-      outPath = join(outPath, 'explorbot.config.js');
+      outPath = join(outPath, configName);
     } else if (!extname(outPath)) {
-      outPath = join(outPath, 'explorbot.config.js');
+      outPath = join(outPath, configName);
     }
 
     const dir = dirname(outPath);
@@ -132,15 +144,21 @@ export function runInitCommand(options: InitCommandOptions): void {
       process.exit(1);
     }
 
-    writeFileSync(outPath, defaultConfigTemplate(), 'utf8');
+    const esm = extname(outPath) !== '.js' || isModuleProject(dirname(outPath));
+    writeFileSync(outPath, defaultConfigTemplate(provider, esm), 'utf8');
     log(`Created config file: ${relativeToCwd(outPath)}`);
 
     const envPath = resolve(process.cwd(), '.env');
     if (!existsSync(envPath)) {
-      writeFileSync(envPath, `${DEFAULT_ENV_TEMPLATE}\n`, 'utf8');
+      writeFileSync(envPath, `${envTemplate(provider)}\n`, 'utf8');
       log(`Created env file: ${relativeToCwd(envPath)}`);
     } else {
       log(`Env file already exists: ${relativeToCwd(envPath)}`);
+    }
+
+    const missing = missingRoles(provider);
+    if (missing.length) {
+      tag('warning').log(`No recommended ${missing.join(' and ')} for ${provider} — set the model ids in ${relativeToCwd(outPath)}`);
     }
 
     log('');
@@ -149,7 +167,7 @@ export function runInitCommand(options: InitCommandOptions): void {
     log('2. Set AI models config file');
     log('3. Set web application URL in the config file');
     log('4. Add initial knowledge (how to authorize to the application, etc.)');
-    tag('substep').log(chalk.yellow(`${getCliName()} learn * 'to aurhorize use these credentials: admin@example.com / secret123'`));
+    tag('substep').log(chalk.yellow(`${getCliName()} learn * 'to authorize use these credentials: admin@example.com / secret123'`));
     tag('substep').log('You can use ${env.LOGIN} and ${env.PASSWORD} to reference environment variables.');
 
     log('5. Launch application on a relative URL');
@@ -213,6 +231,28 @@ async function renderInitWizard(mode: 'choose' | 'global'): Promise<'local' | 'g
   });
 }
 
+async function renderLocalProviderWizard(): Promise<string | null> {
+  const [{ render }, React, InitWizard] = await Promise.all([import('ink'), import('react'), import('../components/InitWizard.js').then((m) => m.default)]);
+
+  return new Promise((resolve) => {
+    const finish = (provider: string | null) => {
+      unmount();
+      resolve(provider);
+    };
+    const { unmount } = render(
+      React.createElement(InitWizard, {
+        mode: 'local',
+        globalConfigExists: !!findGlobalConfig(),
+        onLocal: () => finish(null),
+        onComplete: () => finish(null),
+        onCancel: () => finish(null),
+        onLocalProvider: (provider: string) => finish(provider),
+      }),
+      { exitOnCtrlC: false, patchConsole: false }
+    );
+  });
+}
+
 function modelLines(provider: string): string {
   const recommended = ConfigParser.recommendedModels()[provider] || {};
   const roles: Array<[ModelRoleName, string]> = [
@@ -245,8 +285,27 @@ ${modelLines(provider)}
   },
 };
 
-export default config;
+module.exports = config;
 `;
+}
+
+function isModuleProject(configDir: string): boolean {
+  let currentDir = resolve(configDir);
+
+  while (true) {
+    const packagePath = join(currentDir, 'package.json');
+    if (existsSync(packagePath)) {
+      try {
+        return JSON.parse(readFileSync(packagePath, 'utf8')).type === 'module';
+      } catch {
+        return false;
+      }
+    }
+
+    const parentDir = dirname(currentDir);
+    if (parentDir === currentDir) return false;
+    currentDir = parentDir;
+  }
 }
 
 function missingRoles(provider: string): string[] {

--- a/src/components/InitWizard.tsx
+++ b/src/components/InitWizard.tsx
@@ -10,14 +10,15 @@ import InputReadline from './InputReadline.js';
 const PROVIDER_NAMES = Object.keys(PROVIDERS);
 
 interface InitWizardProps {
-  mode: 'choose' | 'global';
+  mode: 'choose' | 'global' | 'local';
   globalConfigExists: boolean;
   onLocal: () => void;
   onComplete: () => void;
   onCancel: () => void;
+  onLocalProvider?: (provider: string) => void;
 }
 
-const InitWizard: React.FC<InitWizardProps> = ({ mode, globalConfigExists, onLocal, onComplete, onCancel }) => {
+const InitWizard: React.FC<InitWizardProps> = ({ mode, globalConfigExists, onLocal, onComplete, onCancel, onLocalProvider }) => {
   const [step, setStep] = useState<'target' | 'provider' | 'key' | 'validate'>(mode === 'choose' ? 'target' : 'provider');
   const [targetIndex, setTargetIndex] = useState(0);
   const [providerIndex, setProviderIndex] = useState(0);
@@ -78,7 +79,10 @@ const InitWizard: React.FC<InitWizardProps> = ({ mode, globalConfigExists, onLoc
     if (step === 'provider') {
       if (key.upArrow) setProviderIndex((index) => Math.max(0, index - 1));
       if (key.downArrow) setProviderIndex((index) => Math.min(PROVIDER_NAMES.length - 1, index + 1));
-      if (key.return) setStep('key');
+      if (key.return) {
+        if (mode === 'local') onLocalProvider?.(provider);
+        else setStep('key');
+      }
       return;
     }
 
@@ -151,7 +155,7 @@ const InitWizard: React.FC<InitWizardProps> = ({ mode, globalConfigExists, onLoc
 
       <Box marginTop={1}>
         <Text dimColor>
-          Config goes to {globalDir()} | {step === 'key' ? 'Enter: continue' : '↑↓: select | Enter: confirm'} | Ctrl+C: exit
+          Config goes to {mode === 'local' ? 'the current directory' : globalDir()} | {step === 'key' ? 'Enter: continue' : '↑↓: select | Enter: confirm'} | Ctrl+C: exit
         </Text>
       </Box>
     </Box>

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -255,6 +255,7 @@ class Explorer {
     const projectRoot = configParser.getProjectRoot();
     (global as any).output_dir = configParser.getStatesDir();
     (global as any).codecept_dir = projectRoot;
+    (global as any).codeceptjs = codeceptjs;
 
     configParser.validateConfig(this.config);
 

--- a/src/knowledge-tracker.ts
+++ b/src/knowledge-tracker.ts
@@ -95,7 +95,7 @@ export class KnowledgeTracker {
     return this.applicationSpec?.renderFor(state) || '';
   }
 
-  addKnowledge(urlPattern: string, description: string): { filename: string; filePath: string; isNewFile: boolean } {
+  addKnowledge(urlPattern: string, description: string, opts?: { replace?: boolean }): { filename: string; filePath: string; isNewFile: boolean } {
     const configParser = ConfigParser.getInstance();
     const configPath = configParser.getConfigPath();
 
@@ -130,10 +130,10 @@ export class KnowledgeTracker {
 
       // Append new knowledge with separator
       let newContent;
-      if (existingDescription) {
-        newContent = `${existingDescription}\n\n---\n\n${description}`;
-      } else {
+      if (opts?.replace || !existingDescription) {
         newContent = description;
+      } else {
+        newContent = `${existingDescription}\n\n---\n\n${description}`;
       }
 
       const fileContent = matter.stringify(newContent, frontmatter);

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -141,7 +141,7 @@ describe('ConfigParser environment mode', () => {
   });
 
   it('rejects a role the provider has no recommendation for', async () => {
-    await expect(resolveModel('anthropic', 'model')).rejects.toThrow(/no recommended model/);
+    await expect(resolveModel('poolside', 'visionModel')).rejects.toThrow(/has no recommended/);
   });
 
   it('fills every role from one provider name', async () => {

--- a/tests/unit/global-config.test.ts
+++ b/tests/unit/global-config.test.ts
@@ -4,10 +4,10 @@ import os, { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { render } from 'ink-testing-library';
 import React from 'react';
-import InitWizard from '../../src/components/InitWizard.tsx';
 import { ApibotConfigParser } from '../../boat/api-tester/src/config.ts';
 import { runInit, runInitCommand } from '../../src/commands/init-command.ts';
-import { ConfigParser } from '../../src/config.ts';
+import InitWizard from '../../src/components/InitWizard.tsx';
+import { ConfigParser, PROVIDERS } from '../../src/config.ts';
 import { listSites, registerSite, resolveSiteTarget, siteFolderName } from '../../src/global-config.ts';
 
 const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'GLOBAL_ONLY_KEY', 'SHARED_KEY'];
@@ -351,6 +351,24 @@ describe('explorbot init', () => {
     expect(readFileSync(join(home, '.explorbot', '.env'), 'utf8')).toContain('GROQ_API_KEY=test-key');
   });
 
+  it('uses an explicit provider locally when a project path is given', async () => {
+    await runInit({ path: workDir, provider: 'anthropic' });
+
+    const config = readFileSync(join(workDir, 'explorbot.config.js'), 'utf8');
+    const env = readFileSync(join(workDir, '.env'), 'utf8');
+    expect(config).toContain(`model: 'anthropic/${ConfigParser.recommendedModels().anthropic.model}'`);
+    expect(env).toContain('ANTHROPIC_API_KEY=');
+    expect(env).toContain('# OPENROUTER_API_KEY=');
+    expect(existsSync(join(home, '.explorbot', 'config.js'))).toBe(false);
+  });
+
+  it('keeps an explicit provider global when no project path is given', async () => {
+    await runInit({ provider: 'groq' });
+
+    expect(readFileSync(join(home, '.explorbot', 'config.js'), 'utf8')).toContain("model: 'groq/");
+    expect(existsSync(join(workDir, 'explorbot.config.js'))).toBe(false);
+  });
+
   it('refuses to overwrite an existing global config without --force and keeps the stored key', async () => {
     await runInit({ global: true, provider: 'groq', apiKey: 'first-key' });
 
@@ -384,6 +402,55 @@ describe('explorbot init', () => {
     expect(wizard.lastFrame()).toContain('•');
   });
 
+  it('ends the local flow with the picked provider and no key entry', async () => {
+    const noop = () => {};
+    let picked: string | null = null;
+    const wizard = render(
+      React.createElement(InitWizard, {
+        mode: 'local',
+        globalConfigExists: false,
+        onLocal: noop,
+        onComplete: noop,
+        onCancel: noop,
+        onLocalProvider: (provider: string) => {
+          picked = provider;
+        },
+      })
+    );
+
+    expect(wizard.lastFrame()).toContain('Pick an AI provider');
+    expect(wizard.lastFrame()).toContain('the current directory');
+
+    wizard.stdin.write('\r');
+
+    expect(picked).toBe(Object.keys(PROVIDERS)[0]);
+  });
+
+  it('cancels the local provider flow without picking a provider', () => {
+    const noop = () => {};
+    let cancelled = false;
+    let picked: string | null = null;
+    const wizard = render(
+      React.createElement(InitWizard, {
+        mode: 'local',
+        globalConfigExists: false,
+        onLocal: noop,
+        onComplete: noop,
+        onCancel: () => {
+          cancelled = true;
+        },
+        onLocalProvider: (provider: string) => {
+          picked = provider;
+        },
+      })
+    );
+
+    wizard.stdin.write('\u001b');
+
+    expect(cancelled).toBe(true);
+    expect(picked).toBeNull();
+  });
+
   it('offers both installations and marks global as installed', () => {
     const noop = () => {};
     const chooser = render(React.createElement(InitWizard, { mode: 'choose', globalConfigExists: true, onLocal: noop, onComplete: noop, onCancel: noop }));
@@ -411,6 +478,20 @@ describe('explorbot init', () => {
     }
   });
 
+  it('writes an ESM config in a "type": "module" project and CommonJS otherwise', async () => {
+    writeFileSync(join(workDir, 'package.json'), '{"name":"t","type":"module"}\n', 'utf8');
+
+    runInitCommand({ path: workDir });
+    expect(readFileSync(join(workDir, 'explorbot.config.js'), 'utf8')).toContain('export default config;');
+    expect((await ConfigParser.getInstance().loadConfig({ path: workDir })).ai?.model).toBeTruthy();
+
+    rmSync(join(workDir, 'explorbot.config.js'));
+    rmSync(join(workDir, 'package.json'));
+
+    runInitCommand({ path: workDir });
+    expect(readFileSync(join(workDir, 'explorbot.config.js'), 'utf8')).toContain('module.exports = config;');
+  });
+
   it('scaffolds a local config that loads without installing a provider package', async () => {
     runInitCommand({ path: workDir });
 
@@ -420,5 +501,21 @@ describe('explorbot init', () => {
     const config = await ConfigParser.getInstance().loadConfig({ path: workDir });
     expect(config.ai.model.modelId).toBe(ConfigParser.recommendedModels().openrouter.model);
     expect(config.ai.visionModel.modelId).toBe(ConfigParser.recommendedModels().openrouter.visionModel);
+  });
+
+  it('writes ESM when an .mjs config path is explicitly requested', () => {
+    runInitCommand({ path: workDir, configPath: 'custom.mjs' });
+
+    expect(readFileSync(join(workDir, 'custom.mjs'), 'utf8')).toContain('export default config;');
+  });
+
+  it('uses the nearest package.json to choose the module format', () => {
+    writeFileSync(join(workDir, 'package.json'), '{"name":"root","type":"commonjs"}\n', 'utf8');
+    mkdirSync(join(workDir, 'nested'));
+    writeFileSync(join(workDir, 'nested', 'package.json'), '{"name":"nested","type":"module"}\n', 'utf8');
+
+    runInitCommand({ path: workDir, configPath: 'nested/explorbot.config.js' });
+
+    expect(readFileSync(join(workDir, 'nested', 'explorbot.config.js'), 'utf8')).toContain('export default config;');
   });
 });

--- a/tests/unit/knowledge-tracker.test.ts
+++ b/tests/unit/knowledge-tracker.test.ts
@@ -249,5 +249,16 @@ describe('KnowledgeTracker', () => {
       expect(matched.length).toBeGreaterThan(0);
       expect(matched[0].content).toContain('Use admin credentials');
     });
+
+    it('replaces existing knowledge with the replace option instead of appending', () => {
+      const tracker = new KnowledgeTracker();
+      tracker.addKnowledge('/login', 'first entry');
+
+      tracker.addKnowledge('/login', 'corrected entry', { replace: true });
+
+      const matched = tracker.getMatchingKnowledge('/login');
+      expect(matched[0].content).toContain('corrected entry');
+      expect(matched[0].content).not.toContain('first entry');
+    });
   });
 });

--- a/tests/unit/navigator-resolve-state.test.ts
+++ b/tests/unit/navigator-resolve-state.test.ts
@@ -76,6 +76,28 @@ function createHarness(
 }
 
 describe('Navigator resolveState', () => {
+  it('resolves immediately when already at the target URL, without spending AI calls', async () => {
+    const harness = createHarness({ responses: ["```js\nI.click('noop')\n```"] });
+
+    const resolved = await harness.navigator.resolveState('reach /login', fakeActionResult('/login'), { expectedUrl: '/login' });
+
+    expect(resolved).toBe(true);
+    expect(harness.attempts).toHaveLength(0);
+    expect(harness.sent).toHaveLength(0);
+    expect(harness.flows).toHaveLength(0);
+  });
+
+  it('names the reached and the expected URL when verification fails', async () => {
+    const harness = createHarness({
+      responses: ["```js\nI.click('wrong')\n```", ''],
+      attempt: () => true,
+    });
+
+    await harness.navigator.resolveState('reach /defects', fakeActionResult('/login'), { expectedUrl: '/defects' });
+
+    expect(harness.sent.some((text) => text.includes('Reached /login, expected /defects'))).toBe(true);
+  });
+
   it('resolves when a proposed step reaches the expected URL', async () => {
     const harness = createHarness({
       responses: ["```js\nI.amOnPage('/login')\nI.click('#login-btn')\n```"],
@@ -156,7 +178,7 @@ describe('Navigator resolveState', () => {
 
     const resolved = await harness.navigator.resolveState('reach /defects', fakeActionResult('/login', 'start'), { expectedUrl: '/defects' });
 
-    expect(harness.sent[1]).toContain('URL did not change (still /defects)');
+    expect(harness.sent[1]).toContain('Reached /defects but the page state did not change');
     expect(resolved).toBe(true);
   });
 
@@ -194,7 +216,7 @@ describe('Navigator resolveState', () => {
     expect(resolved).toBe(false);
     const retry = harness.sent[1];
     expect(retry).toContain('<previous_failures>');
-    expect(retry).toContain('URL did not change (still /login)');
+    expect(retry).toContain('Reached /login, expected /defects');
     expect(retry).toContain('Invalid email or password');
     expect(retry).toContain('Full HTML context');
     expect(retry).toContain('Choose exactly ONE path');


### PR DESCRIPTION
 ## Summary

  Fixes the issues reported from a fresh local Explorbot setup:

  - support `init --path . --provider <name>` without switching to global installation
  - generate matching model IDs and `.env` keys for the selected provider
  - add missing Anthropic model recommendations
  - make CodeceptJS resolution independent of npm hoisting layout
  - add `learn --replace`
  - fix the `aurhorize` typo in init output
  - resolve same-URL navigation immediately and improve navigation failure diagnostics

  Existing behavior remains compatible:

  - `init --provider <name>` without a project path remains global
  - `init --path .` without a provider keeps OpenRouter as the default
  - generated and existing `.js`, `.mjs`, and `.ts` configs remain supported
  - documentation keeps the existing `explorbot.config.js` filename