### PR TITLE
Report a click that changed nothing as no change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-28
+
+### Changes
+
+- Page Diff: A click that changed nothing is reported as one again. When a page re-renders a long
+  list without changing anything on it — every row rewritten, but nothing added, removed, selected
+  or checked — the diff listed one empty entry per row. That was enough to suppress the warning
+  that an action produced no observable change, so an agent read "success" and carried on from a
+  step that never happened. Rows carrying no added or removed element are now left out, and a diff
+  left with nothing in it says so.
+
 ## 2026-08-23
 
 ### Changes

--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -554,8 +554,9 @@ export class ActionResult implements ActionResultData {
           processedParts.push({ ...part, subtree: minified });
         }
       }
-      if (processedParts.length > 0) {
-        pageDiff.htmlParts = collapseHtmlParts(processedParts);
+      const collapsed = collapseHtmlParts(processedParts);
+      if (collapsed.length > 0) {
+        pageDiff.htmlParts = collapsed;
       }
     }
 
@@ -596,10 +597,12 @@ function collapseHtmlParts(parts: HtmlDiffPart[]): HtmlDiffPart[] {
   const fullPageReRender = total > HTML_PARTS_TOTAL_BUDGET || parts.length > HTML_PARTS_COUNT_LIMIT;
 
   if (fullPageReRender) {
-    return parts.map((part) => ({
-      ...part,
-      subtree: `<html><head></head><body>...collapsed (${part.subtree.length} chars, ${part.added.length} added, ${part.removed.length} removed)...</body></html>`,
-    }));
+    return parts
+      .filter((part) => part.added.length > 0 || part.removed.length > 0)
+      .map((part) => ({
+        ...part,
+        subtree: `<html><head></head><body>...collapsed (${part.subtree.length} chars, ${part.added.length} added, ${part.removed.length} removed)...</body></html>`,
+      }));
   }
 
   return parts.map((part) => {

--- a/tests/unit/page-diff-evidence.test.ts
+++ b/tests/unit/page-diff-evidence.test.ts
@@ -120,6 +120,32 @@ describe('pageDiff evidence', () => {
     expect(pageDiff?.requests).toEqual([{ method: 'POST', path: '/api/runs', status: 400 }]);
   });
 
+  test('drops parts of a re-render that carry no added or removed element', async () => {
+    const rows = (ids: string[]) => page(ids.map((id) => `<li><span><input id="${id}" type="checkbox"></span></li>`).join(''));
+    const before = rows(Array.from({ length: 12 }, (_, i) => `row-before-${i}`));
+    const after = rows(Array.from({ length: 12 }, (_, i) => `row-after-${i}`));
+
+    const previous = new ActionResult({ id: 1, url: '/plans/new', html: before });
+    const current = new ActionResult({ id: 2, url: '/plans/new', html: after });
+
+    const { pageDiff } = await current.toToolResult(previous, 'Select from list');
+
+    expect(pageDiff?.htmlParts).toBeUndefined();
+    expect(successToolResult('click', { pageDiff }).suggestion).toContain('no observable change');
+  });
+
+  test('keeps parts of a re-render that added elements', async () => {
+    const rows = (extra: string) => page(Array.from({ length: 12 }, (_, i) => `<li><span><input id="row-${i}" type="checkbox">${extra}</span></li>`).join(''));
+
+    const previous = new ActionResult({ id: 1, url: '/plans/new', html: rows('') });
+    const current = new ActionResult({ id: 2, url: '/plans/new', html: rows('<button>Remove</button>') });
+
+    const { pageDiff } = await current.toToolResult(previous, 'Select from list');
+
+    expect(pageDiff?.htmlParts?.length).toBe(12);
+    expect(successToolResult('click', { pageDiff }).suggestion).not.toContain('no observable change');
+  });
+
   test('reports requests of a first-ever capture with no previous state', async () => {
     const current = new ActionResult({
       id: 1,


### PR DESCRIPTION
## What went wrong

Found while diagnosing session `LimitedReluctantBlue585` (trace `16a5bf1e9978a760bcdd9666f399c3ac`), a mixed-plan creation test that failed in 110 seconds.

The Tester clicked a row in a test picker. Nothing was selected — but the tool returned `success: true` carrying **218 `htmlParts`, every one `added: [], removed: []`, every subtree replaced by** `...collapsed (180 chars, 0 added, 0 removed)...`, with no `ariaChanges` and no URL change. The picker had 217 rows and the app re-rendered all of them, so the HTML diff saw an attribute change on every checkbox and nothing else.

Believing the row was selected, the Tester then clicked the picker's confirm control — a button labelled **"Select 0 tests"** — reasoning verbatim: *"That button will update to 'Select 1 tests'."* The picker closed empty. Everything after was cascade: 4 failed `verify` calls, 3 dead clicks and 2 dead `xpathCheck`s hunting checkboxes in a picker that no longer existed, and a correct `fail` verdict from the Pilot.

## Root cause

`successToolResult` already has the warning that would have caught this (`src/ai/tools.ts:1217`):

> Action ran without error but produced no observable change (URL, ARIA and HTML all unchanged). […] Re-locate via `xpathCheck()` or verify with `see()` before treating this as success.

It was suppressed because `htmlParts` was non-empty. Those 218 entries were empty by construction:

- `buildDiffParts` gives attribute-only changes `added: []` (only newly appeared paths get `ELEMENT:` entries) and `removed: []` (never populated, for any part) — for those parts the information lives in `subtree`.
- `collapseHtmlParts` then throws the subtree away, because 218 parts blows past `HTML_PARTS_COUNT_LIMIT` and the diff is treated as a full-page re-render.

Attribute-only change + collapse = an entry with no subtree, no added and no removed. Nothing a caller can read, yet counted.

## The change

Drop those parts once collapse has taken their subtree, and omit `htmlParts` when nothing survives — matching how `messages`, `requests` and `ariaChanges` are only set when they carry something. Six lines in `src/action-result.ts`.

The uncollapsed branch is untouched: below the budget, an attribute-only part still carries a real subtree (a `disabled` attribute appearing, a value changing) and still reaches the model.

## Why not report the attribute changes instead

That list already exists, one layer up and over a closed vocabulary: `diffAriaSnapshots` reports `toggled` (`checked`/`selected`/`pressed`/`expanded`) and `typed` (value changes) as `checkbox "X": unchecked -> checked`. It was right here — nothing toggled, so the diff was empty. Building the same list from the HTML diff, where the attribute set is open, would have printed 217 lines of `id: select-test-checkbox-a -> select-test-checkbox-b`: worse than the placeholders, because it looks meaningful.

## Trade-off

A click that only restyles a list — class sweeps, hover or selection styling across many rows — now reads as "no observable change", so an agent may spend an extra `see()` or `xpathCheck()` re-verifying a click that genuinely worked.

## Tests

`tests/unit/page-diff-evidence.test.ts` gains a miniature of the session: 12 rows whose ids churn and nothing else. It fails on `main` with 12 parts of `...collapsed (93 chars, 0 added, 0 removed)...`, and a companion test pins that parts carrying real additions still survive collapse.

- `bun test tests/unit/` — 1078 pass
- `bun test tests/integration/` — 80 pass, 1 skip
- `bun run format`, `bun run lint:fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D1omW7q6MBzFAuxqvoJEy