### PR TITLE
Report each command a batch ran, with its status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,11 @@
 
 ### Changes
 
-- Page Diff: A click that changed nothing is reported as one again. When a page re-renders a long
-  list without changing anything on it — every row rewritten, but nothing added, removed, selected
-  or checked — the diff listed one empty entry per row. That was enough to suppress the warning
-  that an action produced no observable change, so an agent read "success" and carried on from a
-  step that never happened. Rows carrying no added or removed element are now left out, and a diff
-  left with nothing in it says so.
-- [Researcher] UI map rows written as `{ role: 'checkbox', name: 'Filter' }` keep their locator. Both
-  `text` and `name` name an element the same way when a locator runs, but the UI map only recognised
-  `text` and blanked every row using `name` to `-`, throwing away a locator that works. Three prompts
-  also spent a line teaching that `name` is wrong; they no longer do.
+- [Tester] `form()` and `interact()` now report every command they ran and whether it passed. A batch
+  used to come back as a single pass/fail, so one bad command at the end hid the fact that the ones
+  before it had worked — the AI and the Pilot both concluded nothing had happened and redid work that
+  was already done. Failures now list each command as OK or FAILED and say how many never ran.
+
 ## 2026-08-27
 
 ### Changes

--- a/src/action.ts
+++ b/src/action.ts
@@ -332,7 +332,7 @@ class Action {
 
     const executedSteps: ExecutedStep[] = [];
     const assertionSteps: Array<{ name: string; args: any[] }> = [];
-    const stepListener = attachStepLogger(executedSteps, assertionSteps);
+    const detachSteps = attachStepLogger(executedSteps, assertionSteps);
     const groupId = this.recorder ? await this.recorder.beginAction(codeString) : null;
     this.playwrightGroupId = groupId;
     const detachResponses = this.captureResponses();
@@ -387,7 +387,7 @@ class Action {
       this.restorePageTimeout();
       detachResponses();
       if (groupId) await this.recorder!.endAction();
-      detachStepLogger(stepListener);
+      detachSteps();
       if (stepSpan) {
         stepSpan.end();
       }
@@ -489,7 +489,7 @@ const ASSERTION_STEP_NAMES = new Set(['see', 'dontSee', 'seeElement', 'dontSeeEl
 
 type StepListener = (step: any, error?: any) => void;
 
-export const attachStepLogger = (target: ExecutedStep[], assertionsTarget?: Array<{ name: string; args: any[] }>): StepListener => {
+export const attachStepLogger = (target: ExecutedStep[], assertionsTarget?: Array<{ name: string; args: any[] }>): (() => void) => {
   const listener: StepListener = (step, error) => {
     if (!step?.toCode) return;
     if (step.name?.startsWith('grab')) return;
@@ -507,12 +507,10 @@ export const attachStepLogger = (target: ExecutedStep[], assertionsTarget?: Arra
   };
   codeceptjs.event.dispatcher.on(codeceptjs.event.step.passed, listener);
   codeceptjs.event.dispatcher.on(codeceptjs.event.step.failed, listener);
-  return listener;
-};
-
-export const detachStepLogger = (listener: StepListener) => {
-  codeceptjs.event.dispatcher.off(codeceptjs.event.step.passed, listener);
-  codeceptjs.event.dispatcher.off(codeceptjs.event.step.failed, listener);
+  return () => {
+    codeceptjs.event.dispatcher.off(codeceptjs.event.step.passed, listener);
+    codeceptjs.event.dispatcher.off(codeceptjs.event.step.failed, listener);
+  };
 };
 
 const readFocusedElement = () => {

--- a/src/action.ts
+++ b/src/action.ts
@@ -37,6 +37,7 @@ class Action {
   public playwrightHelper: any;
   public playwrightGroupId: string | null = null;
   public assertionSteps: Array<{ name: string; args: any[] }> = [];
+  public executedSteps: ExecutedStep[] = [];
   public lastValue: unknown;
   private recorder?: PlaywrightRecorder;
   private recovery: RecoveryRunner;
@@ -329,7 +330,7 @@ class Action {
 
     let codeString = code.replace(/^\(I\) => /, '').trim();
 
-    const executedSteps: string[] = [];
+    const executedSteps: ExecutedStep[] = [];
     const assertionSteps: Array<{ name: string; args: any[] }> = [];
     const stepListener = attachStepLogger(executedSteps, assertionSteps);
     const groupId = this.recorder ? await this.recorder.beginAction(codeString) : null;
@@ -365,7 +366,7 @@ class Action {
       this.restorePageTimeout();
 
       if (executedSteps.length > 0) {
-        codeString = executedSteps.join('\n');
+        codeString = executedSteps.map((step) => step.command).join('\n');
       }
 
       const pageState = await this.captureOnce({ codeBlock: codeString });
@@ -382,6 +383,7 @@ class Action {
       this.assertionSteps = [];
       throw err;
     } finally {
+      this.executedSteps = executedSteps;
       this.restorePageTimeout();
       detachResponses();
       if (groupId) await this.recorder!.endAction();
@@ -487,11 +489,13 @@ const ASSERTION_STEP_NAMES = new Set(['see', 'dontSee', 'seeElement', 'dontSeeEl
 
 type StepListener = (step: any, error?: any) => void;
 
-const attachStepLogger = (target: string[], assertionsTarget?: Array<{ name: string; args: any[] }>): StepListener => {
+export const attachStepLogger = (target: ExecutedStep[], assertionsTarget?: Array<{ name: string; args: any[] }>): StepListener => {
   const listener: StepListener = (step, error) => {
     if (!step?.toCode) return;
     if (step.name?.startsWith('grab')) return;
-    target.push(step.toCode());
+    const executed: ExecutedStep = { command: step.toCode(), success: !error };
+    if (error) executed.error = errorToString(error);
+    target.push(executed);
     if (assertionsTarget && ASSERTION_STEP_NAMES.has(step.name)) {
       assertionsTarget.push({ name: step.name, args: step.args || [] });
     }
@@ -506,7 +510,7 @@ const attachStepLogger = (target: string[], assertionsTarget?: Array<{ name: str
   return listener;
 };
 
-const detachStepLogger = (listener: StepListener) => {
+export const detachStepLogger = (listener: StepListener) => {
   codeceptjs.event.dispatcher.off(codeceptjs.event.step.passed, listener);
   codeceptjs.event.dispatcher.off(codeceptjs.event.step.failed, listener);
 };
@@ -530,3 +534,9 @@ const readFocusedElement = () => {
   if (typeof value === 'string' && value) focused.value = value.slice(0, 200);
   return focused;
 };
+
+export interface ExecutedStep {
+  command: string;
+  success: boolean;
+  error?: string;
+}

--- a/src/ai/navigator.ts
+++ b/src/ai/navigator.ts
@@ -3,6 +3,7 @@ import dedent from 'dedent';
 import { z } from 'zod';
 import { ActionResult } from '../action-result.js';
 import type Action from '../action.ts';
+import type { ExecutedStep } from '../action.ts';
 import type { ExplorbotConfig } from '../config.ts';
 import type { ExperienceTracker } from '../experience-tracker.js';
 import Explorer from '../explorer.ts';
@@ -37,6 +38,7 @@ class Navigator implements Agent {
 
   private MAX_ATTEMPTS = Number.parseInt(process.env.MAX_ATTEMPTS || '5');
   lastFailureReason: string | null = null;
+  executedSteps: ExecutedStep[] = [];
 
   private systemPrompt = dedent`
   <role>
@@ -217,6 +219,7 @@ class Navigator implements Agent {
     if (!this.provider) throw new Error('AI-assisted recovery is unavailable: no AI model is configured.');
 
     this.lastFailureReason = null;
+    this.executedSteps = [];
     tag('info').log('AI Navigator resolving state at', actionResult.url);
     debugLog('Resolution message:', message);
 
@@ -466,6 +469,7 @@ class Navigator implements Agent {
 
     debugLog(`Attempting resolution: ${codeBlock}`);
     const ok = await action.attempt(codeBlock, message);
+    this.executedSteps.push(...action.executedSteps);
 
     const page = action.playwrightHelper?.page;
     if (page) {

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1,6 +1,7 @@
 import { tool } from 'ai';
 import dedent from 'dedent';
 import { z } from 'zod';
+import type { ExecutedStep } from '../action.ts';
 import { ActionResult, type PageDiff, type ToolResultMetadata } from '../action-result.ts';
 import { type ExperienceTracker, renderExperienceRecipes } from '../experience-tracker.ts';
 import { Stats } from '../stats.ts';
@@ -411,7 +412,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
             const message = errorText(action.lastError);
             await commitNote(activeNote, TestResult.FAILED, toolResult, action);
 
-            let formSuggestion = 'Look into error message and identify which commands passed and which failed. Continue execution using step-by-step approach using click() and form() tools.';
+            let formSuggestion = 'Commands after the failing one never ran. Retry only those, using click() or form().';
             if (message.toLowerCase().includes(MULTIPLE_ELEMENTS_PATTERN)) {
               const disambiguated = await disambiguateElements(action.lastError, explanation, ai);
               if (disambiguated) {
@@ -421,10 +422,11 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
 
             return failedToolResult(
               'form',
-              `Form execution FAILED! ${message}`,
+              `Form execution FAILED! ${message}\n${formatExecutedSteps(action.executedSteps, codeLines.length)}`,
               {
                 ...toolResult,
                 code: codeBlock,
+                attempts: action.executedSteps,
                 suggestion: formSuggestion,
               },
               action.lastError
@@ -446,6 +448,7 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
               ...toolResult,
               message: `Form completed successfully with ${lines.length} commands.`,
               commandsExecuted: lines.length,
+              attempts: action.executedSteps,
               code: codeBlock,
               suggestion: 'Verify the form was filled in correctly using see() tool. If needed to submit: try click() tool or form() with I.pressKey("Enter").',
             },
@@ -806,21 +809,26 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
           const actionResult = ActionResult.fromState(currentState);
           const experience = renderExperienceRecipes(explorer.activeTest?.getAppliedExperience(actionResult) ?? []);
           const success = await navigator.resolveState(instruction, actionResult, { experience });
+          const attempts = navigator.executedSteps;
+          let stepReport = '';
+          if (attempts.length) stepReport = `\n${formatExecutedSteps(attempts)}`;
 
           const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, instruction);
 
           if (success) {
             return successToolResult('interact', {
               ...toolResult,
-              message: `Successfully executed: ${instruction}`,
+              message: `Successfully executed: ${instruction}${stepReport}`,
+              attempts,
             });
           }
 
           let reason = '';
           if (navigator.lastFailureReason) reason = `: ${navigator.lastFailureReason}`;
 
-          return failedToolResult('interact', `Failed to execute: ${instruction}${reason}`, {
+          return failedToolResult('interact', `Failed to execute: ${instruction}${reason}${stepReport}`, {
             ...toolResult,
+            attempts,
             suggestion: 'The action could not be completed. Try a different instruction or use more specific element descriptions.',
           });
         } catch (error) {
@@ -1230,6 +1238,14 @@ export function isMajorPageChange(pageDiff: PageDiff): boolean {
 
 export function hasFailedRequest(pageDiff: PageDiff): boolean {
   return (pageDiff.requests ?? []).some((request) => request.status >= 400);
+}
+
+export function formatExecutedSteps(steps: ExecutedStep[], requestedCount = steps.length): string {
+  if (!steps.length) return `No command ran of ${requestedCount} requested.`;
+  const lines = steps.map((step) => `  ${step.success ? 'OK' : 'FAILED'} ${step.command}`);
+  const notRun = requestedCount - steps.length;
+  if (notRun > 0) lines.push(`  NOT RUN ${notRun} more`);
+  return lines.join('\n');
 }
 
 function hasObservablePageChange(data?: Record<string, any>): boolean {

--- a/tests/unit/executed-steps.test.ts
+++ b/tests/unit/executed-steps.test.ts
@@ -1,0 +1,43 @@
+import codeceptjs from 'codeceptjs';
+import { describe, expect, it } from 'bun:test';
+import { attachStepLogger, detachStepLogger, type ExecutedStep } from '../../src/action.ts';
+import { formatExecutedSteps } from '../../src/ai/tools.ts';
+
+function step(code: string) {
+  return { name: code.replace(/^I\./, '').replace(/\(.*/, ''), args: [], toCode: () => code };
+}
+
+describe('executed steps', () => {
+  it('records each command with its status and stops at the failing one', () => {
+    const steps: ExecutedStep[] = [];
+    const listener = attachStepLogger(steps);
+
+    codeceptjs.event.dispatcher.emit(codeceptjs.event.step.passed, step("I.amOnPage('/suite/1')"));
+    codeceptjs.event.dispatcher.emit(codeceptjs.event.step.failed, step("I.waitForElement('Some Title')"), new Error('still not present on page after 30 sec'));
+
+    detachStepLogger(listener);
+
+    expect(steps).toHaveLength(2);
+    expect(steps[0]).toMatchObject({ command: "I.amOnPage('/suite/1')", success: true });
+    expect(steps[1]?.success).toBe(false);
+    expect(steps[1]?.error).toContain('still not present');
+  });
+
+  it('reports a successful command even when a later one fails', () => {
+    const report = formatExecutedSteps(
+      [
+        { command: "I.amOnPage('/suite/1')", success: true },
+        { command: "I.waitForElement('Some Title')", success: false, error: 'not present' },
+      ],
+      3
+    );
+
+    expect(report).toContain("OK I.amOnPage('/suite/1')");
+    expect(report).toContain("FAILED I.waitForElement('Some Title')");
+    expect(report).toContain('NOT RUN 1 more');
+  });
+
+  it('reports when nothing ran', () => {
+    expect(formatExecutedSteps([], 2)).toBe('No command ran of 2 requested.');
+  });
+});

--- a/tests/unit/executed-steps.test.ts
+++ b/tests/unit/executed-steps.test.ts
@@ -1,6 +1,6 @@
 import codeceptjs from 'codeceptjs';
 import { describe, expect, it } from 'bun:test';
-import { attachStepLogger, detachStepLogger, type ExecutedStep } from '../../src/action.ts';
+import { attachStepLogger, type ExecutedStep } from '../../src/action.ts';
 import { formatExecutedSteps } from '../../src/ai/tools.ts';
 
 function step(code: string) {
@@ -10,12 +10,12 @@ function step(code: string) {
 describe('executed steps', () => {
   it('records each command with its status and stops at the failing one', () => {
     const steps: ExecutedStep[] = [];
-    const listener = attachStepLogger(steps);
+    const detachSteps = attachStepLogger(steps);
 
     codeceptjs.event.dispatcher.emit(codeceptjs.event.step.passed, step("I.amOnPage('/suite/1')"));
     codeceptjs.event.dispatcher.emit(codeceptjs.event.step.failed, step("I.waitForElement('Some Title')"), new Error('still not present on page after 30 sec'));
 
-    detachStepLogger(listener);
+    detachSteps();
 
     expect(steps).toHaveLength(2);
     expect(steps[0]).toMatchObject({ command: "I.amOnPage('/suite/1')", success: true });

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -6,23 +6,23 @@ const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 const pageRegistry = new Map<string, string>();
 
 mock.module('codeceptjs', () => {
-  const listeners = new Map<string, Array<(payload: any) => void>>();
+  const listeners = new Map<string, Array<(...args: any[]) => void>>();
   const dispatch = {
-    on(event: string, handler: (payload: any) => void) {
+    on(event: string, handler: (...args: any[]) => void) {
       const handlers = listeners.get(event) || [];
       listeners.set(event, [...handlers, handler]);
     },
-    off(event: string, handler: (payload: any) => void) {
+    off(event: string, handler: (...args: any[]) => void) {
       const handlers = listeners.get(event) || [];
       listeners.set(
         event,
         handlers.filter((fn) => fn !== handler)
       );
     },
-    emit(event: string, payload: any) {
+    emit(event: string, ...args: any[]) {
       const handlers = listeners.get(event) || [];
       for (const handler of handlers) {
-        handler(payload);
+        handler(...args);
       }
     },
   };

--- a/tests/unit/navigator-attempt-hook.test.ts
+++ b/tests/unit/navigator-attempt-hook.test.ts
@@ -16,6 +16,7 @@ describe('Navigator resolveState attempt hook', () => {
     const action: any = {
       lastError: null,
       actionResult: null,
+      executedSteps: [],
       exitIframe: async () => {},
       attempt: async (code: string) => {
         if (code.includes(succeedsWith)) {

--- a/tests/unit/navigator-resolve-state.test.ts
+++ b/tests/unit/navigator-resolve-state.test.ts
@@ -41,6 +41,7 @@ function createHarness(
   const action: any = {
     lastError: null,
     actionResult: null,
+    executedSteps: [],
     exitIframe: async () => {},
     attempt: async (code: string) => {
       attempts.push(code);


### PR DESCRIPTION
## The bug

`form()` sends many commands and gets back one pass/fail. A command that errors erases the evidence that everything before it worked.

Session `OtherYappiestIndigo973` (trace `33fe2b45ba23ed568a2dcc0769deacb3`):

```js
I.amOnPage('/projects/.../suite/28989496')                  // ran, navigated
I.waitForElement('Description Persistence Suite Other…')    // a title, not a locator — 30s timeout
```

The tool reported only `Form execution FAILED!`. Pilot concluded the reload never happened, rejected `finish()` three times, and failed a scenario whose own verifications had passed.

## The fix

`attachStepLogger` already listened to both `step.passed` and `step.failed`, so it always saw which commands ran and which one broke — the list was just discarded on the error path.

The executors own the information; the tools only read it:

- **`Action.executedSteps`** — `{command, success, error?}`, the shape `click()` already returns.
- **`Navigator.executedSteps`** — accumulated across the attempts it drives, alongside the existing `lastFailureReason`.
- **`form()` / `interact()`** — read those and report, in the `message` (the channel that reaches the tester conversation *and* Pilot's session log) and as structured `attempts`, which pilot's `formatActions` already reads.

```
Form execution FAILED! element (…) still not present on page after 30 sec
  OK I.amOnPage('/projects/.../suite/28989496')
  FAILED I.waitForElement('Description Persistence Suite Other…')
```

No prompt changes: with the commands enumerated, neither the Tester nor Pilot has to infer what ran.

`ActionResult` was considered as the carrier and rejected — it is a page-state snapshot, persisted and rebuilt via `fromState(WebPageState)`, and on the failure path `executeOnce` throws before `captureOnce()` runs, so the only ActionResult available is the previous state object StateManager owns and reuses.

## Verification

- `tests/unit/executed-steps.test.ts` — the failing command is recorded with `success:false`, nothing after it appears, and the report lists OK/FAILED plus how many never ran.
- `bun test tests/unit/ tests/integration/` — 1193 pass, 1 skip. The one failure (`remote > announces the run…`) reproduces on clean `main` under the full suite and passes standalone: pre-existing ordering issue, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
