### PR TITLE
Cap the overlay research prompt, and stop research failures from failing the test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-08-28
+
+### Changes
+
+- [Researcher] Opening a large overlay no longer breaks the model's context window. When a click or
+  a modal revealed a long list — a folder tree, a picker with hundreds of rows — the whole revealed
+  markup was sent for analysis, which on a big page ran to well over a hundred thousand tokens and
+  the request was simply rejected. The revealed markup is now capped, so the overlay gets described
+  and its elements reach the UI map.
+- [Tester] Research that fails no longer fails the test with it. A page or overlay that could not be
+  analyzed is now reported as a warning and the scenario carries on with the accessibility tree it
+  already has, instead of ending the test on an error that had nothing to do with the scenario.
+
 ## 2026-08-23
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 - [Researcher] Opening a large overlay no longer breaks the model's context window. When a click or
   a modal revealed a long list — a folder tree, a picker with hundreds of rows — the whole revealed
   markup was sent for analysis, which on a big page ran to well over a hundred thousand tokens and
-  the request was simply rejected. The revealed markup is now capped, so the overlay gets described
-  and its elements reach the UI map.
+  the request was simply rejected. The revealed markup now goes through the same cleaning as every
+  other page snapshot, which drops the styling classes that made up half its size, and what is left
+  is capped. The overlay gets described and its elements reach the UI map.
 - [Tester] Research that fails no longer fails the test with it. A page or overlay that could not be
   analyzed is now reported as a warning and the scenario carries on with the accessibility tree it
   already has, instead of ending the test on an error that had nothing to do with the scenario.

--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -550,16 +550,7 @@ export class ActionResult implements ActionResultData {
     }
 
     if (diff.htmlParts.length > 0) {
-      const htmlConfig = this.normalizeHtmlConfig();
-      const processedParts: HtmlDiffPart[] = [];
-      for (const part of diff.htmlParts) {
-        const filteredHtml = htmlCombinedSnapshot(part.subtree, htmlConfig?.combined);
-        const minified = await minifyHtml(filteredHtml);
-        if (minified) {
-          processedParts.push({ ...part, subtree: minified });
-        }
-      }
-      const collapsed = collapseHtmlParts(processedParts);
+      const collapsed = collapseHtmlParts(await diff.cleanedHtmlParts());
       if (collapsed.length > 0) {
         pageDiff.htmlParts = collapsed;
       }
@@ -661,6 +652,17 @@ export class Diff {
   get htmlParts(): HtmlDiffPart[] {
     if (!this._htmlDiffResult) return [];
     return this._htmlDiffResult.parts;
+  }
+
+  async cleanedHtmlParts(): Promise<HtmlDiffPart[]> {
+    const htmlConfig = ConfigParser.getInstance().getConfig().html;
+    const cleaned: HtmlDiffPart[] = [];
+    for (const part of this.htmlParts) {
+      const minified = await minifyHtml(htmlCombinedSnapshot(part.subtree, htmlConfig?.combined));
+      if (!minified) continue;
+      cleaned.push({ ...part, subtree: minified });
+    }
+    return cleaned;
   }
 
   get ariaChanged(): string | null {

--- a/src/ai/researcher/deep-analysis.ts
+++ b/src/ai/researcher/deep-analysis.ts
@@ -9,6 +9,7 @@ import { detectFocusArea, diffAriaSnapshots } from '../../utils/aria.ts';
 import { extractCodeBlocks } from '../../utils/code-extractor.ts';
 import { tag } from '../../utils/logger.js';
 import { mdq } from '../../utils/markdown-query.ts';
+import { truncate } from '../../utils/strings.ts';
 import type { Provider } from '../provider.js';
 import { getCachedResearch, getPreviousResearch, saveResearch } from './cache.ts';
 import { type Constructor, debugLog } from './mixin.ts';
@@ -16,6 +17,7 @@ import { type ResearchElement, parseResearchSections } from './parser.ts';
 import type { ResearchResult } from './research-result.ts';
 
 const DEFAULT_MAX_EXPANDABLE_CLICKS = 10;
+const MAX_HTML_DIFF_CHARS = 20_000;
 
 export function WithDeepAnalysis<T extends Constructor>(Base: T) {
   return class extends Base {
@@ -486,6 +488,8 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
         `;
       }
 
+      const htmlChanges = truncate(diff.htmlParts.map((p) => `[Container: ${p.container}]\n${p.subtree}`).join('\n\n'), MAX_HTML_DIFF_CHARS);
+
       const prompt = dedent`
         ${intro}
         Analyze the changes and produce a UI map section.
@@ -494,7 +498,7 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
         ${diff.ariaChanged || 'none'}
 
         HTML changes:
-        ${diff.htmlParts.map((p) => `[Container: ${p.container}]\n${p.subtree}`).join('\n\n') || 'none'}
+        ${htmlChanges || 'none'}
         ${alreadyHint}
 
         Respond with a SINGLE section in this format:

--- a/src/ai/researcher/deep-analysis.ts
+++ b/src/ai/researcher/deep-analysis.ts
@@ -488,7 +488,8 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
         `;
       }
 
-      const htmlChanges = truncate(diff.htmlParts.map((p) => `[Container: ${p.container}]\n${p.subtree}`).join('\n\n'), MAX_HTML_DIFF_CHARS);
+      const cleanedParts = await diff.cleanedHtmlParts();
+      const htmlChanges = truncate(cleanedParts.map((p) => `[Container: ${p.container}]\n${p.subtree}`).join('\n\n'), MAX_HTML_DIFF_CHARS);
 
       const prompt = dedent`
         ${intro}

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -66,6 +66,12 @@ export class Tester extends TaskAgent implements Agent {
   private stalledIterations = 0;
   private readonly MAX_STALLED_ITERATIONS = 3;
 
+  private skipResearch = (err: Error): string => {
+    if (err.name === 'AbortError') throw err;
+    tag('warning').log(`Research skipped: ${err.message}`);
+    return '';
+  };
+
   constructor(deps: AgentDeps, researcher: Researcher, navigator: Navigator, agentTools?: any) {
     super(deps);
     this.requestStore = deps.requestStore;
@@ -568,12 +574,7 @@ export class Tester extends TaskAgent implements Agent {
       const alreadySeenUiMap = this.seenUiMapUrls.has(currentUrl);
       let research = '';
       if (!alreadySeenUiMap) {
-        try {
-          research = await this.researcher.research(currentState);
-        } catch (err) {
-          if (!(err instanceof ErrorPageError)) throw err;
-          tag('warning').log(`Research skipped: ${err.message}`);
-        }
+        research = await this.researcher.research(currentState).catch(this.skipResearch);
       }
       this.pageStateHash = currentStateHash;
       this.pageActionResult = currentState;
@@ -614,7 +615,7 @@ export class Tester extends TaskAgent implements Agent {
     }
 
     if (focusArea.detected && focusArea.name && this.pageStateHash && this.pageActionResult) {
-      const overlaySection = await this.researcher.researchOverlay(currentState, this.pageActionResult, this.pageStateHash);
+      const overlaySection = await this.researcher.researchOverlay(currentState, this.pageActionResult, this.pageStateHash).catch(this.skipResearch);
       if (overlaySection) {
         context += dedent`
 

--- a/tests/integration/researcher.test.ts
+++ b/tests/integration/researcher.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { createOpenAI } from '@ai-sdk/openai';
 import { LLMock } from '@copilotkit/aimock';
 import { ActionResult, Diff } from '../../src/action-result.ts';
+import { clearActivity } from '../../src/activity.ts';
 import { Provider } from '../../src/ai/provider.ts';
 import { Researcher } from '../../src/ai/researcher.ts';
 import { clearResearchCache, getCachedResearch, saveResearch } from '../../src/ai/researcher/cache.ts';
@@ -141,6 +142,7 @@ describe('Researcher with aimock', () => {
     mock.clearFixtures();
     clearResearchCache();
     ConfigParser.setupTestConfig();
+    clearActivity(true);
 
     researcher = new Researcher({ ...createMockDeps(), ai: provider } as any);
 
@@ -149,6 +151,7 @@ describe('Researcher with aimock', () => {
 
   afterAll(async () => {
     await mock.stop();
+    clearActivity(true);
   });
 
   it('returns research markdown from AI response', async () => {
@@ -218,7 +221,7 @@ describe('Researcher with aimock', () => {
   });
 
   it('caps the HTML diff of an expansion so a large overlay stays within context', async () => {
-    const diff = await buildExpansionDiff(4000);
+    const diff = await buildExpansionDiff(600);
 
     await (researcher as any)._analyzeExpandedAction('', 'Select folder', diff, []);
 

--- a/tests/integration/researcher.test.ts
+++ b/tests/integration/researcher.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createOpenAI } from '@ai-sdk/openai';
 import { LLMock } from '@copilotkit/aimock';
-import { ActionResult } from '../../src/action-result.ts';
+import { ActionResult, Diff } from '../../src/action-result.ts';
 import { Provider } from '../../src/ai/provider.ts';
 import { Researcher } from '../../src/ai/researcher.ts';
 import { clearResearchCache, getCachedResearch, saveResearch } from '../../src/ai/researcher/cache.ts';
@@ -103,6 +103,15 @@ function extractPromptText(entry: any): string {
       return '';
     })
     .join('\n');
+}
+
+const TREE_ROW = '<li class="tree-node flex items-center px-2 space-x-2 opacity-40"><button class="expand-btn">Open folder</button><span>Folder name here</span></li>';
+
+async function buildExpansionDiff(rows: number): Promise<Diff> {
+  const page = (body: string, aria: string) => new ActionResult({ url: '/tasks/board', title: 'Task Board', html: `<html><body><main>${body}</main></body></html>`, ariaSnapshot: aria });
+  const previous = page('<div class="tree"></div>', '- main');
+  const current = page(`<div class="tree"><ul>${TREE_ROW.repeat(rows)}</ul></div>`, '- main\n- button "Select folder"');
+  return Diff.create(current, previous);
 }
 
 describe('Researcher with aimock', () => {
@@ -209,11 +218,7 @@ describe('Researcher with aimock', () => {
   });
 
   it('caps the HTML diff of an expansion so a large overlay stays within context', async () => {
-    const treeRow = '<li class="tree-node"><button class="expand-btn"></button><span>Folder</span></li>';
-    const diff: any = {
-      ariaChanged: '- button "Select folder"',
-      htmlParts: Array.from({ length: 400 }, (_, i) => ({ container: `body > div:nth-child(${i + 1})`, subtree: treeRow.repeat(20) })),
-    };
+    const diff = await buildExpansionDiff(4000);
 
     await (researcher as any)._analyzeExpandedAction('', 'Select folder', diff, []);
 
@@ -221,6 +226,18 @@ describe('Researcher with aimock', () => {
     const htmlChanges = prompt.slice(prompt.indexOf('HTML changes:'));
     expect(htmlChanges.length).toBeLessThan(25_000);
     expect(prompt).toContain('button "Select folder"');
-    expect(prompt).toContain('[Container: body > div:nth-child(1)]');
+    expect(prompt).toContain('[Container:');
+  });
+
+  it('strips utility classes from an expansion so the cap holds real elements', async () => {
+    await (researcher as any)._analyzeExpandedAction('', 'Select folder', await buildExpansionDiff(2), []);
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    const htmlChanges = prompt.slice(prompt.indexOf('HTML changes:'));
+    expect(htmlChanges).not.toContain('flex');
+    expect(htmlChanges).not.toContain('px-2');
+    expect(htmlChanges).not.toContain('space-x-2');
+    expect(htmlChanges).toContain('tree-node');
+    expect(htmlChanges).toContain('Folder');
   });
 });

--- a/tests/integration/researcher.test.ts
+++ b/tests/integration/researcher.test.ts
@@ -207,4 +207,20 @@ describe('Researcher with aimock', () => {
     expect(cached).toContain('## Navigation');
     expect(cached).toContain('Create Task');
   });
+
+  it('caps the HTML diff of an expansion so a large overlay stays within context', async () => {
+    const treeRow = '<li class="tree-node"><button class="expand-btn"></button><span>Folder</span></li>';
+    const diff: any = {
+      ariaChanged: '- button "Select folder"',
+      htmlParts: Array.from({ length: 400 }, (_, i) => ({ container: `body > div:nth-child(${i + 1})`, subtree: treeRow.repeat(20) })),
+    };
+
+    await (researcher as any)._analyzeExpandedAction('', 'Select folder', diff, []);
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    const htmlChanges = prompt.slice(prompt.indexOf('HTML changes:'));
+    expect(htmlChanges.length).toBeLessThan(25_000);
+    expect(prompt).toContain('button "Select folder"');
+    expect(prompt).toContain('[Container: body > div:nth-child(1)]');
+  });
 });

--- a/tests/unit/tester-focus-scope.test.ts
+++ b/tests/unit/tester-focus-scope.test.ts
@@ -169,7 +169,7 @@ describe('Tester research failures', () => {
     };
     const state = buildState('- main:', '/page');
 
-    expect((tester as any).reinjectContextIfNeeded(2, state)).rejects.toThrow('aborted');
+    await expect((tester as any).reinjectContextIfNeeded(2, state)).rejects.toThrow('aborted');
   });
 });
 

--- a/tests/unit/tester-focus-scope.test.ts
+++ b/tests/unit/tester-focus-scope.test.ts
@@ -133,6 +133,46 @@ describe('Tester reinjectContextIfNeeded — focus scope hint', () => {
   });
 });
 
+describe('Tester research failures', () => {
+  it('keeps the scenario running when page research fails, reporting it as a warning', async () => {
+    const tester = buildTester();
+    (tester as any).researcher.research = async () => {
+      throw new Error('Please reduce the length of the messages or completion.');
+    };
+    const state = buildState('- main:\n  - button "Save"', '/page');
+
+    const context = await (tester as any).reinjectContextIfNeeded(2, state);
+
+    expect(context).toContain('CURRENT URL: /page');
+    expect(context).not.toContain('</page_ui_map>');
+  });
+
+  it('keeps the scenario running when overlay research fails', async () => {
+    const tester = buildTester();
+    (tester as any).researcher.researchOverlay = async () => {
+      throw new Error('Please reduce the length of the messages or completion.');
+    };
+    await (tester as any).reinjectContextIfNeeded(1, buildState('- main:', '/page'));
+
+    const context = await (tester as any).reinjectContextIfNeeded(2, buildState('- dialog "Select folder":\n  - button "OK"', '/page'));
+
+    expect(context).toContain('<focus_scope>');
+    expect(context).not.toContain('</page_ui_map_overlay>');
+  });
+
+  it('still aborts the scenario when research is interrupted', async () => {
+    const tester = buildTester();
+    (tester as any).researcher.research = async () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      throw err;
+    };
+    const state = buildState('- main:', '/page');
+
+    expect((tester as any).reinjectContextIfNeeded(2, state)).rejects.toThrow('aborted');
+  });
+});
+
 describe('Tester experience context', () => {
   it('keeps recorded experience out of the scenario prompt, so only what the Pilot forwards reaches it', () => {
     const tester = buildTesterWithExperience();


### PR DESCRIPTION
Diagnosed from Langfuse trace `efd815cbccf9f81ed069a5e601f5223a` (session `BumpyNuclearAquamarine742`).

## What happened

A tester scenario — *"Create a new suite inside a visible parent folder"* — clicked `Creates in: Root`, which opened a `Select folder` modal, then tried three times to fill the suite title while that modal still covered the page. The third failure said so outright: `<div id="modal-overlays">...</div> subtree intercepts pointer events`.

The one mechanism that would have told the tester what was inside that modal is the researcher's overlay expansion. It never ran. Its prompt was **594,334 characters (~150k tokens)** and failed 12 times in 5.3 seconds with `Please reduce the length of the messages or completion.` The tester counted those as execution errors and handed the scenario to the Pilot, which failed it.

## Root cause

`_analyzeExpandedAction` interpolated `diff.htmlParts` into a single-shot prompt with no size bound. The modal's diff was 464 `<li class="tree-node">` rows of a folder tree.

The diff's own cleaning did run — `NON_SEMANTIC_TAGS` in `html-diff.ts` strips `path`, `g`, `circle`, `use` and the rest, so there is not a single `<path>` in the 566k-char prompt. What it does not strip is the `<svg>` element itself (911 empty tags, 108k chars, 19%) or class attributes, and those are the bulk: `class=` alone is **290k chars, 51% of the block**.

Unlike the tool path (`ActionResult.toPageDiff()`), this one also skipped `htmlCombinedSnapshot`/`minifyHtml`, which is where class filtering lives — so the diff never ran the `TAILWIND_CLASS_PATTERNS` filtering that every other snapshot gets.

It was never recoverable. The prompt sizes across the 12 attempts show the reduction ladder achieving 1.5%:

```
594334 x3 -> trimMessagesForRetry -> 585374 x3 -> throw   (x2, the tester researches the overlay twice)
```

`compactMessagesForRetry` bails on a 1-message array, and there are no tagged blocks worth trimming in a plain prompt.

## Changes

**1. Cap the revealed markup** (`deep-analysis.ts`) — `MAX_HTML_DIFF_CHARS = 20_000` applied via the existing `truncate()` to the *joined* HTML block; a per-part cap would still multiply across 200+ parts. The cap sits at the prompt site rather than on `Diff.htmlParts`, which also feeds `toPageDiff`.

**2. Clean the markup the way every other snapshot is cleaned** (`action-result.ts`, `deep-analysis.ts`) — `toPageDiff` already did this inline, so it moves onto `Diff` as `cleanedHtmlParts()` and both call sites use it instead of two copies of the loop. `collapseHtmlParts` stays in `toPageDiff`: its full-page-re-render collapse is a tool-output concern the research prompt should not inherit.

On this content that is 565,328 → 314,257 chars. It does not by itself make the prompt fit (~78k tokens), so the cap still does that — but it roughly doubles how many real elements survive underneath it.

**3. Research failures warn instead of failing the test** (`tester.ts`) — a shared `.catch(this.skipResearch)` on both research calls. This widens the existing catch, which only swallowed `ErrorPageError`, and covers the overlay call, which had no catch at all. `AbortError` still propagates so an interrupted run aborts.

## Trade-off

On expansions whose diff exceeds 20k characters the model sees only the first slice, so elements appearing late in the diff may lose their CSS column — they still reach it through the (already capped) ARIA block as ARIA locators.

## Tests

Five new tests, each verified to fail without the code it covers:

- the expansion prompt stays capped for a 600-row folder tree
- utility classes are stripped from an expansion while component classes survive
- a scenario survives page research failing
- a scenario survives overlay research failing
- an interrupted research still aborts the scenario — a guard on the one sharp edge of the blanket catch

`bun test tests/unit/` 1079 pass · `bun test tests/integration/` 81 pass · `bun run check:fix` clean.

This touches the researcher and tester loop, so it is worth a `regression` label before merge — I have not applied one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjKP4UoeEM57WCm7KvD6D9




## Residue worth knowing about

Ember framework classes still survive the clean — `ember-attacher*` and `ember-view` account for ~2,000 occurrences on this page — because `cleanElement` applies `TAILWIND_CLASS_PATTERNS` but not `TRASH_HTML_CLASSES`, which does list `ember-`. Left alone deliberately: widening `cleanElement` changes every `combinedHtml()` consumer, and `isGenericClass` in the xpath utils keeps component classes on purpose as locator anchors. Worth a separate decision.