### PR TITLE
Accept name as an alias for text in ARIA locators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 2026-08-28
+
+### Changes
+
+- [Researcher] UI map rows written as `{ role: 'checkbox', name: 'Filter' }` keep their locator. Both
+  `text` and `name` name an element the same way when a locator runs, but the UI map only recognised
+  `text` and blanked every row using `name` to `-`, throwing away a locator that works. Three prompts
+  also spent a line teaching that `name` is wrong; they no longer do.
+
 ## 2026-08-23
 
 ### Changes

--- a/src/ai/researcher.ts
+++ b/src/ai/researcher.ts
@@ -403,7 +403,6 @@ export class Researcher extends ResearcherBase implements Agent {
       - If an element has data-explorbot-hit="covered" or "offscreen", do not present it as directly actionable. Prefer the overlay, drawer, dialog, or focused section covering it, and mention what must be dismissed or revealed first.
       - Every element with an eidx attribute MUST appear in exactly one matching UI map section — describe icon-only buttons by their visual role.
       - Every UI map row needs a CSS selector; ARIA may be "-" for icon-only buttons, CSS must never be "-".
-      - ARIA locator JSON uses keys "role" and "text" (NOT "name").
       - Mark elements with likely hover interactions (title, aria-describedby, menu items with submenus) as "(hover)".
       </rules>
 

--- a/src/ai/researcher/sections.ts
+++ b/src/ai/researcher/sections.ts
@@ -111,7 +111,6 @@ export function WithSections<T extends Constructor>(Base: T) {
         - Do not copy global toolbar, navigation, list, or detail elements into this section unless they are descendants of this section container.
         - Every element with eidx inside this section's container MUST appear in the table.
         - Every row needs CSS; ARIA may be "-" for icon-only buttons.
-        - ARIA locator JSON uses keys "role" and "text" (NOT "name").
         - Elements marked data-explorbot-hit="covered" or "offscreen" are not directly actionable; describe the covering or focused UI first.
         - In split-pane pages, entity detail panels are active detail context; include close/back/pin controls in the detail panel section when present.
         </rules>

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -71,7 +71,6 @@ const locatorStrategyRule = dedent`
 
   <bad_aria_locator_example>
   { "role": "button", "text": "" }  // INVALID - empty text is useless, use "-" instead
-  { "role": "button", "name": "Save" }  // WRONG key - use "text", not "name"
   </bad_aria_locator_example>
 
   NEVER include \`eidx\` attribute in any locator (ARIA, CSS, XPath). It is an internal annotation.

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -586,7 +586,7 @@ export function parseAriaLocator(ariaStr: string): { role: string; text: string 
   const trimmed = ariaStr.trim();
   if (trimmed === '-' || trimmed === '' || trimmed === '"-"') return null;
 
-  const match = trimmed.match(/\{\s*["']?role["']?\s*:\s*['"]([^'"]+)['"]\s*,\s*["']?text["']?\s*:\s*['"]([^'"]*)['"]\s*\}/);
+  const match = trimmed.match(/\{\s*["']?role["']?\s*:\s*['"]([^'"]+)['"]\s*,\s*["']?(?:text|name)["']?\s*:\s*['"]([^'"]*)['"]\s*\}/);
   if (!match) return null;
 
   return { role: match[1], text: match[2] };

--- a/tests/unit/aria.test.ts
+++ b/tests/unit/aria.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { compactAriaSnapshot, diffAriaSnapshots } from '../../src/utils/aria.ts';
+import { compactAriaSnapshot, diffAriaSnapshots, parseAriaLocator } from '../../src/utils/aria.ts';
 
 describe('aria', () => {
   it('returns null diff for identical snapshots', () => {
@@ -252,5 +252,14 @@ describe('aria', () => {
 
     expect(result).toContain('ref=e10');
     expect(result).toContain('ref=e13');
+  });
+
+  it('reads an ARIA locator written with the name key, as CodeceptJS resolves it', () => {
+    expect(parseAriaLocator("{ role: 'checkbox', name: 'Select test or suite' }")).toEqual({ role: 'checkbox', text: 'Select test or suite' });
+    expect(parseAriaLocator("{ role: 'button', text: 'Save' }")).toEqual({ role: 'button', text: 'Save' });
+  });
+
+  it('rejects a key that carries no accessible name', () => {
+    expect(parseAriaLocator("{ role: 'button', aria-label: 'Close' }")).toBeNull();
   });
 });


### PR DESCRIPTION
## The runtime already accepts both keys

`handleRoleLocator` in CodeceptJS (`lib/helper/Playwright.js:4210`):

```js
if (roleObj.text) options.name = roleObj.text
if (roleObj.name) options.name = roleObj.name
```

Both land on Playwright's `getByRole(role, { name })`, and `I.click` reaches it — `findClickable` → `findElements` → `handleRoleLocator` for any non-fuzzy role object. Verified against the installed CodeceptJS:

```
{"role":"checkbox","name":"Select test or suite"}  → getByRole(checkbox, {"name":"Select test or suite"})
{"role":"button","text":"Save"}                    → getByRole(button,   {"name":"Save"})
```

`parseAriaLocator` (`src/utils/aria.ts:589`) only ever matched `text`.

## What that cost

`ResearchResult.cleanup()` (`src/ai/researcher/research-result.ts:75`) blanks any ARIA cell the parser cannot read:

```js
if (row.ARIA && !parseAriaLocator(row.ARIA)) {
  row.ARIA = '-';
}
```

So a UI map row the model wrote as `{ role: 'checkbox', name: 'Filter' }` — a locator that resolves correctly at runtime — was thrown away before the Tester ever saw it, and the `Type` backfill on the line above (`parseAriaLocator(row.ARIA)?.role`) fell back to `-` with it.

Meanwhile three prompts each spent a line policing the distinction:

- `src/ai/rules.ts:74` — listed `{ "role": "button", "name": "Save" }` as a **bad** ARIA locator example
- `src/ai/researcher.ts:406` and `src/ai/researcher/sections.ts:114` — *"ARIA locator JSON uses keys \"role\" and \"text\" (NOT \"name\")."*

Three places enforcing a restriction Playwright does not make, on a key that is arguably the more accurate name for what it selects.

## The change

One token in the parser — `(?:text|name)` — and the three rules deleted.

## Not changed: `aria-label`

The overlay UI map that prompted this also emitted `{ role: 'button', aria-label: 'Close' }`. That one is genuinely broken, and worse than an error:

```
{"role":"button","aria-label":"Close"} → getByRole(button, undefined)   // matches EVERY button
```

Neither key is present, so the name option is dropped and the locator silently over-matches. `parseAriaLocator` still rejects it and `cleanup()` still blanks it to `-`, which is the right outcome — a missing locator beats one that matches every button on the page. Left alone deliberately; worth handling separately if the silent over-match shows up in a session.

## Background

Found while diagnosing session `LimitedReluctantBlue585`, alongside #149. Note that the failed checkbox clicks in that session were **not** caused by this — the picker had already closed by then. This is a separate defect the same trace exposed.

## Tests

`tests/unit/aria.test.ts` gains two cases: `name` and `text` parse to the same result, and a key carrying no accessible name is still rejected. The first fails on `main`.

- `bun test tests/unit/` — 1078 pass
- `bun test tests/integration/` — 80 pass, 1 skip
- `bun run format`, `bun run lint:fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D1omW7q6MBzFAuxqvoJEy