### PR TITLE
Let Pilot read the Tester's reasoning on failed actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-08-28
+
+### Changes
+
+- [Pilot] When a Tester action fails, Pilot now also sees the Tester's own account of why it picked
+  that element, not just the failure message. A Tester that admits it cannot find a control and
+  clicks a made-up one anyway is now visible to Pilot on the first failure, instead of only showing
+  up as a run of identical failed attempts. Shown for failed actions only, and only for models that
+  report their thinking.
+
 ## 2026-08-23
 
 ### Changes

--- a/src/ai/conversation.ts
+++ b/src/ai/conversation.ts
@@ -5,12 +5,13 @@ export interface ToolExecution {
   input: any;
   output: any;
   wasSuccessful: boolean;
+  reasoning?: string;
 }
 
-export function toToolExecution(toolName: string, input: any, rawOutput: any): ToolExecution {
+export function toToolExecution(toolName: string, input: any, rawOutput: any, reasoning?: string): ToolExecution {
   let output = rawOutput;
   if (rawOutput?.type === 'json' && rawOutput?.value) output = rawOutput.value;
-  return { toolName, input, output, wasSuccessful: output?.success !== false };
+  return { toolName, input, output, wasSuccessful: output?.success !== false, reasoning };
 }
 
 export function toolExecutionLabel(input: Record<string, any> | undefined): string {
@@ -211,13 +212,17 @@ export class Conversation {
   }
 
   getToolExecutions(): ToolExecution[] {
-    const toolCalls = new Map<string, any>();
+    const toolCalls = new Map<string, { input: any; reasoning?: string }>();
     for (const message of this.messages) {
       if (message.role !== 'assistant') continue;
       if (!Array.isArray(message.content)) continue;
+      const reasoning = message.content
+        .filter((part: any) => part.type === 'reasoning' && part.text?.trim())
+        .map((part: any) => part.text.trim())
+        .join('\n');
       for (const part of message.content) {
         if (part.type !== 'tool-call') continue;
-        toolCalls.set(part.toolCallId, part.input);
+        toolCalls.set(part.toolCallId, { input: part.input, reasoning });
       }
     }
 
@@ -227,7 +232,8 @@ export class Conversation {
       if (!Array.isArray(message.content)) continue;
       for (const part of message.content) {
         if (part.type !== 'tool-result') continue;
-        executions.push(toToolExecution(part.toolName, toolCalls.get(part.toolCallId) || {}, part.output));
+        const call = toolCalls.get(part.toolCallId);
+        executions.push(toToolExecution(part.toolName, call?.input || {}, part.output, call?.reasoning));
       }
     }
 

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -27,6 +27,7 @@ import { withdrawVisionTools } from './tools.ts';
 
 const CHECK_TOOLS = ['verify', 'see', 'research', 'context'];
 const META_TOOLS = ['record', 'reset', 'stop', 'finish'];
+const PILOT_REASONING_LIMIT = 500;
 const PILOT_MESSAGE_LIMIT = 2;
 const PILOT_MESSAGE_MAX_LENGTH = 160;
 
@@ -1038,6 +1039,12 @@ export class Pilot implements Agent {
 
         if (resultMessage) line += `\n   result: ${resultMessage}`;
         if (errorDetail && errorDetail !== resultMessage) line += `\n   error: ${errorDetail}`;
+
+        if (!t.wasSuccessful && t.reasoning) {
+          let rationale = t.reasoning;
+          if (rationale.length > PILOT_REASONING_LIMIT) rationale = `...${rationale.slice(-PILOT_REASONING_LIMIT)}`;
+          line += `\n   tester reasoned: ${rationale.replace(/\n+/g, ' ')}`;
+        }
 
         const attempts = t.output?.attempts;
         if (attempts && attempts.length > 1 && t.wasSuccessful) {


### PR DESCRIPTION
Pilot already receives the Tester's conversation, but `getToolExecutions()` walked only `tool-call` and `tool-result` parts. The Tester's own account of *why* it picked an element was retained in the messages and dropped on the way out — Pilot saw what the Tester did and never why.

## Why it matters

Diagnosing a failed session (trace `e6aaae29db58c9b0cd3adde10d994e37`), the decisive evidence was sitting in the Tester's reasoning the whole time:

> *"In aria snapshot earlier, I didn't see such. But we can attempt click using text \"H1\"."*

The Tester stated that the control was in neither the accessibility tree nor the UI map, then clicked an invented locator anyway — 9 action calls across 4 identical `form` retries, with zero grounding calls. All Pilot could see was four failures, with no way to distinguish a fabricated locator from a near miss.

## Change

- `conversation.ts` — `ToolExecution` gains an optional `reasoning`; the toolCallId map carries it from the assistant message that issued the call. Other consumers (captain, quartermaster) ignore the new field.
- `pilot.ts:1043` — `formatActions` prints it on **failed** actions only, tail-cut to 500 chars (the decision lands at the end of a reasoning block).

Scoped to `formatActions`, which feeds `analyzeProgress` and `reviewNewPage`. `formatSessionLog` (final review) is untouched — mid-run is where seeing a guess changes what Pilot tells the Tester next; the final verdict in that session was already correct.

No Pilot prompt change. "Not in aria snapshot… but we can attempt" is self-evident to the model reading it; a prompt paragraph would be a second fix point.

## Cost

Failures only × `stepsToReview` (5) × 500-char cap ≈ **≤2.5KB worst case**, keeping Pilot's context light per the agent's design contract.

## One trap worth flagging

The Langfuse export renders reasoning as `{"type":"reasoning","content":…}`, but the AI SDK's actual `ReasoningPart` is `{type:'reasoning', text: string}`. Coding against the export would have yielded `undefined` forever — a silent no-op. Extraction is written against the SDK type and verified against trace-shaped messages.

## Trade-offs

- Pilot now reads the Tester's *framing*, not just its outcomes. Reasoning is persuasive prose, so a confidently-wrong Tester may talk Pilot into its own mistake.
- Models that emit no reasoning make this a clean no-op — correct, but the value is model-dependent.

## Testing

- `bun test tests/unit/` — 1077 pass
- `bun test tests/integration/` — 80 pass, 1 skip
- `bun run format`, `bun run lint:fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0167vQdZDY76rNSeUF65MufH