### PR TITLE
Fail loudly when browser commands never reach the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Changes
 
+- Action: A browser command that never reached the page is reported as a failure instead of a
+  silent success. When the command channel stops, every `I.*` step is still logged but none of them
+  run, and nothing raises — so clicks landed on elements that were not there, form fills left the
+  page untouched, and assertions passed against text that was never on screen, for a whole session.
+  Each step now checks the channel afterwards and fails loudly, which also restores it for the
+  next command.
 - Page Diff: A click that changed nothing is reported as one again. When a page re-renders a long
   list without changing anything on it — every row rewritten, but nothing added, removed, selected
   or checked — the diff listed one empty entry per row. That was enough to suppress the warning

--- a/src/action.ts
+++ b/src/action.ts
@@ -360,6 +360,7 @@ class Action {
         await recorder.add(() => sleep(this.config.action?.delay || 500));
         await recorder.promise();
         this.lastValue = await returned;
+        if (!recorder.isRunning()) throw new Error('CodeceptJS recorder is stopped, commands were skipped and never reached the browser');
       }
 
       this.restorePageTimeout();

--- a/tests/unit/action-recorder-recovery.test.ts
+++ b/tests/unit/action-recorder-recovery.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import codeceptjs from 'codeceptjs';
+import Action from '../../src/action.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+const { recorder } = codeceptjs;
+
+function buildAction(click: () => unknown): Action {
+  const action = new Action({ click } as any, {} as any);
+  action.playwrightHelper = {};
+  return action;
+}
+
+async function recorderStillExecutes(): Promise<boolean> {
+  let ran = false;
+  await recorder.add('probe', () => {
+    ran = true;
+  });
+  await recorder.promise().catch(() => {});
+  return ran;
+}
+
+describe('Action recorder recovery', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  it('fails loudly when the recorder is stopped instead of reporting a phantom success', async () => {
+    recorder.start();
+    recorder.stop();
+
+    const action = buildAction(() => undefined);
+
+    await expect(action.execute("I.click('x')")).rejects.toThrow(/recorder is stopped/);
+  });
+
+  it('recovers the recorder after a failed step so the next command still executes', async () => {
+    recorder.start();
+
+    // the task chain codeceptjs builds for every I.* command, see lib/step/record.js
+    const action = buildAction(() => {
+      recorder.add('click: x', () => {
+        throw new Error('element (x) not found');
+      });
+      recorder.add('step passed', () => {});
+      recorder.catch((err: any) => {
+        throw err;
+      });
+      recorder.add('return result', () => undefined);
+      return recorder.promise();
+    });
+
+    await expect(action.execute("I.click('x')")).rejects.toThrow(/element \(x\) not found/);
+
+    // deferred catch handlers land on a later tick, as they do between two AI turns
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(recorder.isRunning()).toBe(true);
+    expect(await recorderStillExecutes()).toBe(true);
+  });
+});

--- a/tests/unit/action-recorder-recovery.test.ts
+++ b/tests/unit/action-recorder-recovery.test.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import codeceptjs from 'codeceptjs';
 import Action from '../../src/action.ts';
+import { clearActivity } from '../../src/activity.ts';
 import { ConfigParser } from '../../src/config.ts';
 
 const { recorder } = codeceptjs;
@@ -13,7 +14,7 @@ function buildAction(click: () => unknown): Action {
 
 async function recorderStillExecutes(): Promise<boolean> {
   let ran = false;
-  await recorder.add('probe', () => {
+  await recorder.add(() => {
     ran = true;
   });
   await recorder.promise().catch(() => {});
@@ -24,6 +25,12 @@ describe('Action recorder recovery', () => {
   beforeEach(() => {
     ConfigParser.resetForTesting();
     ConfigParser.setupTestConfig();
+  });
+
+  // executing an action sets a global activity that is cleared on a timer, and a listener
+  // registered while it is still set is replayed the stale entry
+  afterEach(() => {
+    clearActivity(true);
   });
 
   it('fails loudly when the recorder is stopped instead of reporting a phantom success', async () => {

--- a/tests/unit/action-recorder-recovery.test.ts
+++ b/tests/unit/action-recorder-recovery.test.ts
@@ -35,6 +35,17 @@ describe('Action recorder recovery', () => {
     await expect(action.execute("I.click('x')")).rejects.toThrow(/recorder is stopped/);
   });
 
+  it('leaves the recorder running so the command after a phantom one reaches the browser', async () => {
+    recorder.start();
+    recorder.stop();
+
+    const action = buildAction(() => undefined);
+    await action.execute("I.click('x')").catch(() => {});
+
+    expect(recorder.isRunning()).toBe(true);
+    expect(await recorderStillExecutes()).toBe(true);
+  });
+
   it('recovers the recorder after a failed step so the next command still executes', async () => {
     recorder.start();
 

--- a/tests/unit/action-recorder-recovery.test.ts
+++ b/tests/unit/action-recorder-recovery.test.ts
@@ -45,29 +45,4 @@ describe('Action recorder recovery', () => {
     expect(recorder.isRunning()).toBe(true);
     expect(await recorderStillExecutes()).toBe(true);
   });
-
-  it('recovers the recorder after a failed step so the next command still executes', async () => {
-    recorder.start();
-
-    // the task chain codeceptjs builds for every I.* command, see lib/step/record.js
-    const action = buildAction(() => {
-      recorder.add('click: x', () => {
-        throw new Error('element (x) not found');
-      });
-      recorder.add('step passed', () => {});
-      recorder.catch((err: any) => {
-        throw err;
-      });
-      recorder.add('return result', () => undefined);
-      return recorder.promise();
-    });
-
-    await expect(action.execute("I.click('x')")).rejects.toThrow(/element \(x\) not found/);
-
-    // deferred catch handlers land on a later tick, as they do between two AI turns
-    await new Promise((resolve) => setTimeout(resolve, 50));
-
-    expect(recorder.isRunning()).toBe(true);
-    expect(await recorderStillExecutes()).toBe(true);
-  });
 });

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -39,12 +39,20 @@ mock.module('codeceptjs', () => {
   };
 
   let pending: Array<Promise<unknown>> = [];
+  let running = false;
 
   const recorder = {
     start: async () => {
+      running = true;
       pending = [];
     },
-    isRunning: () => true,
+    stop: () => {
+      running = false;
+    },
+    reset: async () => {
+      pending = [];
+    },
+    isRunning: () => running,
     add: (fn: () => unknown) => {
       const promise = Promise.resolve().then(fn);
       pending.push(promise);

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -46,12 +46,6 @@ mock.module('codeceptjs', () => {
       running = true;
       pending = [];
     },
-    stop: () => {
-      running = false;
-    },
-    reset: async () => {
-      pending = [];
-    },
     isRunning: () => running,
     add: (fn: () => unknown) => {
       const promise = Promise.resolve().then(fn);
@@ -71,6 +65,7 @@ mock.module('codeceptjs', () => {
       pending = [];
     },
     stop: async () => {
+      running = false;
       pending = [];
     },
     retry: () => {},

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -44,6 +44,7 @@ mock.module('codeceptjs', () => {
     start: async () => {
       pending = [];
     },
+    isRunning: () => true,
     add: (fn: () => unknown) => {
       const promise = Promise.resolve().then(fn);
       pending.push(promise);


### PR DESCRIPTION
## The session that prompted this

Trace `d4605420f17fe6240a7cf05e33f6eb91`, session `RainyGlobalScarlet355` — 3.5 minutes trying to fill one text input, then giving up. Six `fillField` variants, six clicks, two Escapes and a hover **all reported success and left every `pageDiff` empty**.

Two observations from that trace show the commands never reached the browser:

- `I.click({role:'link',text:'RainyGlobalScarlet355 All Tests Run'})` returned success for an element `xpathCheck` proved absent moments later.
- `verify` **passed** `I.seeElement(…)` for text that was not on the page. An assertion can only pass by not running.

## Cause

`recorder.add()` returns a resolved promise **without invoking the task** when the recorder is not running (`codeceptjs/lib/recorder.js:198`). Every `I.*` reaches the page only through that call (`lib/step/record.js:37`), but `event.step.before` / `after` fire outside it (`:31`, `:52`).

So a stopped recorder still logs and reports every step while executing none. `action.lastError` stays null, `attempt()` returns true, and every tool reports success against a page that never changed. Nothing throws, so the restart in `executeOnce`'s catch (`src/action.ts:378`) is never reached, and the session stays phantom to the end.

## The change

One line at the single CodeceptJS dispatch site:

```ts
this.lastValue = await returned;
if (!recorder.isRunning()) throw new Error('CodeceptJS recorder is stopped, commands were skipped and never reached the browser');
```

After dispatch, not before: one check covers a recorder that was already dead and one that died mid-command. The throw lands in the existing catch, which restarts the recorder — so `lastError` is set, the tool reports an honest failure, and the retry actually executes.

The `isPlaywright` branch drives the page directly and needs no guard. `recorder.stop()` has no legitimate mid-session caller: the only two in `src/` are both in `Explorer.stop()`.

`tests/unit/explorer.test.ts` mocks `codeceptjs` with a partial recorder; `isRunning` was added to the double.

## What this does not do

It does not identify what stopped the recorder in that run. Navigation at 11:01:25 worked and the first fill at 11:01:32 was already a phantom; isolated repros of a failing step recover correctly through `Action`, and `store.dryRun` is not involved. The command that kills the channel can still report one false success — only the ones after it turn loud. This makes the next occurrence report a failure with a stack trace instead of a silent 3.5-minute run, which is what will pin the trigger.

## Verification

- `tests/unit/action-recorder-recovery.test.ts` — new. Fails on `main`, passes here.
- `bun test tests/unit/` — 1113 pass, 0 fail
- `bun test tests/integration/` — 80 pass, 1 skip, 0 fail
- `bun run lint:fix`, `bun run format` — clean

## Separate findings, not fixed here

- `cap()` (`src/ai/tools.ts:1132`) keeps the **first** 4000/6000 chars of ARIA/HTML. In this session the runs list ate the whole budget and the overlay under test sat in the 91,806 truncated characters — `context()` returned a snapshot with zero occurrences of `run-title`, `detail-view` or `New Manual Run`. Late-DOM overlays are structurally invisible to the model.
- `store.dryRun` is set by `dryRunTestFile` (`src/utils/test-files.ts:85`) and never reset — a second silent-no-op path into the same helper layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CW3rvmre6ZEbCh3LX5jhts
