### PR TITLE
Catch stale generated docs in PR CI, not at release time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,9 @@ jobs:
     - name: Install dependencies
       run: bun install
 
+    - name: Verify generated docs are up to date
+      run: bunx bunosh docs:sync --check
+
     - name: Check formatting
       run: bun run format:check
 

--- a/docs/basics/providers.md
+++ b/docs/basics/providers.md
@@ -154,14 +154,12 @@ Set the recommended model in the exported config:
 ```javascript
 export default {
   ai: {
+    model: anthropic('claude-haiku-4-5-20251001'),
+    visionModel: anthropic('claude-haiku-4-5-20251001'),
     agenticModel: anthropic('claude-haiku-4-5-20251001'),
   },
 };
 ```
-
-> [!NOTE]
-> This provider currently doesn't serve `model` and `visionModel`, which is required for Explorbot to run at optimal cost and speed.
-> It is recommended to pair it with another AI provider.
 <!-- END provider:anthropic -->
 
 ### Azure OpenAI


### PR DESCRIPTION
The 0.3.3 release job [failed](https://github.com/testomatio/explorbot/actions/runs/33132177563/job/98723989690) on **Verify generated docs are up to date**, before `npm publish` — so 0.3.3 was never published.

## Why

`docs/basics/providers.md` holds generated blocks between `<!-- START/END provider:* -->` markers, built from `models.json`. #148 added `model` and `visionModel` to the `anthropic` entry without running `bunosh docs:sync`, so the doc still advertised only `agenticModel` plus a "this provider doesn't serve `model` and `visionModel`" note — contradicting the config that shipped.

`docs:sync --check` ran only in `publish.yml`. `test.yml`, the workflow on every push and PR, never ran it. The staleness sailed through every PR check and surfaced only once the tag was pushed. It was the one release-gate step with no PR-CI equivalent — the CLI smoke checks are already covered by `tests/node/build.test.mjs`.

## What changed

- Regenerated `docs/basics/providers.md`. Anthropic now lists all three roles and the pair-with-another-provider note is gone. That was the only stale file.
- Added the same `docs:sync --check` step to `test.yml` after `bun install`, so a push or PR touching `models.json` or the `EXPLORBOT_*` env table fails there instead of at release.

The `publish.yml` gate stays as a backstop for tags cut from commits that skipped PR CI.

## After merge

0.3.3 still needs to publish — either re-push the `0.3.3` tag at the merged commit or cut 0.3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RXmuB8FE2dCdpZ2B7ZJzf2