### PR TITLE
Let Pilot, not Planner, name the item a test acts on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changes
 
+- [Planner] Scenarios describe the item to act on by kind and role instead of naming it. A scenario that
+  named one specific record went stale the moment that record was renamed, deleted, or replaced, and the
+  run was spent hunting for a name the page no longer had.
+- [Pilot] Picks the concrete item a scenario runs against — one already on the page, or a fresh one it
+  creates — and hands the Tester its exact name.
 - [Tester] `form()` and `interact()` now report every command they ran and whether it passed. A batch
   used to come back as a single pass/fail, so one bad command at the end hid the fact that the ones
   before it had worked — the AI and the Pilot both concluded nothing had happened and redid work that

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -1114,7 +1114,7 @@ export class Pilot implements Agent {
       state), instruct Tester to verify() and finish(). If goal was already true at the start, propose
       different input data so the test is meaningful. If Tester repeats the same successful action, STOP.
 
-      Scenarios name behavior, not data. You pick the concrete item — from the page, or precondition() one — and give Tester its exact name.
+      You pick the concrete item the scenario acts on — from the page, or precondition() one — and give Tester its exact name.
 
       Action classification: GOAL-ADVANCING actions mutate the scenario's subject data (create/edit/delete/submit/verify).
       VIEW-ONLY actions toggle filters/tabs/sort/collapse without changing data. One VIEW-ONLY to reveal a

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -1114,6 +1114,8 @@ export class Pilot implements Agent {
       state), instruct Tester to verify() and finish(). If goal was already true at the start, propose
       different input data so the test is meaningful. If Tester repeats the same successful action, STOP.
 
+      Scenarios name behavior, not data. You pick the concrete item — from the page, or precondition() one — and give Tester its exact name.
+
       Action classification: GOAL-ADVANCING actions mutate the scenario's subject data (create/edit/delete/submit/verify).
       VIEW-ONLY actions toggle filters/tabs/sort/collapse without changing data. One VIEW-ONLY to reveal a
       target is fine; ≥2 consecutive VIEW-ONLY actions with no GOAL-ADVANCING action in between is thrashing

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -1114,7 +1114,7 @@ export class Pilot implements Agent {
       state), instruct Tester to verify() and finish(). If goal was already true at the start, propose
       different input data so the test is meaningful. If Tester repeats the same successful action, STOP.
 
-      You pick the concrete item the scenario acts on — from the page, or precondition() one — and give Tester its exact name.
+      If needed you should pick the exact item the scenario should act on (from the page, or precondition() one) and pass it to tester
 
       Action classification: GOAL-ADVANCING actions mutate the scenario's subject data (create/edit/delete/submit/verify).
       VIEW-ONLY actions toggle filters/tabs/sort/collapse without changing data. One VIEW-ONLY to reveal a

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -33,7 +33,7 @@ const TasksSchema = z.object({
   scenarios: z
     .array(
       z.object({
-        scenario: z.string().describe('A single sentence describing what to test'),
+        scenario: z.string().describe('A single sentence describing the behavior to test. Name the item by kind and role, never by its title, id, or value.'),
         priority: z.enum(['critical', 'important', 'high', 'normal', 'low']).describe('Priority of the task based on business importance'),
         startUrl: z.string().nullable().describe('Start URL for the test if different from plan URL. Use only stable feature/list/detail pages, not transient create/edit/modal URLs unless the scenario specifically starts inside that form.'),
         steps: z.array(z.string()).describe('List of steps to perform for this scenario. Each step should be a specific action (e.g., "Open the form", "Enter required data", "Submit the form"). Keep steps atomic and actionable.'),

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -33,7 +33,7 @@ const TasksSchema = z.object({
   scenarios: z
     .array(
       z.object({
-        scenario: z.string().describe('A single sentence describing the behavior to test. Name the item by kind and role, never by its title, id, or value.'),
+        scenario: z.string().describe('A single sentence describing the behavior to test.'),
         priority: z.enum(['critical', 'important', 'high', 'normal', 'low']).describe('Priority of the task based on business importance'),
         startUrl: z.string().nullable().describe('Start URL for the test if different from plan URL. Use only stable feature/list/detail pages, not transient create/edit/modal URLs unless the scenario specifically starts inside that form.'),
         steps: z.array(z.string()).describe('List of steps to perform for this scenario. Each step should be a specific action (e.g., "Open the form", "Enter required data", "Submit the form"). Keep steps atomic and actionable.'),


### PR DESCRIPTION
## Problem

Diagnosed from Langfuse trace `aa327eeaef94d32e8582a7802368ce92` — a 3m34s run that ended in `stop` → fail without ever attempting the action it was testing.

The Planner had written a concrete record name into the scenario title. By the time the test ran, that name was not on the page — the closest item differed. The tester noticed the mismatch in its first turn and went looking for the literal anyway, because Pilot's opening plan told it to search for that name:

- 17 `click` tool calls (20 `I.click` steps), 4 `see`, 3 `xpathCheck`
- three search/clear cycles, each returning "0 tests found"
- one `see` call answered "yes, it's there" for a name that was not on the page, its own reasoning admitting it had inferred a character it could not read
- the tester did open the right detail overlay — one step from the goal — and Pilot ordered it closed as "the wrong entity"
- two `xpathCheck` calls then proved the name absent, and the guidance still did not change

The scenario title is written once and read much later. Anything named in it is stale by the time it is used.

## Change

Two lines.

**`src/ai/planner.ts`** — the `scenario` field description now asks for the behavior, with the item described by kind and role rather than by title, id, or value.

**`src/ai/pilot.ts`** — one line in Pilot's system prompt: scenarios name behavior, not data; Pilot picks the concrete item (from the page, or via `precondition()`) and gives Tester its exact name.

This moves item selection to the agent that is looking at the page when the test runs. It closes a gap rather than adding machinery: the reset prompt already prefers `precondition()` when the page lacks target data (`pilot.ts:392`), the precondition-unavailable fallback already says "continue with what the page already shows" (`pilot.ts:737`), and the skip-on-missing-data path already exists (`pilot.ts:807`).

## Not addressed here

- `src/ai/planner.ts:96` (`focusExistingDataDirective`) still tells the planner to use item names visible in page research. It fires only under `--focus` and did not cause this trace.
- The `see` tool over-committing on a name it could not read is downstream of the hunt.
- `I.pressKey(['Meta','a'])` on a search input deleted one character per press instead of selecting all — the query shortened by one character on each of three clear attempts.

## Testing

- `bun test tests/integration/` — 82 pass, 1 skip, 0 fail
- `bun run format` clean

Prompt-only change; behavior is best confirmed by replaying the scenario. Worth the `regression` label if you want that coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XsPDpDQrWdgDLGXkzkgGQr