### PR TITLE
Relay provider rejection reasons to the model on retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 ### Changes
 
+- [Provider] A request the provider rejects as invalid now comes back to the model with the
+  provider's own reason instead of a blind re-roll. gpt-oss sometimes emits tool names carrying its
+  internal channel markers or invents names outright; the provider API rejects the call before any
+  client-side repair can run, and the retry used to resend the same context unchanged — 24, 49 and
+  then 76 wasted generations across the last three overnight runs. The retry now relays the
+  rejection message verbatim (detected by error type and status code, no text matching), so the
+  model sees exactly what it broke and corrects itself on the next attempt.
+- [Tests] Provider unit tests no longer depend on the machine's global explorbot installation: a
+  config-priming call in the setup could reject against a real `~/.explorbot` and fail unrelated
+  tests as stray unhandled rejections.
 - [Tester] `form()` and `interact()` now report every command they ran and whether it passed. A batch
   used to come back as a single pass/fail, so one bad command at the end hid the fact that the ones
   before it had worked — the AI and the Pilot both concluded nothing had happened and redid work that

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -2,7 +2,8 @@ import { OpenTelemetry } from '@ai-sdk/otel';
 import { LangfuseSpanProcessor } from '@langfuse/otel';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { generateObject, generateText, isStepCount, registerTelemetry, tool } from 'ai';
+import dedent from 'dedent';
+import { APICallError, generateObject, generateText, isStepCount, registerTelemetry, tool } from 'ai';
 import type { ModelMessage } from 'ai';
 import { z } from 'zod';
 import { clearActivity, setActivity } from '../activity.ts';
@@ -423,10 +424,19 @@ export class Provider {
     const stopConditions: any[] = [isStepCount(maxRoundtrips)];
     if (extraStop) stopConditions.push(extraStop);
     const config = this.buildGenerateConfig({ tools: toolsWithCommentary, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairToolCall }, { stopWhen: stopConditions, model }, options);
+    let attemptMessages = messages;
+    let invalidRequestFeedbackAdded = false;
     try {
       const response = await this.withModelRequestSlot(() =>
         withRetry(async () => {
-          const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages, ...config, abortSignal: signal }), config.timeout || 30000)) as any;
+          const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages: attemptMessages, ...config, abortSignal: signal }), config.timeout || 30000).catch((error) => {
+            if (!invalidRequestFeedbackAdded) {
+              const amended = withInvalidRequestFeedback(attemptMessages, error);
+              invalidRequestFeedbackAdded = amended !== attemptMessages;
+              attemptMessages = amended;
+            }
+            throw error;
+          })) as any;
           this.recordUsage(options.agentName || 'unknown', modelName, result.usage);
           const hasToolCall = (result.toolCalls?.length || 0) > 0;
           if (!result.text && !hasToolCall && result.finishReason === 'length') {
@@ -691,6 +701,22 @@ export class Provider {
 function repairToolCall(options: ToolCallRepairOptions): any | null {
   if (options.toolCall.toolName.includes('<|channel|>')) return repairChannelMarker(options);
   return repairHarmonyChannel(options);
+}
+
+function withInvalidRequestFeedback(messages: ModelMessage[], error: unknown): ModelMessage[] {
+  if (!(error instanceof APICallError) || error.statusCode !== 400) return messages;
+  tag('warning').log('Provider rejected the request as invalid — relaying its reason before the retry');
+  return [
+    ...messages,
+    {
+      role: 'user',
+      content: dedent`
+        The previous request was rejected by the provider as invalid:
+        "${error.message}"
+        Fix what it describes and re-issue the request.
+      `,
+    },
+  ];
 }
 
 function repairChannelMarker({ toolCall, tools }: ToolCallRepairOptions): any | null {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import type { ModelMessage } from 'ai';
-import { tool } from 'ai';
+import { APICallError, tool } from 'ai';
 import { MockLanguageModelV3 } from 'ai/test';
 import { z } from 'zod';
 import { AiError, Provider } from '../../src/ai/provider.js';
@@ -62,7 +62,9 @@ describe('Provider', () => {
       config: {},
       vision: false,
     };
-    ConfigParser.getInstance().loadConfig({});
+    ConfigParser.getInstance()
+      .loadConfig({})
+      .catch(() => {});
     provider = new Provider(aiConfig);
   });
 
@@ -317,6 +319,33 @@ describe('Provider', () => {
       mockAI.setFailure(true, 5);
 
       await expect(provider.chat(messages, mockAI.getModel(), { maxRetries: 2 })).rejects.toThrow(AiError);
+    });
+
+    it('relays an invalid-request rejection back to the retry', async () => {
+      const prompts: any[] = [];
+      let calls = 0;
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'test',
+        doGenerate: async (params: any) => {
+          calls++;
+          prompts.push(params.prompt);
+          if (calls === 1) {
+            throw new APICallError({ url: 'http://test.local/v1/chat', statusCode: 400, message: 'Tool call validation failed: attempted to call a tool which was not in request.tools' });
+          }
+          return { text: 'recovered', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'recovered' }] };
+        },
+      });
+      const correctingProvider = new Provider(aiConfig);
+      const tools = { finish: tool({ description: 'Finish the test', inputSchema: z.object({}), execute: async () => ({ success: true }) }) };
+
+      const response = await correctingProvider.generateWithTools([{ role: 'user', content: 'go' }], model, tools, { maxRetries: 3 });
+
+      expect(response.text).toBe('recovered');
+      expect(calls).toBe(2);
+      const relayed = prompts[1].at(-1);
+      expect(relayed.role).toBe('user');
+      expect(JSON.stringify(relayed.content)).toContain('attempted to call a tool which was not in request.tools');
     });
 
     it('should honor configured retry attempts and delay', () => {


### PR DESCRIPTION
## Summary

Requests the provider rejects as invalid (400) — tool names with channel markers invented tool names, malformed arguments — were retried blind: same context, new dice, no feedback. That cost 24 → 49 → 76 wasted generations across the last three overnight runs. The retry now appends the provider's own rejection message verbatim to the next attempt (detected purely by error type and status code, no text matching), so the model sees exactly what it broke and self-corrects in one step. The feedback is retry-scoped: never persisted to the conversation or any stored state. Also isolates provider unit tests from the machine's ~/.explorbot (a stray unhandled loadConfig was failing random tests locally).