### PR TITLE
Skip planning on error and not-found pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
   record, a failed load, or a page with nothing on it still came back with a full set of invented
   scenarios, every one of them written against a page that had nothing to click. The planner now
   proposes nothing for such a page.
-- Explore: A sub-page that turns out to be an error page is skipped before any research or planning
-  runs on it, and exploration moves straight on to the next candidate page.
+- Explore: A sub-page with nothing to test is skipped and exploration moves straight on to the next
+  candidate page. An error page is caught before any research or planning runs on it, and a page the
+  planner proposes no scenarios for is dropped as well, instead of being reported as a planning
+  failure and retried once per planning style.
 - [Provider] Groq prompt cache hits are counted again. Groq reports how much of a prompt it served
   from cache, but the pinned `@ai-sdk/groq` build read that number out of the response and then
   dropped it, so every Groq request was recorded as a full-price miss and the cache hit rate showed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 - [Planner] A page that reports the thing you asked for does not exist gets no test plan. A missing
   record, a failed load, or a page with nothing on it still came back with a full set of invented
-  scenarios — every one of them written against a page that had nothing to click — and each planning
-  style spent another call inventing more. The planner now returns no scenarios for such a page.
+  scenarios, every one of them written against a page that had nothing to click. The planner now
+  proposes nothing for such a page.
 - Explore: A sub-page that turns out to be an error page is skipped before any research or planning
   runs on it, and exploration moves straight on to the next candidate page.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-29
+
+### Changes
+
+- [Planner] A page that reports the thing you asked for does not exist gets no test plan. A missing
+  record, a failed load, or a page with nothing on it still came back with a full set of invented
+  scenarios — every one of them written against a page that had nothing to click — and each planning
+  style spent another call inventing more. The planner now returns no scenarios for such a page.
+- Explore: A sub-page that turns out to be an error page is skipped before any research or planning
+  runs on it, and exploration moves straight on to the next candidate page.
+
 ## 2026-08-28
 
 ### Changes

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -195,10 +195,6 @@ export class Planner extends PlannerBase implements Agent {
         throw new Error('No tasks were created successfully');
       }
 
-      if (aiResult.object.scenarios.length === 0 && !this.currentPlan) {
-        throw new EmptyPlanError(actionResult.url || state.url);
-      }
-
       const defaultStartUrl = this.getDefaultStartUrl(state);
       const fromPlanning = aiResult.object.scenarios.map((s: any) => new Test(s.scenario, s.priority, s.expectedOutcomes, s.startUrl || defaultStartUrl, s.steps || []));
 
@@ -632,12 +628,5 @@ export class Planner extends PlannerBase implements Agent {
       8. For a fresh plan propose at least ${this.MIN_TASKS} tests; when expanding an existing plan return ONLY new scenarios not in the tested list, and an empty array if none remain.
     </task>
     `;
-  }
-}
-
-export class EmptyPlanError extends Error {
-  constructor(public readonly url: string) {
-    super(`no scenarios proposed for ${url}`);
-    this.name = 'EmptyPlanError';
   }
 }

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -10,6 +10,7 @@ import type { StateManager } from '../state-manager.js';
 import { Stats } from '../stats.ts';
 import { Suite } from '../suite.ts';
 import { Plan, Test } from '../test-plan.ts';
+import { ErrorPageError } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { jsonToTable } from '../utils/markdown-parser.ts';
 import { mdq } from '../utils/markdown-query.js';
@@ -195,7 +196,8 @@ export class Planner extends PlannerBase implements Agent {
         throw new Error('No tasks were created successfully');
       }
 
-      if (aiResult.object.scenarios.length === 0 && !this.currentPlan) {
+      if (aiResult.object.scenarios.length === 0 && !this.currentPlan?.tests.length) {
+        if (!feature) throw new ErrorPageError(actionResult.url || state.url, actionResult.title, actionResult.httpStatus);
         throw new Error('No tasks were created successfully');
       }
 
@@ -335,6 +337,7 @@ export class Planner extends PlannerBase implements Agent {
       <task>
       Based on the page research, create ${this.MIN_TASKS}-${this.MAX_TASKS} exploratory testing scenarios.
       For each scenario provide specific steps and expected outcomes.
+      Exception: if the page reports the requested resource is missing, shows a failure state, or holds no content and no controls, return an empty scenarios list. Never invent tests for a page with nothing to exercise.
       </task>
 
       <rules>

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -10,7 +10,6 @@ import type { StateManager } from '../state-manager.js';
 import { Stats } from '../stats.ts';
 import { Suite } from '../suite.ts';
 import { Plan, Test } from '../test-plan.ts';
-import { ErrorPageError } from '../utils/error-page.ts';
 import { createDebug, tag } from '../utils/logger.js';
 import { jsonToTable } from '../utils/markdown-parser.ts';
 import { mdq } from '../utils/markdown-query.js';
@@ -196,8 +195,7 @@ export class Planner extends PlannerBase implements Agent {
         throw new Error('No tasks were created successfully');
       }
 
-      if (aiResult.object.scenarios.length === 0 && !this.currentPlan?.tests.length) {
-        if (!feature) throw new ErrorPageError(actionResult.url || state.url, actionResult.title, actionResult.httpStatus);
+      if (aiResult.object.scenarios.length === 0 && !this.currentPlan) {
         throw new Error('No tasks were created successfully');
       }
 

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -196,7 +196,7 @@ export class Planner extends PlannerBase implements Agent {
       }
 
       if (aiResult.object.scenarios.length === 0 && !this.currentPlan) {
-        throw new Error('No tasks were created successfully');
+        throw new EmptyPlanError(actionResult.url || state.url);
       }
 
       const defaultStartUrl = this.getDefaultStartUrl(state);
@@ -632,5 +632,12 @@ export class Planner extends PlannerBase implements Agent {
       8. For a fresh plan propose at least ${this.MIN_TASKS} tests; when expanding an existing plan return ONLY new scenarios not in the tested list, and an empty array if none remain.
     </task>
     `;
+  }
+}
+
+export class EmptyPlanError extends Error {
+  constructor(public readonly url: string) {
+    super(`no scenarios proposed for ${url}`);
+    this.name = 'EmptyPlanError';
   }
 }

--- a/src/commands/explore-command.ts
+++ b/src/commands/explore-command.ts
@@ -1,5 +1,4 @@
 import figureSet from 'figures';
-import { EmptyPlanError } from '../ai/planner.js';
 import { getStyles } from '../ai/planner/styles.js';
 import { outputPath } from '../config.js';
 import { normalizeUrl } from '../state-manager.js';
@@ -113,13 +112,7 @@ export class ExploreCommand extends BaseCommand {
   }
 
   private async runFreshMode(mainUrl: string | undefined, feature: string | undefined, styles?: string[]): Promise<void> {
-    try {
-      await this.runAllStyles(mainUrl, feature, undefined, undefined, styles);
-    } catch (err) {
-      if (!(err instanceof EmptyPlanError)) throw err;
-      tag('warning').log(`Nothing to test here: ${err.message}`);
-      return;
-    }
+    await this.runAllStyles(mainUrl, feature, undefined, undefined, styles);
     this.rememberCurrentPlan();
     const mainPlan = this.explorBot.getCurrentPlan();
     if (!mainPlan) return;
@@ -276,16 +269,12 @@ export class ExploreCommand extends BaseCommand {
         }
         await this.runAllStyles(pick.url, undefined, mainPlan, this.completedPlans, styles);
         const subPlan = this.explorBot.getCurrentPlan();
-        if (subPlan && !this.completedPlans.includes(subPlan)) {
+        if (subPlan?.tests.length && !this.completedPlans.includes(subPlan)) {
           this.completedPlans.push(subPlan);
         }
         knownUrls.add(normalizeUrl(pick.url));
       } catch (err) {
         this.failedSubPages.add(normalizeUrl(pick.url));
-        if (err instanceof EmptyPlanError) {
-          tag('info').log(`Skipping sub-page: ${err.message}`);
-          continue;
-        }
         tag('warning').log(`Sub-page exploration failed: ${err instanceof Error ? err.message : err}`);
       }
     }
@@ -315,6 +304,11 @@ export class ExploreCommand extends BaseCommand {
       if (fresh && parentPlan) opts.extend = parentPlan;
       if (this.dryRun) opts.noSave = true;
       await this.planWithRetry(feature, opts, pageUrl);
+      const plan = this.explorBot.getCurrentPlan();
+      if (plan && plan.tests.length === 0) {
+        tag('warning').log('Nothing to test on this page, moving on');
+        return;
+      }
       await this.runPendingTests();
       this.rememberCurrentPlan();
       fresh = false;
@@ -334,7 +328,7 @@ export class ExploreCommand extends BaseCommand {
 
     await this.explorBot.plan(feature, opts);
     if (this.explorBot.lastPlanError) {
-      if (this.explorBot.lastPlanError instanceof ErrorPageError || this.explorBot.lastPlanError instanceof EmptyPlanError) {
+      if (this.explorBot.lastPlanError instanceof ErrorPageError) {
         throw this.explorBot.lastPlanError;
       }
       tag('info').log(`Retrying planning style '${opts.style}'...`);

--- a/src/commands/explore-command.ts
+++ b/src/commands/explore-command.ts
@@ -249,6 +249,12 @@ export class ExploreCommand extends BaseCommand {
       tag('info').log(`Exploring sub-page: ${pick.url} (${pick.reason})`);
       try {
         await this.explorBot.visit(pick.url);
+        const errorPage = getStateErrorPageError(this.explorBot.stateManager().getCurrentState());
+        if (errorPage) {
+          tag('warning').log(`Skipping sub-page: ${errorPage.message}`);
+          this.failedSubPages.add(normalizeUrl(pick.url));
+          continue;
+        }
         await this.runAllStyles(pick.url, undefined, mainPlan, this.completedPlans, styles);
         const subPlan = this.explorBot.getCurrentPlan();
         if (subPlan && !this.completedPlans.includes(subPlan)) {

--- a/src/commands/explore-command.ts
+++ b/src/commands/explore-command.ts
@@ -1,4 +1,5 @@
 import figureSet from 'figures';
+import { EmptyPlanError } from '../ai/planner.js';
 import { getStyles } from '../ai/planner/styles.js';
 import { outputPath } from '../config.js';
 import { normalizeUrl } from '../state-manager.js';
@@ -100,7 +101,13 @@ export class ExploreCommand extends BaseCommand {
   }
 
   private async runFreshMode(mainUrl: string | undefined, feature: string | undefined, styles?: string[]): Promise<void> {
-    await this.runAllStyles(mainUrl, feature, undefined, undefined, styles);
+    try {
+      await this.runAllStyles(mainUrl, feature, undefined, undefined, styles);
+    } catch (err) {
+      if (!(err instanceof EmptyPlanError)) throw err;
+      tag('warning').log(`Nothing to test here: ${err.message}`);
+      return;
+    }
     this.rememberCurrentPlan();
     const mainPlan = this.explorBot.getCurrentPlan();
     if (!mainPlan) return;
@@ -263,6 +270,10 @@ export class ExploreCommand extends BaseCommand {
         knownUrls.add(normalizeUrl(pick.url));
       } catch (err) {
         this.failedSubPages.add(normalizeUrl(pick.url));
+        if (err instanceof EmptyPlanError) {
+          tag('info').log(`Skipping sub-page: ${err.message}`);
+          continue;
+        }
         tag('warning').log(`Sub-page exploration failed: ${err instanceof Error ? err.message : err}`);
       }
     }
@@ -311,7 +322,7 @@ export class ExploreCommand extends BaseCommand {
 
     await this.explorBot.plan(feature, opts);
     if (this.explorBot.lastPlanError) {
-      if (this.explorBot.lastPlanError instanceof ErrorPageError) {
+      if (this.explorBot.lastPlanError instanceof ErrorPageError || this.explorBot.lastPlanError instanceof EmptyPlanError) {
         throw this.explorBot.lastPlanError;
       }
       tag('info').log(`Retrying planning style '${opts.style}'...`);

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createOpenAI } from '@ai-sdk/openai';
 import { LLMock } from '@copilotkit/aimock';
-import { Planner } from '../../src/ai/planner.ts';
+import { EmptyPlanError, Planner } from '../../src/ai/planner.ts';
 import { clearSessionDedup } from '../../src/ai/planner/session-dedup.ts';
 import { clearStyleCache } from '../../src/ai/planner/styles.ts';
 import { clearPlanRegistry, registerPlan } from '../../src/ai/planner/subpages.ts';
@@ -282,10 +282,24 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('return an empty scenarios list');
   });
 
-  it('throws when AI returns empty scenarios and no current plan', async () => {
+  it('signals an empty plan when AI returns no scenarios and there is no current plan', async () => {
     mock.clearFixtures();
     mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
 
-    await expect(planner.plan()).rejects.toThrow('No tasks were created successfully');
+    await expect(planner.plan()).rejects.toThrow(EmptyPlanError);
+  });
+
+  it('keeps an existing plan when a later style returns empty scenarios', async () => {
+    const existingPlan = new Plan('Task Board Testing');
+    existingPlan.url = '/tasks/board';
+    existingPlan.addTest(new Test('Create a new task via the Create Task modal', 'critical', ['Task appears'], '/tasks/board', ['Click Create']));
+    planner.currentPlan = existingPlan;
+
+    mock.clearFixtures();
+    mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
+
+    const plan = await planner.plan();
+
+    expect(plan.tests.length).toBe(1);
   });
 });

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -10,6 +10,7 @@ import { clearPlanRegistry, registerPlan } from '../../src/ai/planner/subpages.t
 import { Provider } from '../../src/ai/provider.ts';
 import { ConfigParser } from '../../src/config.ts';
 import { Plan, Test } from '../../src/test-plan.ts';
+import { ErrorPageError } from '../../src/utils/error-page.ts';
 
 const UI_MAPS_DIR = join(process.cwd(), 'test-data', 'ui-maps');
 
@@ -275,10 +276,38 @@ describe('Planner with aimock', () => {
     expect(mock.getRequests().length).toBe(0);
   });
 
-  it('throws when AI returns empty scenarios and no current plan', async () => {
+  it('instructs to return no scenarios for a page with nothing to exercise', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('return an empty scenarios list');
+  });
+
+  it('reports an error page when AI returns empty scenarios', async () => {
     mock.clearFixtures();
     mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
 
-    await expect(planner.plan()).rejects.toThrow('No tasks were created successfully');
+    await expect(planner.plan()).rejects.toThrow(ErrorPageError);
+  });
+
+  it('throws a planning error when feature focus returns empty scenarios', async () => {
+    mock.clearFixtures();
+    mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
+
+    await expect(planner.plan('search')).rejects.toThrow('No tasks were created successfully');
+  });
+
+  it('keeps an existing plan when a later style returns empty scenarios', async () => {
+    const existingPlan = new Plan('Task Board Testing');
+    existingPlan.url = '/tasks/board';
+    existingPlan.addTest(new Test('Create a new task via the Create Task modal', 'critical', ['Task appears'], '/tasks/board', ['Click Create']));
+    planner.currentPlan = existingPlan;
+
+    mock.clearFixtures();
+    mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
+
+    const plan = await planner.plan();
+
+    expect(plan.tests.length).toBe(1);
   });
 });

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -10,7 +10,6 @@ import { clearPlanRegistry, registerPlan } from '../../src/ai/planner/subpages.t
 import { Provider } from '../../src/ai/provider.ts';
 import { ConfigParser } from '../../src/config.ts';
 import { Plan, Test } from '../../src/test-plan.ts';
-import { ErrorPageError } from '../../src/utils/error-page.ts';
 
 const UI_MAPS_DIR = join(process.cwd(), 'test-data', 'ui-maps');
 
@@ -283,31 +282,10 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('return an empty scenarios list');
   });
 
-  it('reports an error page when AI returns empty scenarios', async () => {
+  it('throws when AI returns empty scenarios and no current plan', async () => {
     mock.clearFixtures();
     mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
 
-    await expect(planner.plan()).rejects.toThrow(ErrorPageError);
-  });
-
-  it('throws a planning error when feature focus returns empty scenarios', async () => {
-    mock.clearFixtures();
-    mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
-
-    await expect(planner.plan('search')).rejects.toThrow('No tasks were created successfully');
-  });
-
-  it('keeps an existing plan when a later style returns empty scenarios', async () => {
-    const existingPlan = new Plan('Task Board Testing');
-    existingPlan.url = '/tasks/board';
-    existingPlan.addTest(new Test('Create a new task via the Create Task modal', 'critical', ['Task appears'], '/tasks/board', ['Click Create']));
-    planner.currentPlan = existingPlan;
-
-    mock.clearFixtures();
-    mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
-
-    const plan = await planner.plan();
-
-    expect(plan.tests.length).toBe(1);
+    await expect(planner.plan()).rejects.toThrow('No tasks were created successfully');
   });
 });

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { createOpenAI } from '@ai-sdk/openai';
 import { LLMock } from '@copilotkit/aimock';
-import { EmptyPlanError, Planner } from '../../src/ai/planner.ts';
+import { Planner } from '../../src/ai/planner.ts';
 import { clearSessionDedup } from '../../src/ai/planner/session-dedup.ts';
 import { clearStyleCache } from '../../src/ai/planner/styles.ts';
 import { clearPlanRegistry, registerPlan } from '../../src/ai/planner/subpages.ts';
@@ -282,11 +282,13 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('return an empty scenarios list');
   });
 
-  it('signals an empty plan when AI returns no scenarios and there is no current plan', async () => {
+  it('returns an empty plan when AI returns no scenarios', async () => {
     mock.clearFixtures();
     mock.on({}, { content: JSON.stringify({ planName: 'Empty', scenarios: [] }) });
 
-    await expect(planner.plan()).rejects.toThrow(EmptyPlanError);
+    const plan = await planner.plan();
+
+    expect(plan.tests.length).toBe(0);
   });
 
   it('keeps an existing plan when a later style returns empty scenarios', async () => {


### PR DESCRIPTION
Exploration burned a full planning round on pages with nothing to test — including the case in the reported trace, a 200 response whose only sign of being dead is its own copy.

## Changes

**`explore-command.ts` — sub-page skip.** `discoverNewSubPages` checks the page right after visiting it. If `getStateErrorPageError` reports an error page: warn, mark it failed, move to the next candidate. No research, no planning, no AI call spent on it. This covers server-rendered errors — anything with a 4xx/5xx document status or a standard HTTP error title.

**`planner.ts` — one prompt line.** That check only sees HTTP status and standard error titles, so a page returning 200 with app-specific "doesn't exist" copy slips past it. Reading that from arbitrary wording is AI judgment, so the planning prompt carries the rule (general, no wording from any specific page): a page that reports a missing resource, shows a failure state, or holds no content and no controls gets an empty scenarios list, and nothing is invented for it.

**Empty output is a skip, not a failure.** Zero scenarios with no plan to expand used to throw the same generic planning error as a failed call, so exploration retried the page and then spent two more calls per remaining planning style on it — the prompt rule above bought nothing. An empty scenario list is a value now, not an exception: the planner returns the plan it built, and `runAllStyles` reads its length. No tests means nothing to test here, so it stops trying further styles and the next sub-page candidate is picked; the empty plan is not carried into the saved plans. An expanding plan is untouched — a later style returning nothing keeps the tests already planned.

## Tests

`tests/integration/planner.test.ts` asserts the prompt carries the rule, that empty output yields an empty plan rather than an error, and that an existing plan survives an empty style.

`bun test tests/integration/` and `bun test tests/unit/` pass, format and lint clean.

The prompt half can only be confirmed in a live run — worth the `regression` label if you want it proven against the page in the trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013TYaLWuuLjj5mb26NuYjoj
