### PR TITLE
Count Groq prompt cache hits instead of reporting every request as a miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-08-29
+
+### Changes
+
+- [Provider] Groq prompt cache hits are counted again. Groq reports how much of a prompt it served
+  from cache, but the pinned `@ai-sdk/groq` build read that number out of the response and then
+  dropped it, so every Groq request was recorded as a full-price miss and the cache hit rate showed
+  as zero no matter how much of the prompt was actually reused. Upgrading the provider carries the
+  number through to the run stats and to Langfuse, which records it as `cache_read.input_tokens`.
+  Groq's cache lives on the node that served the request, so expect an uneven rate — a hit covers
+  almost the whole prompt, but only some requests get one.
+
 ## 2026-08-28
 
 ### Changes

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0",
         "@ai-sdk/google": "^4.0.18",
-        "@ai-sdk/groq": "^4.0",
+        "@ai-sdk/groq": "^4.0.34",
         "@ai-sdk/mistral": "^4.0.13",
         "@ai-sdk/openai": "^4.0",
         "@ai-sdk/otel": "^1.0.2",
@@ -29,6 +29,7 @@
         "ai": "^7.0.2",
         "axe-core": "^4.11.1",
         "bash-tool": "^1.3.15",
+        "chalk": "^5.6.2",
         "cli-highlight": "^2.1.11",
         "codeceptjs": "4.0.0-rc.16",
         "commander": "^14.0.1",
@@ -96,7 +97,7 @@
 
     "@ai-sdk/google": ["@ai-sdk/google@4.0.18", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-NRbXRAasXLgFLiZDTsDUiTUuQtEUDVZoqruB5Px3geltTEqOzOo2eHN5WnDp0/OgxwnrNH4olV/TVetza0PzmQ=="],
 
-    "@ai-sdk/groq": ["@ai-sdk/groq@4.0.0", "", { "dependencies": { "@ai-sdk/provider": "4.0.0", "@ai-sdk/provider-utils": "5.0.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QjhpyudO8eGi+C/kjVzSKfVFsLcuXi4smOez8njQITrV+5wZlKJ1xvoHyQom1FlgC9PsR4Ee6icGIqogoSb1Vg=="],
+    "@ai-sdk/groq": ["@ai-sdk/groq@4.0.34", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.33" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-k9nZLVRnw8RB0IivCwBxNMNe1E/P0cP+2ymxEZkqxZHeThxZ0/LqefHWa6wtjhPKWADL+AgnVfKLSL7TW28wNw=="],
 
     "@ai-sdk/mistral": ["@ai-sdk/mistral@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.11" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-VYEWPEY6MhhvUKE0Huu63NJXowu2/nbbO60kE6/sdV9mLTk36PahQ7lNZFkJ2XJQ3eUy19RRWQDqYmyxKMiPlA=="],
 
@@ -2656,6 +2657,10 @@
 
     "@ai-sdk/google/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ=="],
 
+    "@ai-sdk/groq/@ai-sdk/provider": ["@ai-sdk/provider@4.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ=="],
+
+    "@ai-sdk/groq/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.33", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TfjJqJmRsQyxAlb+3hGmP1o1xLUIT79yhOgtJuTF4hqsB37IC3CufGsuFhU04EeTOg7R9iptQ6Bzm0MW0n/c3g=="],
+
     "@ai-sdk/mistral/@ai-sdk/provider": ["@ai-sdk/provider@4.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw=="],
 
     "@ai-sdk/mistral/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-7/96wE+ZsKB35iS9ASyllrE4Ym/EolXEB7AkuJ5FI++fmS85BVTAs77890C+1Z2jwHfBKjBQSBmsliOsAh0iFQ=="],
@@ -3317,6 +3322,8 @@
     "yargs-unparser/decamelize": ["decamelize@4.0.0", "", {}, "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="],
 
     "yup/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
+
+    "@ai-sdk/groq/@ai-sdk/provider-utils/undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
 
     "@ai-sdk/openai-compatible/@ai-sdk/provider-utils/eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
 

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0",
     "@ai-sdk/google": "^4.0.18",
-    "@ai-sdk/groq": "^4.0",
+    "@ai-sdk/groq": "^4.0.34",
     "@ai-sdk/mistral": "^4.0.13",
     "@ai-sdk/openai": "^4.0",
     "@ai-sdk/otel": "^1.0.2",


### PR DESCRIPTION
## Problem

Every Groq request was recorded as a full-price cache miss. Across the last ~1200 generations in Langfuse, Groq accounted for **95% of all input tokens (11.7M) with exactly zero cached tokens reported** on 537 calls, pinning the overall cache hit rate at 2.26%.

| provider | model | calls | input tokens | cached | hit |
|---|---|---|---|---|---|
| groq | openai/gpt-oss-120b | 257 | 6,445,271 | 0 | 0.0% |
| groq | openai/gpt-oss-20b | 280 | 5,320,826 | 0 | 0.0% |
| openrouter | openai/gpt-5.6-luna | 142 | 615,048 | 279,317 | 45.4% |

This was a reporting bug, not a prompt problem. Diffing consecutive tester calls in Langfuse showed a **100% stable prefix** (11312/11313, 17706/17707, 38851/38852 shared chars) — the prompts were perfectly cacheable the whole time.

## Cause

Groq returns `prompt_tokens_details.cached_tokens`, but `@ai-sdk/groq@4.0.0` parses that field in its Zod response schema (`dist/index.js:729,768`) and never assigns it. Usage always came back as `noCacheTokens` = the full prompt.

Downstream, `extractCachedTokens()` in `src/ai/provider.ts:52` reads `inputTokenDetails.cacheReadTokens` / `cachedInputTokens` / `raw` — all undefined — and returns 0. The AI SDK OTEL exporter emitted no cached-token attribute, so Groq spans in Langfuse carried only `input_tokens` and `output_tokens`, while OpenRouter spans carried the cache keys.

`@ai-sdk/openai` does this mapping correctly at its `dist/index.js:203`; groq simply lacked the equivalent.

## Fix

Bump to **4.0.34**, which adds `convertGroqUsage()` mapping `cached_tokens → inputTokens.cacheRead`. `package.json` already allowed it under `^4.0`; only the lockfile pinned 4.0.0. No source changes needed — the existing `extractCachedTokens()` reads exactly the key the new version populates.

## Verification

Fetch interceptor around `generateText`, 12 identical 28k-token prompts — raw hits **3/12**, SDK-reported **3/12**, exact match:

```
raw.cached_tokens=27904  →  {"noCacheTokens":175,"cacheReadTokens":27904}
```

End-to-end through the same `LangfuseSpanProcessor` + `NodeSDK` + `registerTelemetry` wiring the app uses, 14 calls → 5 raw hits → 5 generations in Langfuse carrying `cache_read.input_tokens: 27904`. First time Groq spans have carried that key.

Tests: `bun run test:unit` 1126 pass / 0 fail — `bun test tests/integration` 84 pass / 0 fail.

## Notes

- Groq's cache is per-node, so the hit rate stays uneven by nature: probes suggest roughly a quarter of calls hit, but each hit covers ~99% of the prompt. This PR makes the number visible; it does not raise it.
- The lockfile also picks up the `chalk` entry missing from its workspace manifest block. `chalk` is already declared in `package.json` on `main` — this just syncs the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014xHSmzm2ZczcH2ox3WQAC3
