### PR TITLE
Stream the docs index docbot generates over the WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2026-08-30
+
+### Changes
+
+- Doc Collector: a `docs collect` run streamed with `--ws` now sends the spec index it generates as a
+  `docs` frame — the file path and the full markdown of `docs/index.md` — so a listening UI can show
+  the finished documentation the same way an exploration run streams its session report.
+- Doc Collector: a streamed run now closes the connection on its way out instead of exiting from
+  under it, so the final `result` frame arrives and anything still queued is flushed. Previously the
+  index frame, written moments before exit, was the one most likely to be lost.
+
 ## 2026-08-29
 
 ### Changes

--- a/boat/doc-collector/src/cli.ts
+++ b/boat/doc-collector/src/cli.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Command } from 'commander';
 import { ConfigCommand } from '../../../src/commands/config-command.ts';
+import { remote } from '../../../src/remote.ts';
 import { isVerboseMode, setPreserveConsoleLogs, setQuietMode } from '../../../src/utils/logger.ts';
 import { DocBot, type DocbotOptions } from './docbot.ts';
 
@@ -59,9 +60,11 @@ export function createDocsCommands(name = 'docs'): Command {
       console.log(`Use in Explorbot: npx explorbot start ${startPath} --spec "${result.outputDir}"`);
 
       await bot.stop();
+      await remote.close(0);
       process.exit(0);
     } catch (error) {
       console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
+      await remote.close(1);
       process.exit(1);
     }
   });

--- a/boat/doc-collector/src/docbot.ts
+++ b/boat/doc-collector/src/docbot.ts
@@ -465,7 +465,9 @@ class DocBot {
   private saveIndex(startPath: string, pages: DocumentedPage[], skipped: SkippedPage[], maxPages: number): { indexPath: string; diagramPath: string } {
     const outputDir = this.configParser.getOutputDir();
     const indexPath = path.join(outputDir, 'index.md');
-    writeFileSync(indexPath, renderSpecIndex(outputDir, startPath, pages, skipped, maxPages), 'utf8');
+    const index = renderSpecIndex(outputDir, startPath, pages, skipped, maxPages);
+    writeFileSync(indexPath, index, 'utf8');
+    tag('data').log('docs', { path: indexPath, content: index });
     const diagramPath = path.join(outputDir, 'state-diagram.mmd');
     writeFileSync(diagramPath, renderMermaidBody(outputDir, pages), 'utf8');
     return { indexPath, diagramPath };

--- a/docs/reference/websocket.md
+++ b/docs/reference/websocket.md
@@ -19,6 +19,7 @@ Every message is JSON with a `type` and a `ts`, plus whatever that type carries.
 | `screenshot` | the screenshot file just written |
 | `research` | the researcher's map of a page: markdown and its file |
 | `report` | the analyst's end-of-session report: markdown and its file |
+| `docs` | the doc collector's spec index: markdown and its file |
 | `activity` | what the run is doing this second |
 | `log` | a log line and its level |
 | `ask` | a question for a human, carrying an `askId` |


### PR DESCRIPTION
Docbot was already half-wired to the `--ws` stream: its bin calls `remote.registerOption`, and it inherits every frame the shared modules emit — `hello`, `log`, `activity`, `state` (state-manager), `screenshot` (action.ts), `research` (researcher cache) and `ask` through the execution controller. But every `tag('data')` call site lives in `src/`; nothing under `boat/` emitted a frame of its own, so `docs/index.md` — the artifact the whole run produces — never reached a listener.

## Changes

- **`saveIndex()` emits a `docs` frame** (`boat/doc-collector/src/docbot.ts`) — keeps the rendered markdown in a local, writes it, then `tag('data').log('docs', { path, content })`, mirroring `writeReport()` in `src/ai/session-analyst.ts`. Same `{path, content}` payload as `report`, but a new kind rather than reusing it: a UI keeps the last frame per type, and the analyst's report and the spec index are unrelated artifacts.
- **The exit path closes the remote** (`boat/doc-collector/src/cli.ts`) — `docs collect` ended on a bare `process.exit(0)`, while the main CLI routes exits through `showStatsAndExit` → `remote.close(code)`, which sends `result` and flushes. Docbot did neither, so a listener never learned the run ended. This is a prerequisite, not a separate nit: `saveIndex()` fires at the very last moment before exit, so the new frame was the one most likely to die in the socket buffer. `close()` early-returns when unattached, so no guard is needed.
- **`docs/reference/websocket.md`** — added the `docs` row to the frame table, which is the contract listeners actually read.

Scope is `index.md` only. Per-page `pages/*.md` and `state-diagram.mmd` stay unstreamed, matching the one-shot-at-end shape of `report`.

## Not fixed here

`boat/api-tester` has the same missing `remote.close()` on exit, so apibot runs never send `result` either. Left alone to keep this PR to its stated purpose, and because that boat has unrelated work in flight.

## Testing

`bun run format`, `bun run lint`, and `bun test tests/unit/doc-collector.test.ts` (45 pass) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Twc8quqSCEZNzPn4sK1o55