### PR TITLE
Keep executed tool steps when a generation fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changes
 
+- [Provider] Work a tool already did is no longer redone when the turn it was part of breaks partway
+  through. A model turn can run several tool calls before it fails — because the model asked for a
+  tool that does not exist, answered in plain text where a tool call was demanded, or ran the
+  conversation past the model's context limit. The whole turn was then retried from its starting
+  point, with no trace that the earlier calls had already gone through, so everything they had
+  created got created again, once per retry. The calls that completed now carry over into the retry
+  and into the conversation, and the model continues from them instead of repeating them.
 - Doc Collector: a `docs collect` run streamed with `--ws` now sends the spec index it generates as a
   `docs` frame — the file path and the full markdown of `docs/index.md` — so a listening UI can show
   the finished documentation the same way an exploration run streams its session report.

--- a/src/ai/provider.ts
+++ b/src/ai/provider.ts
@@ -426,10 +426,20 @@ export class Provider {
     const config = this.buildGenerateConfig({ tools: toolsWithCommentary, maxOutputTokens: 16384, toolChoice: 'auto', experimental_repairToolCall: repairToolCall }, { stopWhen: stopConditions, model }, options);
     let attemptMessages = messages;
     let invalidRequestFeedbackAdded = false;
+    const executedStepMessages: ModelMessage[] = [];
     try {
       const response = await this.withModelRequestSlot(() =>
         withRetry(async () => {
-          const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages: attemptMessages, ...config, abortSignal: signal }), config.timeout || 30000).catch((error) => {
+          const stepMessages: ModelMessage[] = [];
+          const onStepEnd = (step: any) => {
+            stepMessages.push(...(step.response?.messages || []));
+          };
+          const result = (await this.raceWithIdleTimeout((signal) => generateText({ messages: attemptMessages, ...config, abortSignal: signal, onStepEnd }), config.timeout || 30000).catch((error) => {
+            if (stepMessages.length > 0) {
+              tag('warning').log(`Keeping ${stepMessages.length} messages from tool steps that already ran before the failure`);
+              executedStepMessages.push(...stepMessages);
+              attemptMessages = [...attemptMessages, ...stepMessages];
+            }
             if (!invalidRequestFeedbackAdded) {
               const amended = withInvalidRequestFeedback(attemptMessages, error);
               invalidRequestFeedbackAdded = amended !== attemptMessages;
@@ -448,6 +458,8 @@ export class Provider {
 
       clearActivity();
 
+      withExecutedSteps(response, executedStepMessages);
+
       // Log tool usage summary
       if (response.toolCalls && response.toolCalls.length > 0) {
         responseLog(response.toolCalls);
@@ -462,12 +474,13 @@ export class Provider {
     } catch (error: any) {
       clearActivity();
       if (error?.message?.includes('Tool choice is required')) {
-        return { text: '', toolCalls: [], toolResults: [], response: { messages: [] }, usage: null };
+        return { text: '', toolCalls: [], toolResults: [], responseMessages: executedStepMessages, usage: null };
       }
       if (error?.name === 'AbortError') throw error;
       if (error instanceof ContextLengthError) throw error;
       if (Provider.isContextLengthError(error)) {
-        return this.recoverFromContextLength(error, messages, options, (m, o) => this.generateWithTools(m, model, tools, o));
+        const recovered = await this.recoverFromContextLength(error, attemptMessages, options, (m, o) => this.generateWithTools(m, model, tools, o));
+        return withExecutedSteps(recovered, executedStepMessages);
       }
       if (error.constructor?.name === 'AI_APICallError') {
         responseLog(error.message);
@@ -701,6 +714,11 @@ export class Provider {
 function repairToolCall(options: ToolCallRepairOptions): any | null {
   if (options.toolCall.toolName.includes('<|channel|>')) return repairChannelMarker(options);
   return repairHarmonyChannel(options);
+}
+
+function withExecutedSteps(result: any, executed: ModelMessage[]): any {
+  if (executed.length === 0) return result;
+  return Object.defineProperty(result, 'responseMessages', { value: [...executed, ...(result.responseMessages || [])], configurable: true, enumerable: true });
 }
 
 function withInvalidRequestFeedback(messages: ModelMessage[], error: unknown): ModelMessage[] {

--- a/tests/unit/provider.test.ts
+++ b/tests/unit/provider.test.ts
@@ -348,6 +348,93 @@ describe('Provider', () => {
       expect(JSON.stringify(relayed.content)).toContain('attempted to call a tool which was not in request.tools');
     });
 
+    it('carries tool steps that already ran into the retry', async () => {
+      const prompts: any[] = [];
+      let calls = 0;
+      let created = 0;
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'test',
+        doGenerate: async (params: any) => {
+          calls++;
+          prompts.push(params.prompt);
+          if (calls === 1) {
+            return {
+              text: undefined,
+              toolCalls: [{ toolCallId: 'c1', toolName: 'create', args: { name: 'suite' } }],
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 1, outputTokens: 1 },
+              content: [{ type: 'tool-call' as const, toolCallId: 'c1', toolName: 'create', input: JSON.stringify({ name: 'suite' }) }],
+            };
+          }
+          if (calls === 2) {
+            throw new APICallError({ url: 'http://test.local/v1/chat', statusCode: 400, message: 'Tool call validation failed: attempted to call a tool which was not in request.tools' });
+          }
+          return { text: 'done', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'done' }] };
+        },
+      });
+      aiConfig.retryDelay = 1;
+      const retryingProvider = new Provider(aiConfig);
+      const tools = {
+        create: tool({
+          description: 'Create a record',
+          inputSchema: z.object({ name: z.string() }),
+          execute: async () => {
+            created++;
+            return { id: 1 };
+          },
+        }),
+      };
+
+      const response = await retryingProvider.generateWithTools([{ role: 'user', content: 'go' }], model, tools, { maxRetries: 3 });
+
+      expect(created).toBe(1);
+      expect(JSON.stringify(prompts[2])).toContain('c1');
+      expect(response.responseMessages.filter((m: any) => m.role === 'tool')).toHaveLength(1);
+      expect(response.responseMessages.at(-1).content).toEqual([{ type: 'text', text: 'done' }]);
+    });
+
+    it('returns the tool steps that ran when the provider rejects every retry', async () => {
+      let calls = 0;
+      let created = 0;
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'test',
+        doGenerate: async () => {
+          calls++;
+          if (calls === 1) {
+            return {
+              text: undefined,
+              toolCalls: [{ toolCallId: 'c1', toolName: 'create', args: { name: 'suite' } }],
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 1, outputTokens: 1 },
+              content: [{ type: 'tool-call' as const, toolCallId: 'c1', toolName: 'create', input: JSON.stringify({ name: 'suite' }) }],
+            };
+          }
+          throw new APICallError({ url: 'http://test.local/v1/chat', statusCode: 400, message: 'Tool choice is required, but model did not call a tool' });
+        },
+      });
+      aiConfig.retryDelay = 1;
+      const retryingProvider = new Provider(aiConfig);
+      const tools = {
+        create: tool({
+          description: 'Create a record',
+          inputSchema: z.object({ name: z.string() }),
+          execute: async () => {
+            created++;
+            return { id: 1 };
+          },
+        }),
+      };
+
+      const response = await retryingProvider.generateWithTools([{ role: 'user', content: 'go' }], model, tools, { maxRetries: 2 });
+
+      expect(created).toBe(1);
+      expect(response.text).toBe('');
+      expect(response.responseMessages).toHaveLength(2);
+      expect(response.responseMessages[1].role).toBe('tool');
+    });
+
     it('should honor configured retry attempts and delay', () => {
       aiConfig.retryAttempts = 7;
       aiConfig.retryDelay = 250;
@@ -658,6 +745,49 @@ describe('Provider', () => {
 
       expect(response.text).toBe('recovered');
       expect(calls).toBe(2);
+    });
+
+    it('keeps tool steps that already ran when it reduces messages', async () => {
+      const prompts: any[] = [];
+      let calls = 0;
+      let created = 0;
+      const model = new MockLanguageModelV3({
+        provider: 'test',
+        modelId: 'ctx-tools-model',
+        doGenerate: async (params: any) => {
+          calls++;
+          prompts.push(params.prompt);
+          if (calls === 1) {
+            return {
+              text: undefined,
+              toolCalls: [{ toolCallId: 'c1', toolName: 'create', args: { name: 'suite' } }],
+              finishReason: 'tool-calls' as const,
+              usage: { inputTokens: 1, outputTokens: 1 },
+              content: [{ type: 'tool-call' as const, toolCallId: 'c1', toolName: 'create', input: JSON.stringify({ name: 'suite' }) }],
+            };
+          }
+          if (calls === 2) throw new Error('context length exceeded');
+          return { text: 'recovered', finishReason: 'stop' as const, usage: { inputTokens: 1, outputTokens: 1 }, content: [{ type: 'text' as const, text: 'recovered' }] };
+        },
+      });
+      const tools = {
+        create: tool({
+          description: 'Create a record',
+          inputSchema: z.object({ name: z.string() }),
+          execute: async () => {
+            created++;
+            return { id: 1 };
+          },
+        }),
+      };
+      const messages: ModelMessage[] = [{ role: 'user', content: `<data>${'x'.repeat(5000)}</data>` }];
+
+      const response = await provider.generateWithTools(messages, model, tools, { maxRetries: 1 });
+
+      expect(created).toBe(1);
+      expect(response.text).toBe('recovered');
+      expect(JSON.stringify(prompts[2])).toContain('c1');
+      expect(response.responseMessages.filter((m: any) => m.role === 'tool')).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
A tool turn can execute several tool calls before the step that follows them fails. When that happens, `withRetry` re-ran `generateText` from the original `messages` — so the calls that had already gone through left no trace in the retry, and whatever they created on the far side got created again, once per attempt.

Seen in Langfuse trace `7d5ddba053a054f6a3725503c9569340`: Fisherman created the same suite + test pair four times in 16 seconds. Each attempt POSTed both (200, 200) at steps 3–4 and then died at step 5, alternating between two Groq 400s — `attempted to call tool 'json'` (the model emitting a harmony pseudo-tool) and `Tool choice is required, but model did not call a tool` (the model writing its summary as prose under `toolChoice: 'required'`). The writes escaped the retry boundary; the record of them did not.

## What changed

`generateWithTools` accumulates each completed step's response messages through `onStepEnd`, and on failure:

- feeds them into the next attempt's `messages`, so the model resumes from what it already did instead of starting over (the existing invalid-request feedback line is appended after them);
- merges them into the returned `responseMessages`, so `invokeConversation` records them on the conversation and the *next* loop iteration sees them too;
- returns them from the `Tool choice is required` swallow, which previously returned an empty message list;
- recurses from them in the context-length recovery, which previously restarted from the original `messages` — the same duplication hazard by a third route.

This is provider-level, so it covers every agent that runs write-effect tools, not just Fisherman.

## Not in scope

When retries exhaust and `generateWithTools` throws `AiError`, executed steps still do not reach the conversation. That is moot for Fisherman (its loop stops on error) but a live hazard for Tester, which keeps iterating on the same conversation after an error. Fixing it means changing what a failed invocation returns to its caller, which is a bigger decision than this PR.

Independently of this, `toolChoice: 'required'` in `src/ai/fisherman.ts` is what turns "model finished and said so in prose" into a hard 400. Worth revisiting separately.

## Testing

Three unit tests in `tests/unit/provider.test.ts`, each verified to fail without the change:

- executed steps carry into the retry and into `responseMessages`, and the tool runs once;
- the `Tool choice is required` swallow returns them;
- the context-length recovery reduces messages without losing them.

`bun test tests/unit/` (1123 pass) and `bun test tests/integration/` (82 pass, 1 skip) are green; `bunx tsc --noEmit` reports the same six pre-existing errors in `provider.ts` as `main`. `bun run build` fails identically on `main` in this checkout — a missing `chromium-bidi` in local `node_modules`, unrelated to the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uAMi5ctXDCk7vbhPnMmEi