### PR TITLE
Plan one business operation per test, and none for records the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@
   scenarios that depend on each other, so a record's whole lifecycle — create it, rename it, delete it —
   landed in a single test. Such chains were the longest tests of a run and failed as a whole at the
   first broken step, discarding everything after it. Creating, updating and deleting the same record are
-  now separate tests, each preparing its own starting state instead of continuing where another test
-  stopped.
+  now separate tests; a test that needs a record names it and the data is prepared before the test, so
+  no test continues where another one stopped.
 - [Planner] Scenarios are no longer planned for a record the page reports as missing. When a detail page
   shows a "not found" message instead of the record, the planner used to invent edit-form scenarios for
   the dead record anyway, and every one of them stopped immediately. The list and recovery behavior are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@
 - Experience Tracker: An unnamed panel no longer marks a page's own experience file as
   panel-scoped. When it did, that page's entire experience became invisible whenever no panel was
   open.
+- [Planner] One scenario now covers one business operation. The old rule told the planner to merge any
+  scenarios that depend on each other, so a record's whole lifecycle — create it, rename it, delete it —
+  landed in a single test. Such chains were the longest tests of a run and failed as a whole at the
+  first broken step, discarding everything after it. Creating, updating and deleting the same record are
+  now separate tests, each preparing its own starting state instead of continuing where another test
+  stopped.
+- [Planner] Scenarios are no longer planned for a record the page reports as missing. When a detail page
+  shows a "not found" message instead of the record, the planner used to invent edit-form scenarios for
+  the dead record anyway, and every one of them stopped immediately. The list and recovery behavior are
+  planned instead.
 
 ## 2026-08-31
 

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -114,13 +114,13 @@ export class Planner extends PlannerBase implements Agent {
       Tests must be relevant to the page
       Tests must be achievable from UI
       Tests must be verifiable from UI
-      One test covers ONE business operation, end to end — its own setup, action, and verification.
-      Micro-steps of a single operation never become separate tests.
+      One test covers ONE business operation: the steps that lead to it, the action itself, and its verification.
+      Steps that merely reach the action — opening a form, expanding a panel, locating an item — belong to the test. Performing another operation never does.
       Bad: "Open delete dropdown" + "Confirm deletion" — these are ONE test, not two.
       Bad: "Search for X" + "Verify search results" — searching and verifying is ONE test.
       Bad: "Leave field empty" + "Click submit" — that's one negative test, not two.
       Separate business operations on the same record — creating it, updating it, deleting it — are SEPARATE tests.
-      Each test prepares its own starting state (its own disposable record, or one already on the page) and must never rely on another test having run first: a chained scenario fails at its first broken step and hides which operations actually work.
+      Creating a record is never another test's setup: a test that needs a record says so in the scenario ("an existing item from the list") and the runner prepares the data before the test starts. A test must never rely on another test having run first — a chained scenario fails at its first broken step and hides which operations actually work.
       Plan for what the page actually shows. When the page reports a record is not found or unavailable, that record is not a testable surface — plan list-level or recovery behavior instead of operations on that record.${featureDirective}${focusExistingDataDirective}
     </task>
 

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -114,11 +114,14 @@ export class Planner extends PlannerBase implements Agent {
       Tests must be relevant to the page
       Tests must be achievable from UI
       Tests must be verifiable from UI
-      NEVER split one workflow into multiple tests. Each test must be a complete end-to-end flow.
+      One test covers ONE business operation, end to end — its own setup, action, and verification.
+      Micro-steps of a single operation never become separate tests.
       Bad: "Open delete dropdown" + "Confirm deletion" — these are ONE test, not two.
       Bad: "Search for X" + "Verify search results" — searching and verifying is ONE test.
       Bad: "Leave field empty" + "Click submit" — that's one negative test, not two.
-      If two scenarios cannot run independently (one requires the other to run first), merge them into one.${featureDirective}${focusExistingDataDirective}
+      Separate business operations on the same record — creating it, updating it, deleting it — are SEPARATE tests.
+      Each test prepares its own starting state (its own disposable record, or one already on the page) and must never rely on another test having run first: a chained scenario fails at its first broken step and hides which operations actually work.
+      Plan for what the page actually shows. When the page reports a record is not found or unavailable, that record is not a testable surface — plan list-level or recovery behavior instead of operations on that record.${featureDirective}${focusExistingDataDirective}
     </task>
 
     ${customPrompt || ''}

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -224,8 +224,9 @@ describe('Planner with aimock', () => {
 
     const prompt = extractPromptText(mock.getLastRequest());
     expect(prompt).toContain('One test covers ONE business operation');
-    expect(prompt).toContain('Micro-steps of a single operation never become separate tests');
+    expect(prompt).toContain('Steps that merely reach the action');
     expect(prompt).toContain('are SEPARATE tests');
+    expect(prompt).toContain("Creating a record is never another test's setup");
     expect(prompt).toContain('never rely on another test having run first');
     expect(prompt).not.toContain('merge them into one');
   });

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -219,6 +219,26 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('One section is marked as **Focused**');
   });
 
+  it('scopes one test to one business operation and forbids relying on other tests', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('One test covers ONE business operation');
+    expect(prompt).toContain('Micro-steps of a single operation never become separate tests');
+    expect(prompt).toContain('are SEPARATE tests');
+    expect(prompt).toContain('never rely on another test having run first');
+    expect(prompt).not.toContain('merge them into one');
+  });
+
+  it('forbids planning operations on a record the page reports missing', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('Plan for what the page actually shows');
+    expect(prompt).toContain('not a testable surface');
+    expect(prompt).toContain('list-level or recovery behavior');
+  });
+
   it('expands existing plan without duplicating tests', async () => {
     const existingPlan = new Plan('Task Board Testing');
     existingPlan.url = '/tasks/board';


### PR DESCRIPTION
 Two planner prompt principles, both traced from last night's cron run 