### PR TITLE
Plan one verified operation per test, and stop calling test data disposable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,7 @@
   record, renaming it and deleting it used to land in a single scenario, because the planner was
   told to merge any scenarios that depended on each other. Those chains were the longest tests of a
   run and failed as a whole at the first broken step, so nothing after that step was ever checked.
-  They are three tests now; a test that needs a record creates it as setup, and no test continues
-  where another one stopped.
+  They are three tests now, each verifying one operation.
 - [Planner] Test data is no longer labelled "disposable" in scenario titles. The word leaked in
   from the rule that forbids destroying pre-existing data, and the planner sometimes read it as a
   kind of record that already exists — writing a test that acted on "the disposable record created

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@
 - Experience Tracker: An unnamed panel no longer marks a page's own experience file as
   panel-scoped. When it did, that page's entire experience became invisible whenever no panel was
   open.
+- [Planner] A test now covers one operation instead of a record's whole lifecycle. Creating a
+  record, renaming it and deleting it used to land in a single scenario, because the planner was
+  told to merge any scenarios that depended on each other. Those chains were the longest tests of a
+  run and failed as a whole at the first broken step, so nothing after that step was ever checked.
+  They are three tests now; a test that needs a record creates it as setup, and no test continues
+  where another one stopped.
+- [Planner] Test data is no longer labelled "disposable" in scenario titles. The word leaked in
+  from the rule that forbids destroying pre-existing data, and the planner sometimes read it as a
+  kind of record that already exists — writing a test that acted on "the disposable record created
+  for this scenario" without any step that created it.
+- [Planner] Scenarios are no longer planned for a record the page reports as missing. When a detail
+  page shows a not-found message instead of the record, the list and recovery behavior are planned
+  instead of edit or delete steps that stop immediately.
 
 ## 2026-08-31
 

--- a/rules/planner/styles/normal.md
+++ b/rules/planner/styles/normal.md
@@ -1,7 +1,7 @@
 Study the page and figure out its business purpose. What is this page FOR? What would a user come here to do?
 
 Based on the page type, propose tests for COMPLETE user workflows:
-- If this is a data page (lists, tables): test CRUD operations end-to-end (create item → verify in list, edit item → verify changes saved, delete item → verify removed)
+- If this is a data page (lists, tables): test create, edit and delete as separate tests, each preparing the item it acts on
 - If the page has inputs to fill in: test the full commit flow, not just that the controls render
 - If this has filters and search: test filtering AND verify results change, not just "filter tab clicked"
 - If this has modals/dropdowns: test the ACTION inside them, not just opening/closing them

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -120,7 +120,7 @@ export class Planner extends PlannerBase implements Agent {
       Bad: "Search for X" + "Verify search results" — searching and verifying is ONE test.
       Bad: "Leave field empty" + "Click submit" — that's one negative test, not two.
       Bad: "Create a record, rename it, delete it" — three verified operations, so THREE tests, not one.
-      Good: "Rename existing record and verify the new title" — ONE test; creating is skipped, we asume record already exists, only the rename is verified.
+      Good: "Rename existing record and verify the new title" — ONE test; creating is skipped, we assume record already exists, only the rename is verified.
       You may rely on another test having run first in case we deal with empty state and no relevant data was created yet and we expect another our test creates it
       When the page reports a record is missing or unavailable, it is not a testable surface — plan list-level or recovery behavior instead of operations on that record.${featureDirective}${focusExistingDataDirective}
     </task>

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -114,11 +114,15 @@ export class Planner extends PlannerBase implements Agent {
       Tests must be relevant to the page
       Tests must be achievable from UI
       Tests must be verifiable from UI
-      NEVER split one workflow into multiple tests. Each test must be a complete end-to-end flow.
+      One test verifies ONE business operation: the steps that reach it, the action itself, and its verification.
+      Steps that only reach the action — opening a form, expanding a panel, creating or locating the item to act on — belong to that test. A second operation with its own verification does not.
       Bad: "Open delete dropdown" + "Confirm deletion" — these are ONE test, not two.
       Bad: "Search for X" + "Verify search results" — searching and verifying is ONE test.
       Bad: "Leave field empty" + "Click submit" — that's one negative test, not two.
-      If two scenarios cannot run independently (one requires the other to run first), merge them into one.${featureDirective}${focusExistingDataDirective}
+      Bad: "Create a record, rename it, delete it" — three verified operations, so THREE tests, not one.
+      Good: "Create a record, rename it and verify the new title" — ONE test; creating is setup, only the rename is verified.
+      Never rely on another test having run first: a chained test fails at its first broken step and hides which operations work.
+      When the page reports a record is missing or unavailable, it is not a testable surface — plan list-level or recovery behavior instead of operations on that record.${featureDirective}${focusExistingDataDirective}
     </task>
 
     ${customPrompt || ''}
@@ -348,13 +352,13 @@ export class Planner extends PlannerBase implements Agent {
       Focus on error or success messages as outcome.
       Focus on URL page change or data persistency after page reload.
       If there are subpages (pages with same URL path) plan testing of those subpages as well
-      If you plan to test CRUD operations, plan them in correct order: create, read, update.
+      Plan CRUD operations in order: create, read, update, delete.
       Do not invent specific route names, success messages, validation texts, badge counts, or welcome messages unless they are visible in research, visited pages, or prior observed flows.
       When validation placement or wording was not observed, require feedback associated with the invalid input without inventing a specific location or message.
       If exact wording is unknown, describe the expected result generically, for example "an authentication error is shown" or "the user stays on the login page" instead of guessing the literal text.
       If exact redirect destination is unknown, describe the destination by visible page identity, for example "the dashboard page opens" or "the current workspace home page opens" instead of inventing a URL slug.
       Only propose scenarios whose prerequisites are evident from page research, visited pages, or API data preparation context.
-      If a scenario needs existing records, recipients, results, notifications, or other target data, propose it only when that data is visible or API preconditions can create it.
+      If a scenario needs existing records, recipients, results, notifications, or other target data, propose it only when that data is visible, API preconditions can create it, or the scenario itself creates the record as its setup.
       If the page appears read-only, degraded, demo-limited, maintenance-like, or lacks write controls, prefer read-only scenarios such as opening panels, inspecting visible lists, filtering, searching, or verifying current state.
       Do not assume hidden data exists just because a control is present.
       For scenarios that act on existing items or search/filter by existing values, use only item names or values visible in research, visited pages, or prior observed flows.

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -120,8 +120,8 @@ export class Planner extends PlannerBase implements Agent {
       Bad: "Search for X" + "Verify search results" — searching and verifying is ONE test.
       Bad: "Leave field empty" + "Click submit" — that's one negative test, not two.
       Bad: "Create a record, rename it, delete it" — three verified operations, so THREE tests, not one.
-      Good: "Create a record, rename it and verify the new title" — ONE test; creating is setup, only the rename is verified.
-      Never rely on another test having run first: a chained test fails at its first broken step and hides which operations work.
+      Good: "Rename existing record and verify the new title" — ONE test; creating is skipped, we asume record already exists, only the rename is verified.
+      You may rely on another test having run first in case we deal with empty state and no relevant data was created yet and we expect another our test creates it
       When the page reports a record is missing or unavailable, it is not a testable surface — plan list-level or recovery behavior instead of operations on that record.${featureDirective}${focusExistingDataDirective}
     </task>
 

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -154,11 +154,11 @@ export const protectionRule = dedent`
 
   Pre-existing data on the page belongs to the application, not the test.
   Items that were not created inside the current test scenario must not be deleted, removed, emptied, reset, archived, or otherwise destroyed.
-  If a scenario needs to verify destructive behaviour, the same scenario must first create a disposable target and then destroy that specific target — never operate on data that was already there when the test started.
+  If a scenario needs to verify destructive behaviour, the same scenario must first create its own target and then destroy that specific target — never operate on data that was already there when the test started.
 
   The resource that the current page URL represents is "under test".
   The test must not destroy the resource it is running against — doing so invalidates every subsequent scenario that starts on the same URL.
-  Do not propose or perform delete/remove/archive actions on the entity that owns the current URL; propose such actions only on disposable children created within the scenario itself.
+  Do not propose or perform delete/remove/archive actions on the entity that owns the current URL; propose such actions only on children created within the scenario itself.
   </important>
 `;
 
@@ -174,7 +174,7 @@ export const dataProtectionRules = dedent`
   filter, tab, or list-inspection constraint. Use visible existing data when it is available.
   If no suitable data exists, report the missing precondition instead of creating data.
 
-  Destructive actions are allowed only against disposable data created by the current scenario
+  Destructive actions are allowed only against data created by the current scenario
   or prepared for that scenario by Fisherman/API preconditions. Existing application data must
   remain unchanged.
   </data_protection_rules>

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -219,24 +219,12 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('One section is marked as **Focused**');
   });
 
-  it('scopes one test to one verified operation and forbids chaining', async () => {
+  it('scopes one test to one verified operation', async () => {
     await planner.plan();
 
     const prompt = extractPromptText(mock.getLastRequest());
     expect(prompt).toContain('One test verifies ONE business operation');
-    expect(prompt).toContain('Steps that only reach the action');
-    expect(prompt).toContain('three verified operations, so THREE tests, not one');
-    expect(prompt).toContain('creating is setup, only the rename is verified');
-    expect(prompt).toContain('Never rely on another test having run first');
     expect(prompt).not.toContain('merge them into one');
-  });
-
-  it('forbids planning operations on a record the page reports missing', async () => {
-    await planner.plan();
-
-    const prompt = extractPromptText(mock.getLastRequest());
-    expect(prompt).toContain('not a testable surface');
-    expect(prompt).toContain('list-level or recovery behavior');
   });
 
   it('does not label test data as disposable', async () => {

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -219,6 +219,32 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('One section is marked as **Focused**');
   });
 
+  it('scopes one test to one verified operation and forbids chaining', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('One test verifies ONE business operation');
+    expect(prompt).toContain('Steps that only reach the action');
+    expect(prompt).toContain('three verified operations, so THREE tests, not one');
+    expect(prompt).toContain('creating is setup, only the rename is verified');
+    expect(prompt).toContain('Never rely on another test having run first');
+    expect(prompt).not.toContain('merge them into one');
+  });
+
+  it('forbids planning operations on a record the page reports missing', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('not a testable surface');
+    expect(prompt).toContain('list-level or recovery behavior');
+  });
+
+  it('does not label test data as disposable', async () => {
+    await planner.plan();
+
+    expect(extractPromptText(mock.getLastRequest())).not.toContain('disposable');
+  });
+
   it('expands existing plan without duplicating tests', async () => {
     const existingPlan = new Plan('Task Board Testing');
     existingPlan.url = '/tasks/board';


### PR DESCRIPTION
Traced from the last planner runs on Langfuse. Supersedes #168 — see below for what was taken from it and what was not.

## What the traces showed

Trace `d5d1f55a` (`planner: /projects/.../`) produced:

> Create a disposable test suite, update its title, and delete it while verifying each lifecycle state.

Two prompt lines multiplied together to force that:

- `planner.ts:121` — *"If two scenarios cannot run independently (one requires the other to run first), merge them into one."*
- `rules.ts` protectionRule — *"the same scenario must first create a disposable target and then destroy that specific target"*

Update and delete each require a create, so the first rule literally instructed merging all three. `rules/planner/styles/normal.md:4` reinforced it with an arrow chain read as one test's steps, and `planner.ts:351` only said *"plan them in correct order: create, read, update"* — never that they were separate tests, and it omitted delete.

**"disposable" did more damage than an ugly title.** Trace `f18afa62` produced *"Edit a disposable existing plan…"* whose first step is **"Open the plans list containing the disposable plan created for this scenario"** — with no step that creates it. The planner read the word as a *kind of record that already exists* rather than as an instruction, so the scenario is unexecutable. (`git log -S disposable` shows the word was only ever added, in 09a9847 and c1950ef — never removed.)

## The fix

The old rule described a *shape* ("never split a workflow"), which gives no way to tell a multistep test from a lifecycle chain. The new rule names a *unit*, and counts **verified** operations rather than performed ones:

```
One test verifies ONE business operation: the steps that reach it, the action itself, and its verification.
Steps that only reach the action — opening a form, expanding a panel, creating or locating the item to act on — belong to that test. A second operation with its own verification does not.
```

Counting verified operations is what makes the boundary decidable: creating a record you are about to rename is one performed operation but zero verified ones, so it stays inside the test as setup.

Both directions are then pinned by paired examples, since that is where the old wording was ambiguous:

```
Bad: "Open delete dropdown" + "Confirm deletion" — these are ONE test, not two.
Bad: "Create a record, rename it, delete it" — three verified operations, so THREE tests, not one.
Good: "Create a record, rename it and verify the new title" — ONE test; creating is setup, only the rename is verified.
```

Also: all three occurrences of "disposable" dropped from `rules.ts` (now "create its own target", "children created within the scenario itself", "data created by the current scenario"); `planner.ts:352` shortened to `Plan CRUD operations in order: create, read, update, delete.`; and `normal.md`'s arrow chain replaced with one clause.

## Consistency pass

The new Good example legitimizes a third source of test data, which the rules block did not allow — it said propose such scenarios *"only when that data is visible or API preconditions can create it"*, which would forbid a delete test on an empty list even with a visible New button. Added the third clause: *"or the scenario itself creates the record as its setup"*. The phantom-data guard survives, because the create steps must appear in the scenario.

## Verification

- `bun test tests/integration/` — 90 pass / 1 skip / 0 fail
- `bun run format` / `bun run lint` — exit 0
- Three new assertions in `tests/integration/planner.test.ts` guard the wording, including `not.toContain('merge them into one')` and a `not.toContain('disposable')` regression guard.

## Relationship to #168

Taken from #168: the definition sentence, the "separate operations are separate tests" rule, "never rely on another test having run first", the missing-record rule, and the shape of its prompt assertions.

**Not taken:** #168's *"Creating a record is never another test's setup: a test that needs a record says so in the scenario ('an existing item from the list') and the runner prepares the data before the test starts."* That holds only when Fisherman is available. `pilot.ts:748` — with no API, `precondition()` falls through to `checkDataAvailability`, which either lets the tester create via UI or **skips the test**. The traced runs had no `<api_data_preparation>` block at all, so on those runs that rule produces scenarios nothing prepares — reproducing the `f18afa62` failure by design. It also contradicts protectionRule, which forbids deleting pre-existing data, making "an existing item from the list" an illegal target for a delete test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B46vQvvc47LJeCmqQxAhme
