### PR TITLE
Report a resolved click ambiguity as a plain success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 - API Requests: Page-URL generalization and the API endpoint list now share one implementation.
   The endpoint list used to walk paths with its own copy of the dynamic-segment logic, which could
   drift from the URL matcher used everywhere else.
+- Click tool: When a locator matches several elements, the click that follows the right pick is now
+  reported as a plain success. The "multiple elements found" error no longer stays in the result, so
+  the AI stops re-sending the same click with a narrower locator — each resend clicked a second time
+  and silently flipped switches and toggles back to where they started.
 
 ## 2026-09-01
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -128,7 +128,9 @@ export function createCodeceptJSTools({ explorer, stateManager, ai }: ToolDeps, 
             }
             const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, retryCmd);
             await commitNote(activeNote, TestResult.PASSED, toolResult, action);
-            return successToolResult('click', { ...toolResult, attempts, code: retryCmd, disambiguated: true }, action);
+            const resolvedAttempts = attempts.filter((a) => !a.error?.toLowerCase().includes(MULTIPLE_ELEMENTS_PATTERN));
+            resolvedAttempts.push({ command: retryCmd, success: true });
+            return successToolResult('click', { ...toolResult, attempts: resolvedAttempts, code: retryCmd, disambiguated: true, suggestion: DISAMBIGUATED_SUGGESTION }, action);
           }
         }
 
@@ -1129,6 +1131,8 @@ export function createAgentTools({ explorer, stateManager, ai, researcher, navig
 
 const PAGE_DIFF_SUGGESTION =
   'Analyze page diff. htmlParts shows what changed and WHERE — each part has a container selector. Use the container as context when clicking elements from the diff. messages holds text the app showed in response, requests the calls it made and consoleErrors what it logged.';
+
+const DISAMBIGUATED_SUGGESTION = 'Your locator matched several elements; the ambiguity was resolved and the click RAN on the element shown in code. This is not a failure — do not reissue the click with a sharper locator. Repeating a click repeats the action and reverts anything that toggles.';
 
 const FAILED_REQUEST_SUGGESTION = 'The server rejected a request made by this action (see requests). The UI accepted the interaction but the operation did not complete — read messages and consoleErrors for the reason and report it instead of repeating the action.';
 

--- a/tests/unit/click-disambiguation.test.ts
+++ b/tests/unit/click-disambiguation.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { createCodeceptJSTools } from '../../src/ai/tools.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+function multipleElementsError(): Error {
+  const element = (xpath: string, html: string) => ({
+    toAbsoluteXPath: async () => xpath,
+    toOuterHTML: async () => html,
+    getText: async () => '',
+  });
+  return Object.assign(new Error('Multiple elements (2) found for "{role: switch}" in strict mode'), {
+    name: 'MultipleElementsFound',
+    webElements: [element('/html/body/div/button[1]', '<button role="switch" aria-checked="false"></button>'), element('/html/body/div/button[2]', '<button role="switch" aria-checked="true"></button>')],
+  });
+}
+
+function fakeDeps(): any {
+  const states = [
+    { url: '/plans/edit/1', html: '<html><body></body></html>', ariaSnapshot: '- switch', id: 'before' },
+    { url: '/plans/edit/1', html: '<html><body></body></html>', ariaSnapshot: '- switch [checked]', id: 'after' },
+  ];
+  let captured = 0;
+  const action: any = {
+    lastError: null,
+    saveScreenshot: async () => undefined,
+    attempt: async (command: string) => {
+      if (!command.includes('elementIndex')) {
+        action.lastError = multipleElementsError();
+        return false;
+      }
+      action.lastError = null;
+      captured = 1;
+      return true;
+    },
+  };
+  return {
+    explorer: { action: () => action },
+    stateManager: { getCurrentState: () => states[captured] },
+    ai: {
+      getModelForAgent: () => ({}),
+      generateObject: async () => ({ object: { position: 1 } }),
+    },
+  };
+}
+
+function fakeTask(): any {
+  return { startNote: () => ({ commit: () => {}, screenshot: undefined }) };
+}
+
+describe('click disambiguation result', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  it('reports the resolved click as a plain success the AI must not repeat', async () => {
+    const tools = createCodeceptJSTools(fakeDeps(), fakeTask());
+
+    const result = await tools.click.execute({ commands: [`I.click({"role":"switch"}, '.detail')`], explanation: 'Toggle the switch' }, {} as any);
+
+    expect(result.success).toBe(true);
+    expect(result.disambiguated).toBe(true);
+    expect(result.code).toContain('elementIndex: 1');
+    expect(result.attempts).toEqual([{ command: result.code, success: true }]);
+    expect(result.suggestion).toContain('do not reissue the click');
+  });
+});


### PR DESCRIPTION
When a click locator matches several elements, the click tool disambiguates, retries with `elementIndex`, and returns `success: true` — but it left the original `MultipleElementsFound` error sitting in `attempts`. Both readers take that error at face value: the Tester sees a failure in the result it just got, and Pilot's `formatActions` pulls the first `attempts[].error` into its evidence line, firing its `MultipleElementsFound → xpathCheck() then precise locator` rule on a click that had already landed.

So both retry. Each retry clicks the element a second time. On anything that toggles, every pair of "retries" puts the control back where it started, and the run carries on believing the setting is on.

## Evidence

Langfuse trace `5172fb3e976aa1e3889f149dd25a039b` (session `ThoughtlessActualViolet630`). A plan's "Run Automated as Manual" switch was clicked four times in 26 seconds — twice from the Tester's own locators, twice more on Pilot's advice — each click reported `success: true, disambiguated: true` with the ambiguity error still in `attempts`, and each time the model concluded the click had not landed:

| Time | ariaDiff | State |
|---|---|---|
| 04:28:36 | added `switch [checked]` | ON |
| 04:28:41 | removed `switch [checked]` | OFF |
| 04:28:57 | added `switch [checked]` | ON |
| 04:29:02 | removed `switch [checked]` | OFF |

Save then PATCHed the plan with the switch off, and the test reported PASS.

## The change

- The resolved ambiguity attempt is dropped from `attempts`; the successful retry is recorded there instead.
- The result carries a suggestion stating the click ran on the element shown in `code` and must not be reissued with a sharper locator.

`pilot.ts:1145` is untouched — that rule is still right for the genuine failure path, where disambiguation returns null or every retry fails. This change only starves it of false positives.

Covered by `tests/unit/click-disambiguation.test.ts` (verified failing without the fix). Unit (1247) and integration (92) suites pass.

## Not fixed here

Two further gaps from the same trace, deliberately out of scope:

- There is no idempotent route for `button[role="switch"]` the way `I.checkOption`/`I.uncheckOption` gives one for real checkboxes, so every repeat inverts state and nothing warns that the action is state-inverting.
- `verify()` accepts progressively weaker assertions. In that trace a correctly failing `"switch is checked"` was re-asked twice until `I.seeElement('button[role="switch"]:not([disabled])')` passed — matching the other, unrelated switch on the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017DuWpxPTjAacCgowWAT631