### PR TITLE
Make Pilot prove a list is empty before calling the data missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 2026-09-03
+
+### Changes
+
+- [Pilot] An empty dropdown or list no longer counts on its own as missing data. Pilot now has the
+  tester wait, checks the page actually changed and that a request went out to load the items, and
+  only calls the list empty once that has been verified. A list that was still loading, or one whose
+  options had not been opened yet, used to be read as "this app has no such data" and the scenario
+  was skipped as impossible.
+- [Pilot] The requests it sees after each action now include the ones that succeeded, not only the
+  failures, so a page that fetched its data is distinguishable from one that never asked for any.
+
 ## 2026-09-02
 
 ### New CLI Options

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -31,6 +31,7 @@ const META_TOOLS = ['record', 'reset', 'stop', 'finish'];
 const PILOT_REASONING_LIMIT = 500;
 const PILOT_MESSAGE_LIMIT = 2;
 const PILOT_MESSAGE_MAX_LENGTH = 160;
+const PILOT_REQUEST_LIMIT = 5;
 
 export class Pilot implements Agent {
   emoji = '🧭';
@@ -1071,9 +1072,13 @@ export class Pilot implements Agent {
 
         if (t.output?.pageDiff?.urlChanged) line += `\n   moved: ${t.output.pageDiff.previousUrl} → ${t.output.pageDiff.currentUrl}`;
 
-        const failedRequests = (t.output?.pageDiff?.requests ?? []).filter((r: any) => r.status >= 400);
-        if (failedRequests.length > 0) {
-          line += `\n   requests: ${failedRequests.map((r: any) => `${r.method} ${r.path} → ${r.status}`).join(', ')}`;
+        const pageRequests = t.output?.pageDiff?.requests ?? [];
+        const requests = pageRequests
+          .filter((r: any) => r.status >= 400)
+          .concat(pageRequests.filter((r: any) => r.status < 400))
+          .slice(0, PILOT_REQUEST_LIMIT);
+        if (requests.length > 0) {
+          line += `\n   requests: ${requests.map((r: any) => `${r.method} ${r.path} → ${r.status}`).join(', ')}`;
         }
 
         const messages = (t.output?.pageDiff?.messages ?? []).slice(0, PILOT_MESSAGE_LIMIT);
@@ -1147,7 +1152,7 @@ export class Pilot implements Agent {
       - Click SUCCESS but executed locator ≠ explanation intent, or "skipped" attempts present → wrong element clicked.
       - form(I.type()) SUCCESS but "element" shows a button/link → keys went to wrong element; click the input first.
       - ariaDiff shows 5+ added/removed → page entered new mode (editor/modal); call context() before guessing selectors.
-      - Empty dropdown/list when items expected → missing data; call precondition() to create it.
+      - Empty dropdown/list when items expected → wait explicitly, then check the state changed: ariaDiff and any GET that loaded data. If still nothing loaded, confirm the empty state with verify().
       - Search-and-select needs SEQUENCE: focus trigger → type to filter → click option. Tell Tester to split into separate tool calls.
       - Multi-action explanation in one tool call → instruct Tester to split.
 

--- a/tests/unit/pilot-action-evidence.test.ts
+++ b/tests/unit/pilot-action-evidence.test.ts
@@ -42,7 +42,7 @@ describe('Pilot recent_actions evidence', () => {
     expect(line).toContain('moved: /runs → /projects');
   });
 
-  it('drops requests that succeeded', () => {
+  it('names failed requests first, then the loads that succeeded', () => {
     const line = format({
       urlChanged: false,
       currentUrl: '/runs',
@@ -52,8 +52,7 @@ describe('Pilot recent_actions evidence', () => {
       ],
     });
 
-    expect(line).toContain('requests: POST /api/runs → 500');
-    expect(line).not.toContain('/api/runs → 200');
+    expect(line).toContain('requests: POST /api/runs → 500, GET /api/runs → 200');
   });
 
   it('keeps at most two messages and one console error', () => {


### PR DESCRIPTION
## What happened

Session `MolecularSouthernPink759` (trace `160c2a6a1da9c6980dcbf00cbc4d1958`) ran the scenario *"Assign an available label to the new suite draft"* and ended:

```
{"decision":"skipped","reason":"Set Labels shows no available labels, so the scenario prerequisite cannot be met."}
```

Twelve labels were in the accessibility tree at the time, the page had reported `12 results`, and one label had already been selected successfully.

Both `see()` calls that reported "no labels" were looking at a **collapsed** combobox. The one time it was expanded, the ARIA listed every option.

## Root cause

`src/ai/pilot.ts` — the diagnostic bullet went straight from appearance to conclusion:

```
- Empty dropdown/list when items expected → missing data; call precondition() to create it.
```

Nothing between "looks empty" and "this app has no such data". A list still loading, or one whose options had not been opened, lands on the same verdict as one that is genuinely empty — and the verdict skips the scenario as impossible.

## Change

The bullet now asks for evidence before the conclusion:

```
- Empty dropdown/list when items expected → wait explicitly, then check the state changed:
  ariaDiff and any GET that loaded data. If still nothing loaded, confirm the empty state with verify().
```

**That second signal was not reachable.** The action summary filtered requests to `status >= 400`, so Pilot only ever saw failures — the `GET /api/…/labels → 200` that populated the list appears **zero** times in its input for that decision. It now sees successful calls too, failures first and capped at 5. `action.ts` already restricts capture to `xhr`/`fetch`, so the cap holds real API calls rather than static assets.

This reverses a deliberate, tested decision (`drops requests that succeeded`); that test now encodes the new intent instead.

## Scope

This addresses the false *skip*. It does not touch a separate mechanism in the same trace, where `pressKey('Escape')` closed the panel and discarded the already-registered selection — so a replay is expected to end as an honest failure rather than a wrong skip.

## Checks

- `bun test tests/unit/` — 1246 pass, 0 fail
- `bun test tests/integration/` — 92 pass, 0 fail
- `bun run format`, `bun run lint:fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChgAkiCHfWmekSBD3Q7R29