### PR TITLE
Keep a passing check alive while the page stays the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Changes
 
+- **A check that passed no longer disappears before the verdict** — once a check passes, it stays
+  attached to the page for as long as you are still on the same page, instead of being cleared by
+  the next screenshot or page snapshot. Tests that genuinely succeeded could be reported as failed
+  because the proof was gone by the time the final verdict was made.
 - **`--json` no longer collides with the banner** — passing it to any command suppresses the
   startup banner, so `explorbot config --json | jq` works without setting `EXPLORBOT_NO_BANNER`.
   `help-json` suppresses it too.

--- a/src/state-manager.ts
+++ b/src/state-manager.ts
@@ -143,13 +143,18 @@ export class StateManager {
   updateState(actionResult: ActionResult, codeBlock?: string, trigger: 'manual' | 'navigation' | 'automatic' = 'manual'): WebPageState {
     const previousState = this.currentState;
     const previousHash = previousState?.hash;
+    const hashChanged = actionResult.hash !== previousHash;
+
+    if (!hashChanged && previousState?.verifications) {
+      const stillTrue = Object.entries(previousState.verifications).filter(([, passed]) => passed);
+      actionResult.verifications = { ...Object.fromEntries(stillTrue), ...actionResult.verifications };
+    }
 
     const newState = actionResult;
     this.currentState = newState;
     this.currentState.id = this.nextStateId++;
     if (newState.url) this.allVisitedUrls.add(normalizeUrl(newState.url));
 
-    const hashChanged = actionResult.hash !== previousHash;
     const regionOpened = !hashChanged && this.regionOpened(previousState, newState);
 
     if (hashChanged || regionOpened) {

--- a/tests/unit/state-manager.test.ts
+++ b/tests/unit/state-manager.test.ts
@@ -156,6 +156,72 @@ describe('StateManager', () => {
       expect(stateManager.getStateHistory()).toHaveLength(1);
     });
 
+    it('should keep verifications when hash stays the same', () => {
+      const verified = new ActionResult({
+        html: '<html><body><h1>Test Page</h1></body></html>',
+        url: 'https://example.com/test',
+        title: 'Test Page',
+        h1: 'Test Page',
+      });
+      verified.addVerification('New folder is visible in the tree', true);
+
+      stateManager.updateState(verified);
+      stateManager.updateState(
+        new ActionResult({
+          html: '<html><body><h1>Test Page</h1></body></html>',
+          url: 'https://example.com/test',
+          title: 'Test Page',
+          h1: 'Test Page',
+        })
+      );
+
+      expect(stateManager.getCurrentState()?.verifications).toEqual({ 'New folder is visible in the tree': true });
+    });
+
+    it('should drop failed verifications when hash stays the same', () => {
+      const verified = new ActionResult({
+        html: '<html><body><h1>Test Page</h1></body></html>',
+        url: 'https://example.com/test',
+        title: 'Test Page',
+        h1: 'Test Page',
+      });
+      verified.addVerification('Success toast is displayed', false);
+
+      stateManager.updateState(verified);
+      stateManager.updateState(
+        new ActionResult({
+          html: '<html><body><h1>Test Page</h1></body></html>',
+          url: 'https://example.com/test',
+          title: 'Test Page',
+          h1: 'Test Page',
+        })
+      );
+
+      expect(stateManager.getCurrentState()?.verifications).toEqual({});
+    });
+
+    it('should drop verifications when hash changes', () => {
+      const verified = new ActionResult({
+        html: '<html><body><h1>Test Page</h1></body></html>',
+        url: 'https://example.com/test',
+        title: 'Test Page',
+        h1: 'Test Page',
+      });
+      verified.addVerification('New folder is visible in the tree', true);
+
+      stateManager.updateState(verified);
+      stateManager.updateState(
+        new ActionResult({
+          html: '<html><body><h1>Other Page</h1></body></html>',
+          url: 'https://example.com/other',
+          title: 'Other Page',
+          h1: 'Other Page',
+        })
+      );
+
+      expect(stateManager.getCurrentState()?.verifications).toBeUndefined();
+    });
+
     it('should default to empty string when action result lacks url', () => {
       const actionResult = new ActionResult({
         html: '<html></html>',


### PR DESCRIPTION
## The bug

Session `FairDullBlue359` ([trace](https://cloud.langfuse.com/) `debfd2398d5fdc2cdf0987197b60b452`) ran *"Create a new folder and verify that it appears in the suite tree"* against `stable.testomat.io`. The folder was created, and Explorbot proved it twice:

- `00:53:44` — `verify` passed with `I.see('PilotFolder_20230904_1230', '.suites-list-content')`
- `00:53:56` — `see` returned *"the folder Pilot Folder_20230904 1230 is visible in the test list, indicating that it was created"*

At `00:54:08` Pilot ruled **fail**: *"The final suite tree shows no newly created folder."* Neither result reached it. `<successful_assertions>` held only the early "Folder creation form is displayed" line, so the verdict rested on a screenshot description that saw the folder and, never having been told its name, called it *"the existing folder."*

## Root cause

`StateManager.updateState` replaced `currentState` wholesale. `Action.captureOnce` builds a **fresh** `ActionResult` on every capture and publishes it, so any capture on an unchanged page erased `verifications` — the one field on the state that is accumulated evidence rather than a fresh observation. Here the `see` tool's `explorer.capture({ screenshot: true })` (`src/ai/tools.ts:577`) wiped the passing verification twelve seconds before Pilot read it at `src/ai/pilot.ts:1015`.

## The fix

Carry passed verifications across a same-hash recapture (`src/state-manager.ts:143`):

```ts
const hashChanged = actionResult.hash !== previousHash;

if (!hashChanged && previousState?.verifications) {
  const stillTrue = Object.entries(previousState.verifications).filter(([, passed]) => passed);
  actionResult.verifications = { ...Object.fromEntries(stillTrue), ...actionResult.verifications };
}
```

Only passed claims are carried, deliberately. A stale **failed** claim is the one that does damage: it would make `verify` refuse a legitimate retry (*"This verification already failed"*, `src/ai/tools.ts:665-672`), and it would feed a failed entry into Navigator's `<already_verified>` block (`src/ai/navigator.ts:716`) where an `ALREADY_VERIFIED` answer is rejected by `checkAlreadyVerified` (it accepts only `=== true`), leaving zero code blocks and the misleading *"No assertion could express this claim."* Dropping failures leaves both paths exactly as they are today.

## Trade-off

A passed claim stays attached for as long as the state hash (URL + headings + region) holds, which covers most in-page actions. A claim invalidated by a change too small to move the hash now reads as still true, and `verify` answers *"already passed, call finish()"* instead of re-checking it.

## Tests

Three cases in `tests/unit/state-manager.test.ts` — passed claims survive a same-hash recapture, failed claims do not, nothing survives a hash change. The two behavioural ones fail against unpatched source.

1305 unit + 102 integration pass; format and lint clean.

## Not in this PR

Tool results from the same `generateText` batch as `finish` never reach Pilot at all: `finish` calls `pilot.reviewFinish` inline (`tester.ts:1059`), but `invokeConversation` only appends response messages after `generateWithTools` returns (`provider.ts:342`), and `getToolExecutions` reads `this.messages`. In this trace `see` ran in step 1 of the very invocation whose step 2 called `finish` — invisible to the verdict. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmFPm3A2E6ESK5hjGuGkHZ