### PR TITLE
Let Pilot judge the run once the round it judges has finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### Changes
 
+- **[Pilot] The final verdict now sees the last round of checks** — a `verify()` or `see()` run in
+  the same round as the decision to finish was invisible to Pilot, so a test could be reported as
+  failed on evidence it had already produced. The verdict is now made once the round is complete.
+  When Pilot rejects a finish or a stop, its reasoning arrives as guidance for the next step rather
+  than a bare rejection.
 - **`--json` no longer collides with the banner** — passing it to any command suppresses the
   startup banner, so `explorbot config --json | jq` works without setting `EXPLORBOT_NO_BANNER`.
   `help-json` suppresses it too.

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -53,6 +53,7 @@ export class Tester extends TaskAgent implements Agent {
   MAX_ITERATIONS = 30;
   MAX_EXTENSIONS = 2;
   ASSERTION_TOOLS = ['verify'];
+  private pendingReview = '';
   researcher: Researcher;
   navigator: Navigator;
   agentTools: any;
@@ -119,6 +120,7 @@ export class Tester extends TaskAgent implements Agent {
     this.seenUiMapUrls.clear();
     this.lastAnalyzedStateHash = null;
     this.stalledIterations = 0;
+    this.pendingReview = '';
     this.previousRegionPresent = null;
     this.regionTransitioned = false;
     this.stateManager.clearHistory();
@@ -333,7 +335,7 @@ export class Tester extends TaskAgent implements Agent {
           const result = await this.provider.invokeConversation(conversation, tools, {
             maxToolRoundtrips: 3,
             toolChoice: 'required',
-            stopWhen: () => task.hasFinished,
+            stopWhen: () => task.hasFinished || !!this.pendingReview,
           });
 
           if (!result) throw new Error('Failed to get response from provider');
@@ -386,6 +388,14 @@ export class Tester extends TaskAgent implements Agent {
                 ${task.expected.map((expectation) => `- ${expectation}`).join('\n')}
             `);
             }
+          }
+
+          if (this.pendingReview && this.pilot) {
+            const reviewed = this.pendingReview;
+            this.pendingReview = '';
+            const reviewState = this.getCurrentState();
+            if (reviewed === 'finish') await this.pilot.reviewFinish(task, reviewState, conversation, this.navigator);
+            if (reviewed === 'stop') await this.pilot.reviewStop(task, reviewState, conversation);
           }
 
           if (task.hasFinished) {
@@ -1006,18 +1016,9 @@ export class Tester extends TaskAgent implements Agent {
         }),
         execute: async ({ reason }) => {
           task.addNote(`Stop requested: ${reason}`);
+          this.pendingReview = 'stop';
 
-          if (this.pilot) {
-            const currentState = this.getCurrentState();
-            await this.pilot.reviewStop(task, currentState, conversation);
-            if (!task.hasFinished) {
-              return {
-                success: false,
-                action: 'stop',
-                message: 'Stop rejected; Continue execution',
-              };
-            }
-          } else {
+          if (!this.pilot) {
             task.addNote(reason, TestResult.FAILED);
             task.finish(TestResult.FAILED);
           }
@@ -1053,18 +1054,9 @@ export class Tester extends TaskAgent implements Agent {
             return { success: true, action: 'finish', message: 'already finished' };
           }
           task.addNote(`Finish requested: ${verify}`);
+          this.pendingReview = 'finish';
 
-          if (this.pilot) {
-            const currentState = this.getCurrentState();
-            await this.pilot.reviewFinish(task, currentState, conversation, this.navigator);
-            if (!task.hasFinished) {
-              return {
-                success: false,
-                action: 'finish',
-                message: 'Finishing rejected; Continue execution',
-              };
-            }
-          } else {
+          if (!this.pilot) {
             task.addNote('Test finished successfully', TestResult.PASSED);
             task.finish(TestResult.PASSED);
           }

--- a/tests/unit/tester-finish-review-deferred.test.ts
+++ b/tests/unit/tester-finish-review-deferred.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'bun:test';
+import { Tester } from '../../src/ai/tester.ts';
+
+function buildTester(pilot: any): any {
+  return Object.assign(Object.create(Tester.prototype), {
+    pilot,
+    pendingReview: '',
+    getCurrentState: () => ({ url: '/items' }),
+  });
+}
+
+function buildTask(): any {
+  return {
+    hasFinished: false,
+    startUrl: '/',
+    notes: [] as string[],
+    getVisitedUrls: () => [],
+    addNote(note: string) {
+      this.notes.push(note);
+    },
+    finish() {
+      this.hasFinished = true;
+    },
+  };
+}
+
+describe('Tester defers the Pilot verdict', () => {
+  it('does not review finish while the tool batch is still running', async () => {
+    let reviewed = false;
+    const tester = buildTester({
+      reviewFinish: async () => {
+        reviewed = true;
+      },
+    });
+    const task = buildTask();
+
+    const tools = tester.createTestFlowTools(task, { url: '/items' }, {});
+    const result = await tools.finish.execute({ verify: 'Item Foo is visible in the list' });
+
+    expect(reviewed).toBe(false);
+    expect(tester.pendingReview).toBe('finish');
+    expect(result.success).toBe(true);
+    expect(task.hasFinished).toBe(false);
+  });
+
+  it('does not review stop while the tool batch is still running', async () => {
+    let reviewed = false;
+    const tester = buildTester({
+      reviewStop: async () => {
+        reviewed = true;
+      },
+    });
+    const task = buildTask();
+
+    const tools = tester.createTestFlowTools(task, { url: '/items' }, {});
+    const result = await tools.stop.execute({ reason: 'The feature is absent from this build' });
+
+    expect(reviewed).toBe(false);
+    expect(tester.pendingReview).toBe('stop');
+    expect(result.success).toBe(true);
+    expect(task.hasFinished).toBe(false);
+  });
+
+  it('finishes without a Pilot to defer to', async () => {
+    const tester = buildTester(null);
+    const task = buildTask();
+
+    const tools = tester.createTestFlowTools(task, { url: '/items' }, {});
+    await tools.finish.execute({ verify: 'Item Foo is visible in the list' });
+
+    expect(task.hasFinished).toBe(true);
+  });
+});


### PR DESCRIPTION
Follow-up to #186, from the same trace. Independent change — either can land first.

## The bug

`finish` and `stop` call `pilot.reviewFinish` / `reviewStop` from inside their own `execute()` (`tester.ts:1059`, `:1012`), while `generateWithTools` is still walking its roundtrips. `invokeConversation` appends the response messages only **after** that call returns (`provider.ts:342-348`), and `Conversation.getToolExecutions` reads those messages — so every tool that ran earlier in the same round is invisible to the verdict.

In session `FairDullBlue359` the tester called `see` in step 1 and `finish` in step 2 of one invocation. `see` had answered *"the folder Pilot Folder_20230904 1230 is visible in the test list, indicating that it was created."* Pilot never saw it, and ruled **fail**.

Reviewing mid-flight corrupts message order too: on rejection `reviewDecision` does `testerConversation.addUserText(...)` on the conversation the model is still generating against, so the assistant and tool messages for that round get appended *after* the injected user text.

## The fix

The tools record which verdict is pending and stop the roundtrips; the loop runs the review once the round is complete and the conversation holds all of it.

```ts
stopWhen: () => task.hasFinished || !!this.pendingReview,
```

```ts
if (this.pendingReview && this.pilot) {
  const reviewed = this.pendingReview;
  this.pendingReview = '';
  const reviewState = this.getCurrentState();
  if (reviewed === 'finish') await this.pilot.reviewFinish(task, reviewState, conversation, this.navigator);
  if (reviewed === 'stop') await this.pilot.reviewStop(task, reviewState, conversation);
}
```

Net −8 lines in `tester.ts`: both tools lose their inline review branch and their bespoke rejection results.

## Behaviour change

A rejected finish or stop no longer comes back as a `"Finishing rejected; Continue execution"` tool result mid-round. `reviewDecision` already writes `Pilot: <reason>` plus `What to do next: <guidance>` into the conversation on `continue`, so the model gets that instead, on the next iteration — more actionable than the bare rejection, at the cost of one loop iteration (and one context re-injection) per rejection.

## Not covered

`reset` reviews inline as well and has the same blind spot, but it *acts* on approval — the navigation happens inside the tool — so deferring it means restructuring the reset itself. Left alone.

## Tests

`tests/unit/tester-finish-review-deferred.test.ts` — `finish` and `stop` mark a pending verdict without calling Pilot; the no-Pilot fallback still finishes the task directly. The two behavioural cases fail against unpatched source.

1305 unit + 110 integration pass; format and lint clean. `tsc --noEmit` reports the same two pre-existing `tester.ts` errors as the baseline, line-shifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MmFPm3A2E6ESK5hjGuGkHZ