### PR TITLE
Show the tester what is inside an open modal, and its root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-04
+
+### Changes
+
+- [Tester] While a modal is open, the tester is now shown the modal's own list of elements and the
+  selector its content lives in, and is told to build locators scoped to that selector. It used to
+  get one flat list mixing the modal with the page behind it, so a field covered by the modal looked
+  as available as the buttons inside it — the tester kept typing into a form it could not reach and
+  the click that would have submitted it was swallowed by the overlay.
+
 ## 2026-09-03
 
 ### Changes

--- a/src/action-result.ts
+++ b/src/action-result.ts
@@ -33,6 +33,7 @@ interface ActionResultData extends WebPageState {
   iframeSnapshots?: Array<{ src: string; html: string; id?: string }>;
   ariaSnapshot?: string | null;
   ariaSnapshotFile?: string;
+  regionAria?: string | null;
   focusedElement?: FocusedElement | null;
   iframeURL?: string;
   links?: Link[];
@@ -90,6 +91,7 @@ export class ActionResult implements ActionResultData {
   public links: Link[] = [];
   public verifications?: Record<string, boolean>;
   public overlay: Region = new Region();
+  public regionAria: string | null = null;
   private _diffCache: { previousId: number | undefined; diff: Diff } | null = null;
 
   constructor(data: ActionResultData) {
@@ -106,6 +108,7 @@ export class ActionResult implements ActionResultData {
     this.iframeURL = data.iframeURL;
     this.notes = data.notes ?? [];
     this.verifications = data.verifications;
+    this.regionAria = data.regionAria ?? null;
 
     // Set readonly properties
     if (data.screenshotFile !== undefined) {
@@ -302,6 +305,10 @@ export class ActionResult implements ActionResultData {
 
   getInteractiveARIA(): string {
     return compactAriaSnapshot(this.ariaSnapshot, false);
+  }
+
+  getRegionARIA(): string {
+    return compactAriaSnapshot(this.regionAria, false);
   }
 
   getCompactARIA(): string {

--- a/src/action.ts
+++ b/src/action.ts
@@ -14,8 +14,8 @@ import { browserErrorMessage, isFatalBrowserError, isNavigationTransitionError }
 import { captureHtmlForSnapshot, htmlCombinedSnapshot, minifyHtml } from './utils/html.js';
 import { createDebug, setStepSpanParent, tag } from './utils/logger.js';
 import { Overlay, OverlayPage } from './utils/overlay.js';
-import type { Region } from './utils/region.js';
 import { sleep, waitForPageReadiness } from './utils/page-readiness.ts';
+import type { Region } from './utils/region.js';
 import { safeFilename } from './utils/strings.ts';
 import { codeceptJSSandbox, hasPlaywrightCommands, playwrightSandbox, sanitizeCodeBlock } from './utils/web-sandbox.ts';
 
@@ -182,7 +182,19 @@ class Action {
         focusedElement,
         iframeURL: frame ? frame.url?.() || 'iframe' : undefined,
       });
-      if (!frame) await this.detectRegion(result).catch((err: Error) => debugLog('Region detection failed:', err.message));
+      if (!frame) {
+        await this.detectRegion(result).catch((err: Error) => debugLog('Region detection failed:', err.message));
+        const regionRoot = result.overlay.root;
+        if (result.overlay.isModal && regionRoot) {
+          result.regionAria = await this.playwrightHelper.page
+            .locator(regionRoot)
+            .ariaSnapshot()
+            .catch((err: Error) => {
+              debugLog('Region ARIA snapshot failed:', err.message);
+              return null;
+            });
+        }
+      }
       this.stateManager.updateState(result, codeBlock);
       return result;
     } catch (err) {

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -579,16 +579,19 @@ export class Tester extends TaskAgent implements Agent {
 
     if (region.isModal) {
       const areaName = region.name ? ` "${region.name}"` : '';
-      let rootHint = '';
-      if (region.root) rootHint = `\nIts content lives inside \`${region.root}\` — scope locators to it.`;
+      let scoping = 'Use <page_aria> to confirm the element you target is actually inside the overlay.';
+      if (region.root) {
+        scoping = `Its root is \`${region.root}\` — build every locator as ARIA scoped to that root, e.g. I.click({ role: 'button', text: 'Continue' }, '${region.root}')`;
+      }
       context += dedent`
         <overlay>
-        An overlay${areaName} is currently open above the page.${rootHint}
-        Scope all interactions to elements inside this overlay.
-        Page navigation, filters, and tabs that exist outside it are not actionable while it is open and may share names or roles with elements inside it — prefer the locator inside the overlay.
-        Use <page_aria> to confirm the element you target is actually inside the overlay.
-        </overlay>
+        You are inside an overlay${areaName} opened above the page.
+        ${scoping}
+        Elements outside the overlay are behind it and not actionable while it is open — they may share names or roles with the ones inside, so never target them by bare text.
       `;
+      const regionAria = currentState.getRegionARIA();
+      if (regionAria) context += `\nIt holds exactly these elements:\n<overlay_aria>\n${regionAria}\n</overlay_aria>`;
+      context += '\n</overlay>\n';
     }
 
     if (!region.isModal && region.isOpen && isNewState) {

--- a/tests/unit/tester-focus-scope.test.ts
+++ b/tests/unit/tester-focus-scope.test.ts
@@ -3,6 +3,7 @@ import { ActionResult } from '../../src/action-result.ts';
 import { Tester } from '../../src/ai/tester.ts';
 import { renderExperienceToc } from '../../src/experience-tracker.ts';
 import { Test, TestResult } from '../../src/test-plan.ts';
+import { Overlay } from '../../src/utils/overlay.ts';
 
 function buildTester(): Tester {
   const provider: any = {
@@ -99,8 +100,8 @@ describe('Tester reinjectContextIfNeeded — focus scope hint', () => {
     const context = await (tester as any).reinjectContextIfNeeded(2, state);
 
     expect(context).toContain('<overlay>');
-    expect(context).toContain('An overlay "Create Requirement"');
-    expect(context).toContain('Scope all interactions to elements inside this overlay');
+    expect(context).toContain('an overlay "Create Requirement"');
+    expect(context).toContain('not actionable while it is open');
   });
 
   it('emits <overlay> for alertdialog role', async () => {
@@ -110,7 +111,7 @@ describe('Tester reinjectContextIfNeeded — focus scope hint', () => {
     const context = await (tester as any).reinjectContextIfNeeded(2, state);
 
     expect(context).toContain('<overlay>');
-    expect(context).toContain('An overlay "Confirm Delete"');
+    expect(context).toContain('an overlay "Confirm Delete"');
   });
 
   it('omits <overlay> when no dialog or modal is open', async () => {
@@ -129,7 +130,21 @@ describe('Tester reinjectContextIfNeeded — focus scope hint', () => {
     const context = await (tester as any).reinjectContextIfNeeded(2, newUrlState);
 
     expect(context).toContain('<overlay>');
-    expect(context).toContain('An overlay "New Form"');
+    expect(context).toContain('an overlay "New Form"');
+  });
+
+  it('lists the overlay ARIA scoped to its root and recommends root-scoped locators', async () => {
+    const tester = buildTester();
+    const state = buildState('- dialog "Select suite":\n  - button "Cancel"');
+    state.overlay = new Overlay({ name: 'Select suite', root: '#modal-overlays' });
+    state.regionAria = '- searchbox "Search"\n- list:\n  - listitem:\n    - button "Suite A"\n- button "Cancel"';
+
+    const context = await (tester as any).reinjectContextIfNeeded(2, state);
+
+    expect(context).toContain("I.click({ role: 'button', text: 'Continue' }, '#modal-overlays')");
+    expect(context).toContain('<overlay_aria>');
+    expect(context).toContain('  - listitem:\n    - button "Suite A"');
+    expect(context).not.toContain('Use <page_aria> to confirm');
   });
 });
 


### PR DESCRIPTION
## What happened

Traced from Langfuse session `CharacteristicAnonymousRose148` (trace `ff3db6dd9b7571f877d02a27edb9c202`), a CI run against `zyntra-don-t-touch-cloned`.

The suite-selection modal opened at 01:10:28 and was detected correctly — `areaOfInterest: overlay "Select suite for test" opened, scope: #modal-overlays`. The tester then spent the next eight minutes trying to fill the test-title field **behind** it, four times over.

The `<overlay>` block was in the prompt the whole time. What it could not do was tell the model which elements were reachable. The ARIA it had came from `context()` at 01:11:15 — one flat list, no boundary:

```
- searchbox "Search Search"           <- modal
- button "Cancel"                     <- modal
- button "Select 0 suites" [disabled] <- modal
- textbox "Title should not be empty" <- page, behind the modal
- tablist: Markdown / Rich editor     <- page, behind the modal
```

`textbox "Title should not be empty"` reads as available as anything else there, so the model picked it. So did the Pilot, whose guidance in the same turn was *"the prior title locator failed because it used placeholder text as CSS"* — a locator-syntax diagnosis that sent the tester straight back at the covered field. Playwright's real answer was in the failure at 01:11:46, truncated mid-selector: `<div data-emd-overlay class="emd-debug ember-modal-overlay translucent"> ... from <div id="modal` intercepting the click.

The block also closed with *"Use `<page_aria>` to confirm the element you target is actually inside the overlay"* — an instruction nothing in `<page_aria>` could answer.

## The change

Once region detection settles, capture an ARIA snapshot scoped to the region root and put it in the `<overlay>` block along with the root and the container form to use:

```
<overlay>
You are inside an overlay "Select suite for test" opened above the page.
Its root is `#modal-overlays` — build every locator as ARIA scoped to that root,
e.g. I.click({ role: 'button', text: 'Continue' }, '#modal-overlays')
Elements outside the overlay are behind it and not actionable while it is open — they may
share names or roles with the ones inside, so never target them by bare text.
It holds exactly these elements:
<overlay_aria>
- searchbox "Search"
- list:
  - listitem:
    - button "Suite Updated by Pilot 107 tests"
- button "Cancel"
- button "Select 0 suites" [disabled]
</overlay_aria>
</overlay>
```

- `src/action.ts` — the scoped snapshot is taken after `detectRegion`, since `root` is not known at the point the page-wide ARIA is captured.
- `src/action-result.ts` — `regionAria` plus `getRegionARIA()`, mirroring `getInteractiveARIA()`.
- `src/ai/tester.ts` — the `<overlay>` block. No root or no snapshot falls back to the previous text.

The ARIA is concatenated rather than interpolated into the `dedent` block. `dedent` collapses the relative indentation, and in an ARIA snapshot that indentation *is* the containment.

## Not in this PR

Three things the same trace turned up:

1. **`<page_aria>` is flattened by `dedent`.** Real prompt from this run — `- list:` and its child at the same level:
   ```
   <page_aria>
         - list:
   - listitem:
     - button "{img}"
   ```
   One level of nesting is missing from every page ARIA the model has ever seen. One-line fix, same function.

2. **A Monaco editor was classified as a modal overlay** (`div.code-editor-frame`), and the real modal was stacked on it as a child. `measureLayout` promotes the largest out-of-flow descendant, and Monaco's absolutely-positioned layers hold the viewport centre, so `modalScore` returns 1.0 against a floor of 0.25. Later in the same run: `overlay "unnamed" opened, scope: div.tree.tree-list-item.vertical-line.vertical`.

3. **`isStillOpen` reads "positional xpath stopped resolving" as "region closed".** Ember re-rendered the suite tree — checkbox ids shift `ember395` → `ember893` between 01:11:00 and 01:11:08 — so the modal was declared closed and `action.ts` restored its parent, the Monaco false positive from (2). For a full iteration the block pointed at `div.code-editor-frame`. The stable `root` was never consulted.

(2) and (3) are why this PR marks the boundary rather than filtering to it: during that window scoping would have shown the model the editor and hidden the modal.

## Tests

`bun test tests/unit/` — 1282 pass. `bun test tests/integration/` — 102 pass, 1 skip. New case covers root-scoped ARIA reaching the block with its nesting intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GrBvtJPCTcch2kvEwLueuc