### PR TITLE
Run API testing without a config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 2026-09-07
+
+### New CLI Options
+
+- **`-H, --header <header>`** — A header sent with every API request, written as `Name: value`. Repeat it
+  for more than one. Headers reach the startup health check too, so a protected API fails on a bad token
+  instead of on the first test, and they merge over any `headers` a config file already sets. This is the
+  last thing that needed a config file, so an API run can now be described entirely on the command line.
+  ```bash
+  explorbot api explore https://api.example.com/v1 --spec ./openapi.yaml -H "Authorization: Bearer $TOKEN"
+  explorbot api plan /users --endpoint https://api.example.com/v1 -H "Authorization: Bearer $TOKEN" -H "X-Tenant: acme"
+  ```
+- **`explorbot api explore <base-endpoint>`** — `api explore` now accepts the base endpoint itself as its
+  argument, not only a path inside the API. Given a full URL it tests the whole API from its root; a path
+  like `/users` still works and takes the base from `--endpoint` or `EXPLORBOT_URL`.
+  ```bash
+  explorbot api explore https://api.example.com/v1 --spec ./openapi.yaml
+  explorbot api explore /users --endpoint https://api.example.com/v1 --spec ./openapi.yaml
+  ```
+
+### Configuration
+
+- **`EXPLORBOT_API_HEADERS`** — Headers sent with every API request, one `Name: value` per line. The
+  environment twin of `-H`; the flag wins when both are set. Shown as `set` rather than printed by
+  `explorbot config`, so a token does not end up in terminal output or CI logs.
+
+### Changes
+
+- API testing now runs without a config file. Passing the API's base endpoint to `explorbot api` used to
+  end in "No API endpoint to test. Pass --endpoint" whenever models came from `EXPLORBOT_AI_PROVIDER`, and
+  with a global config it silently dropped the path prefix — `https://api.example.com/v1` became
+  `https://api.example.com`, so every request went to the wrong path.
+- API testing no longer fails at startup with "Configuration not loaded" when local HTML or markdown
+  reports are switched on. `explorbot init --global` turns both on by default, which made every `api plan`,
+  `api test` and `api explore` run from a global config stop before it began.
+- Plan files from `api explore` are named after the endpoint again. Pointing it at a full URL wrote
+  `https___api_example_com_v1_normal.md`; it now writes `root_normal.md`.
+
 ## 2026-09-03
 
 ### Changes

--- a/boat/api-tester/src/apibot.ts
+++ b/boat/api-tester/src/apibot.ts
@@ -10,7 +10,7 @@ import { setVerboseMode, tag } from '../../../src/utils/logger.ts';
 import { Chief } from './ai/chief.ts';
 import { Curler } from './ai/curler.ts';
 import { ApiClient } from './api-client.ts';
-import { type ApibotConfig, ApibotConfigParser } from './config.ts';
+import { type ApibotConfig, ApibotConfigParser, type ApibotRunOptions } from './config.ts';
 
 export class ApiBot {
   private configParser: ApibotConfigParser;
@@ -48,7 +48,7 @@ export class ApiBot {
     const outputDir = this.configParser.getOutputDir();
     this.configParser.ensureDirectory(outputDir);
     this.requestState = new RequestStore(outputDir);
-    this.reporter = new Reporter(this.config.reporter);
+    this.reporter = new Reporter(this.config.reporter, undefined, outputDir);
     this.knowledgeTracker = new KnowledgeTracker({ knowledgeDir: this.configParser.getKnowledgeDir() });
 
     validateSpecs(this.config.api.spec);
@@ -141,7 +141,7 @@ export class ApiBot {
     return this.currentPlan;
   }
 
-  savePlan(filename?: string): string | null {
+  savePlan(suffix?: string): string | null {
     if (!this.currentPlan) return null;
 
     const plansDir = this.configParser.getPlansDir();
@@ -149,8 +149,7 @@ export class ApiBot {
       mkdirSync(plansDir, { recursive: true });
     }
 
-    const planFilename = filename || this.generatePlanFilename();
-    const planPath = path.join(plansDir, planFilename);
+    const planPath = path.join(plansDir, this.generatePlanFilename(suffix));
     this.currentPlan.saveToMarkdown(planPath);
     return planPath;
   }
@@ -192,20 +191,16 @@ export class ApiBot {
     }
   }
 
-  private generatePlanFilename(): string {
+  private generatePlanFilename(suffix?: string): string {
     const endpoint = this.currentPlan?.url || '/';
-    const sanitized = endpoint.replace(/^\//, '').replace(/[^a-zA-Z0-9]/g, '_') || 'root';
-    return `${sanitized.slice(0, 200)}.md`;
+    let name = endpoint.replace(/^\//, '').replace(/[^a-zA-Z0-9]/g, '_') || 'root';
+    if (suffix) name = `${name}_${suffix}`;
+    return `${name.slice(0, 200)}.md`;
   }
 }
 
-interface ApibotOptions {
+interface ApibotOptions extends ApibotRunOptions {
   verbose?: boolean;
-  config?: string;
-  path?: string;
-  endpoint?: string;
-  baseEndpoint?: string;
-  spec?: string;
 }
 
 export type { ApibotOptions };

--- a/boat/api-tester/src/apibot.ts
+++ b/boat/api-tester/src/apibot.ts
@@ -48,7 +48,7 @@ export class ApiBot {
     const outputDir = this.configParser.getOutputDir();
     this.configParser.ensureDirectory(outputDir);
     this.requestState = new RequestStore(outputDir);
-    this.reporter = new Reporter(this.config.reporter, undefined, outputDir);
+    this.reporter = new Reporter(this.config.reporter);
     this.knowledgeTracker = new KnowledgeTracker({ knowledgeDir: this.configParser.getKnowledgeDir() });
 
     validateSpecs(this.config.api.spec);

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -16,6 +16,7 @@ function buildOptions(options: any): ApibotOptions {
     path: options.path,
     baseEndpoint: options.endpoint,
     spec: options.spec,
+    header: options.header,
   };
 }
 
@@ -26,7 +27,8 @@ function addCommonOptions(cmd: Command): Command {
     .option('-c, --config <path>', 'Path to configuration file')
     .option('-p, --path <path>', 'Working directory path')
     .option('--endpoint <url>', 'Base API endpoint to test (env: EXPLORBOT_URL)')
-    .option('--spec <path>', 'OpenAPI spec file or URL (env: EXPLORBOT_API_SPEC)');
+    .option('--spec <path>', 'OpenAPI spec file or URL (env: EXPLORBOT_API_SPEC)')
+    .option('-H, --header <header>', 'Header sent with every request, as "Name: value". Repeatable (env: EXPLORBOT_API_HEADERS)', (value: string, previous: string[] = []) => [...previous, value]);
 }
 
 function selectTests(tests: any[], index?: string): any[] {
@@ -101,6 +103,7 @@ export function createApiCommands(name = 'api'): Command {
       const [site] = listSites();
       const runOptions = buildOptions(options);
       runOptions.endpoint = endpoint || site?.url;
+      if (runOptions.endpoint && URL.canParse(runOptions.endpoint)) runOptions.baseEndpoint ||= runOptions.endpoint;
       try {
         const config = await parser.loadConfig(runOptions);
         console.log(ConfigCommand.render(config, { configPath: parser.getConfigPath(), root: parser.getProjectRoot(), json: options.json }));
@@ -149,9 +152,10 @@ export function createApiCommands(name = 'api'): Command {
     }
   });
 
-  addCommonOptions(cmd.command('explore <endpoint>').description('Full cycle: plan all styles, execute tests, re-plan')).action(async (endpoint, options) => {
+  addCommonOptions(cmd.command('explore <endpoint>').description('Full cycle: plan all styles, execute tests, re-plan. The endpoint may be the base endpoint itself')).action(async (endpoint, options) => {
     setPreserveConsoleLogs(true);
     try {
+      if (URL.canParse(endpoint)) options.endpoint ||= endpoint;
       const bot = new ApiBot({ ...buildOptions(options), endpoint });
       await bot.start();
 
@@ -182,7 +186,7 @@ export function createApiCommands(name = 'api'): Command {
           else totalFailed++;
         }
 
-        bot.savePlan(`${endpoint.replace(/^\//, '').replace(/[^a-zA-Z0-9]/g, '_')}_${style}.md`);
+        bot.savePlan(style);
       }
 
       console.log('\n=== Final Results ===');

--- a/boat/api-tester/src/config.ts
+++ b/boat/api-tester/src/config.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path, { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseEnv } from 'node:util';
-import { type AIConfig, type ApiHookFn, type ApiConfig as BaseApiConfig, ConfigMissingError, EXPLORBOT_CONFIG_PATHS, createModel, envConfigRequested, materializeKnowledge, missingConfigMessage, resolveConfigModels, resolveModel, resolveOutputRoot } from '../../../src/config.ts';
+import { type AIConfig, type ApiHookFn, type ApiConfig as BaseApiConfig, ConfigMissingError, EXPLORBOT_CONFIG_PATHS, createModel, envConfigRequested, materializeKnowledge, missingConfigMessage, resolveConfigModels, resolveModel, resolveOutputRoot, setOutputDir } from '../../../src/config.ts';
 import { type SiteRecord, findGlobalConfig, globalEnvPath, isGlobalConfigPath, registerSite, resolveSiteTarget } from '../../../src/global-config.ts';
 
 export type { AIConfig };
@@ -109,6 +109,7 @@ export class ApibotConfigParser {
       }
 
       this.validateConfig(this.config);
+      setOutputDir(this.getOutputDir());
 
       return this.config;
     } finally {
@@ -237,6 +238,7 @@ export class ApibotConfigParser {
     };
     this.configPath = path.join(outputRoot, 'apibot.config.js');
     this.validateConfig(this.config);
+    setOutputDir(this.getOutputDir());
 
     return this.config;
   }

--- a/boat/api-tester/src/config.ts
+++ b/boat/api-tester/src/config.ts
@@ -24,6 +24,20 @@ interface ApibotConfig {
   };
 }
 
+function isAbsoluteEndpoint(value?: string): boolean {
+  return !!value && (value.startsWith('http://') || value.startsWith('https://'));
+}
+
+function parseHeaders(raw: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  for (const line of raw.split('\n')) {
+    const separator = line.indexOf(':');
+    if (separator < 1) continue;
+    headers[line.slice(0, separator).trim()] = line.slice(separator + 1).trim();
+  }
+  return headers;
+}
+
 export class ApibotConfigParser {
   private static instance: ApibotConfigParser;
   private config: ApibotConfig | null = null;
@@ -45,7 +59,7 @@ export class ApibotConfigParser {
     Object.assign(process.env, parseEnv(readFileSync(resolved, 'utf8')));
   }
 
-  async loadConfig(options?: { config?: string; path?: string; endpoint?: string; baseEndpoint?: string; spec?: string }): Promise<ApibotConfig> {
+  async loadConfig(options?: ApibotRunOptions): Promise<ApibotConfig> {
     if (this.config && !options?.config && !options?.path) return this.config;
 
     const originalCwd = process.cwd();
@@ -84,6 +98,7 @@ export class ApibotConfigParser {
 
       this.config = this.mergeWithDefaults(loadedConfig);
       this.applyEnvSpec(this.config.api);
+      this.applyEnvHeaders(this.config.api);
       if (options?.baseEndpoint) this.config.api.baseEndpoint = options.baseEndpoint.replace(/\/$/, '');
       await resolveConfigModels(this.config.ai);
       this.configPath = resolvedPath;
@@ -125,12 +140,15 @@ export class ApibotConfigParser {
   }
 
   resolveEndpointPath(endpoint: string): string {
-    if (!this.site) return endpoint;
+    if (!this.site && !isAbsoluteEndpoint(endpoint)) return endpoint;
 
-    const resolved = resolveSiteTarget(endpoint, this.site.url);
-    if (resolved.baseUrl !== this.site.url) return endpoint;
+    const base = new URL(this.getConfig().api.baseEndpoint);
+    const origin = this.site?.url || base.origin;
 
-    const basePath = new URL(this.getConfig().api.baseEndpoint).pathname.replace(/\/$/, '');
+    const resolved = resolveSiteTarget(endpoint, origin);
+    if (resolved.baseUrl !== origin) return endpoint;
+
+    const basePath = base.pathname.replace(/\/$/, '');
     if (!basePath) return resolved.path;
     if (resolved.path === basePath) return '/';
     if (resolved.path.startsWith(`${basePath}/`)) return resolved.path.slice(basePath.length);
@@ -156,14 +174,20 @@ export class ApibotConfigParser {
     }
   }
 
-  private applyRunOptions(options?: { baseEndpoint?: string; spec?: string }): void {
+  private applyRunOptions(options?: ApibotRunOptions): void {
     if (options?.baseEndpoint) process.env.EXPLORBOT_URL = options.baseEndpoint;
     if (options?.spec) process.env.EXPLORBOT_API_SPEC = options.spec;
+    if (options?.header?.length) process.env.EXPLORBOT_API_HEADERS = options.header.join('\n');
   }
 
   private applyEnvSpec(api: ApiConfig): void {
     if (!process.env.EXPLORBOT_API_SPEC) return;
     api.spec = [process.env.EXPLORBOT_API_SPEC];
+  }
+
+  private applyEnvHeaders(api: ApiConfig): void {
+    if (!process.env.EXPLORBOT_API_HEADERS) return;
+    api.headers = { ...api.headers, ...parseHeaders(process.env.EXPLORBOT_API_HEADERS) };
   }
 
   private enterGlobalMode(config: ApibotConfig, endpoint?: string): void {
@@ -189,7 +213,7 @@ export class ApibotConfigParser {
       throw new Error('EXPLORBOT_AI_MODEL needs a provider — set EXPLORBOT_AI_PROVIDER, or write it as "provider/model-id"');
     }
 
-    const baseEndpoint = process.env.EXPLORBOT_URL;
+    const baseEndpoint = process.env.EXPLORBOT_URL?.replace(/\/$/, '');
     if (!baseEndpoint) {
       throw new Error('No API endpoint to test. Pass --endpoint or set EXPLORBOT_URL to the API base endpoint');
     }
@@ -199,6 +223,7 @@ export class ApibotConfigParser {
 
     const api: ApiConfig = { baseEndpoint };
     this.applyEnvSpec(api);
+    this.applyEnvHeaders(api);
 
     let model: any;
     if (provider && modelSpec) model = await createModel(provider, modelSpec);
@@ -282,4 +307,13 @@ export class ApibotConfigParser {
   }
 }
 
-export type { ApibotConfig, ApiConfig, HookFn };
+interface ApibotRunOptions {
+  config?: string;
+  path?: string;
+  endpoint?: string;
+  baseEndpoint?: string;
+  spec?: string;
+  header?: string[];
+}
+
+export type { ApibotConfig, ApiConfig, HookFn, ApibotRunOptions };

--- a/docs/api-testing/basics.md
+++ b/docs/api-testing/basics.md
@@ -30,7 +30,7 @@ export default {
 
 - **`baseEndpoint`** (required) — the base URL prepended to every request. Test steps use relative paths like `/users`; Curler adds the base for you.
 - **`spec`** (required) — one or more OpenAPI specs, given as HTTP(S) URLs or local file paths, in YAML or JSON. Chief uses the spec to plan; Curler uses it to look up schemas. Both agents refuse to run without one.
-- **`headers`** — sent with every request. This is where API keys and auth tokens go.
+- **`headers`** — sent with every request. This is where API keys and auth tokens go. `-H "Name: value"` on the command line and `EXPLORBOT_API_HEADERS` add to them without a config file.
 
 See the [full configuration reference](../reference/configuration.md) for every option and [providers](../basics/providers.md) for choosing an AI model.
 
@@ -61,15 +61,23 @@ A matching `teardown` hook runs after all tests finish — use it to clean up da
 Chief and Curler need three things: where the API is, what its spec says, and how to authenticate. Pass all three on the command line and no config file is needed:
 
 ```bash
+npx explorbot api explore https://api.example.com/v1 \
+  --spec ./openapi.yaml \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+`api explore` takes the base endpoint as its argument, so one line covers the whole run: it plans in every style, executes each plan, and reports the totals. The other commands take a path within the API and read the base from `--endpoint`:
+
+```bash
 npx explorbot api plan /users \
   --endpoint https://api.example.com/v1 \
   --spec ./openapi.yaml \
-  --knowledge 'Send X-Api-Key: ${env.API_KEY} on every request'
+  -H "Authorization: Bearer $TOKEN"
 ```
 
-`--endpoint` and `--spec` each have an environment twin — `EXPLORBOT_URL` and `EXPLORBOT_API_SPEC` — and the flag wins when both are set. `--knowledge` adds to the facts `EXPLORBOT_KNOWLEDGE` and `EXPLORBOT_KNOWLEDGE_FILE` bring in rather than replacing them. Configure your models once with `npx explorbot init --global` and every run stores its plans and requests per host under `~/.explorbot/sites/<host>/`, so a later `api test` against the same API picks up where the last one left off. Knowledge given on the command line lasts for the run; `api know` is what writes it down.
+Each flag has an environment twin — `EXPLORBOT_URL`, `EXPLORBOT_API_SPEC` and `EXPLORBOT_API_HEADERS` — and the flag wins when both are set. `-H` is repeatable and takes one `Name: value` per use; the variable takes one per line. Headers land on every request, the startup health check included, and merge over any `headers` a config file sets. `--knowledge` adds to the facts `EXPLORBOT_KNOWLEDGE` and `EXPLORBOT_KNOWLEDGE_FILE` bring in rather than replacing them. Configure your models once with `npx explorbot init --global` and every run stores its plans and requests per host under `~/.explorbot/sites/<host>/`, so a later `api test` against the same API picks up where the last one left off. Knowledge given on the command line lasts for the run; `api know` is what writes it down.
 
-`--endpoint` keeps its path prefix: given `https://api.example.com/v1`, steps stay relative (`/users`) and Curler sends them to `https://api.example.com/v1/users`. `api test`, which takes a plan file rather than an endpoint, reads it from the flag or the variable.
+The base endpoint keeps its path prefix: given `https://api.example.com/v1`, steps stay relative (`/users`) and Curler sends them to `https://api.example.com/v1/users`. `api test`, which takes a plan file rather than an endpoint, reads the base from the flag or the variable.
 
 ### A dedicated API project
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -117,6 +117,7 @@ EXPLORBOT_AI_PROVIDER=openrouter \
 | `EXPLORBOT_KNOWLEDGE_FILE` | Path to a knowledge markdown file |
 | `EXPLORBOT_SPEC` | Docbot application spec directory or index.md, used as page knowledge |
 | `EXPLORBOT_API_SPEC` | OpenAPI spec path for the API boat |
+| `EXPLORBOT_API_HEADERS` | Headers sent with every API request, one "Name: value" per line |
 | `EXPLORBOT_NO_BANNER` | Suppress the startup banner, for machine-readable output |
 | `EXPLORBOT_MAX_DURATION` | Wall-clock budget in minutes for an explore run; same as --max-duration |
 <!-- END env -->

--- a/docs/workflow/agentic-usage.md
+++ b/docs/workflow/agentic-usage.md
@@ -58,6 +58,7 @@ No `init`, no config file, no project directory, no model IDs to look up. These 
 | `EXPLORBOT_KNOWLEDGE_FILE` | no | Path to a knowledge markdown file |
 | `EXPLORBOT_SPEC` | no | Docbot application spec directory or index.md, used as page knowledge |
 | `EXPLORBOT_API_SPEC` | no | OpenAPI spec path for the API boat |
+| `EXPLORBOT_API_HEADERS` | no | Headers sent with every API request, one "Name: value" per line |
 | `EXPLORBOT_NO_BANNER` | no | Suppress the startup banner, for machine-readable output |
 | `EXPLORBOT_MAX_DURATION` | no | Wall-clock budget in minutes for an explore run; same as --max-duration |
 <!-- END env -->
@@ -219,11 +220,12 @@ The same variables drive API testing and doc collection.
 ```bash
 EXPLORBOT_URL=https://api.example.com \
 EXPLORBOT_API_SPEC=./openapi.yaml \
+EXPLORBOT_API_HEADERS="Authorization: Bearer $TOKEN" \
 EXPLORBOT_AI_PROVIDER=openrouter \
   npx explorbot api explore /users
 ```
 
-The API boat also takes those two as flags, so one line carries the whole run: `npx explorbot api explore /users --endpoint https://api.example.com --spec ./openapi.yaml`.
+The API boat also takes those three as flags, so one line carries the whole run: `npx explorbot api explore https://api.example.com --spec ./openapi.yaml -H "Authorization: Bearer $TOKEN"`. Given a full URL, `api explore` reads it as the base endpoint; a path like `/users` needs the base in `--endpoint` or `EXPLORBOT_URL`.
 
 ```bash
 EXPLORBOT_AI_PROVIDER=openrouter \

--- a/src/commands/config-command.ts
+++ b/src/commands/config-command.ts
@@ -45,7 +45,10 @@ export class ConfigCommand extends BaseCommand {
     const env: Record<string, string> = {};
     for (const variable of EXPLORBOT_ENV_VARS) {
       const value = process.env[variable.name];
-      if (value) env[variable.name] = value;
+      if (!value) continue;
+      let shown = value;
+      if (variable.secret) shown = 'set';
+      env[variable.name] = shown;
     }
 
     const models: Record<string, string> = {};

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ export const PROVIDERS: Record<string, ProviderInfo> = {
 export const MODEL_ROLES: ModelRole[] = ['model', 'visionModel', 'agenticModel'];
 
 let cachedOutputRoot: string | null = null;
+let runOutputDir: string | null = null;
 
 interface PlaywrightConfig {
   browser: 'chromium' | 'firefox' | 'webkit';
@@ -497,6 +498,7 @@ export class ConfigParser {
   // For testing purposes only
   public static resetForTesting(): void {
     cachedOutputRoot = null;
+    runOutputDir = null;
     if (ConfigParser.instance) {
       ConfigParser.instance.config = null;
       ConfigParser.instance.configPath = null;
@@ -745,7 +747,12 @@ export class ConfigParser {
   }
 }
 
+export function setOutputDir(dir: string): void {
+  runOutputDir = dir;
+}
+
 export function outputPath(...segments: string[]): string {
+  if (runOutputDir) return path.join(runOutputDir, ...segments);
   return path.join(ConfigParser.getInstance().getOutputDir(), ...segments);
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -275,6 +275,7 @@ export const EXPLORBOT_ENV_VARS: EnvVar[] = [
   { name: 'EXPLORBOT_KNOWLEDGE_FILE', description: 'Path to a knowledge markdown file' },
   { name: 'EXPLORBOT_SPEC', description: 'Docbot application spec directory or index.md, used as page knowledge' },
   { name: 'EXPLORBOT_API_SPEC', description: 'OpenAPI spec path for the API boat' },
+  { name: 'EXPLORBOT_API_HEADERS', description: 'Headers sent with every API request, one "Name: value" per line', secret: true },
   { name: 'EXPLORBOT_NO_BANNER', description: 'Suppress the startup banner, for machine-readable output' },
   { name: 'EXPLORBOT_MAX_DURATION', description: 'Wall-clock budget in minutes for an explore run; same as --max-duration' },
 ];
@@ -912,6 +913,7 @@ interface EnvVar {
   name: string;
   description: string;
   required?: boolean;
+  secret?: boolean;
 }
 
 export type { ModelRole, EnvVar, ProviderInfo, ConfiguredModel };

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -24,10 +24,12 @@ export class Reporter {
   private isRunStarted = false;
   private reporterEnabled: boolean;
   private stateManager?: StateManager;
+  private outputDir?: string;
 
-  constructor(config?: ReporterConfig, stateManager?: StateManager) {
+  constructor(config?: ReporterConfig, stateManager?: StateManager, outputDir?: string) {
     this.reporterEnabled = Reporter.resolveEnabled(config);
     this.stateManager = stateManager;
+    this.outputDir = outputDir;
 
     if (this.reporterEnabled && config?.html) {
       this.configureHtmlPipe();
@@ -67,9 +69,14 @@ export class Reporter {
     return Boolean(process.env.TESTOMATIO);
   }
 
+  private reportsFolder(): string {
+    if (this.outputDir) return join(this.outputDir, 'reports');
+    return outputPath('reports');
+  }
+
   private configureHtmlPipe(): void {
     process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
-    process.env.TESTOMATIO_HTML_REPORT_FOLDER = outputPath('reports');
+    process.env.TESTOMATIO_HTML_REPORT_FOLDER = this.reportsFolder();
     process.env.TESTOMATIO_HTML_FILENAME = `${Stats.sessionLabel()}.html`;
     debugLog('HTML report pipe configured', {
       folder: process.env.TESTOMATIO_HTML_REPORT_FOLDER,
@@ -79,7 +86,7 @@ export class Reporter {
 
   private configureMarkdownPipe(): void {
     process.env.TESTOMATIO_MARKDOWN_REPORT_SAVE = '1';
-    process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER = outputPath('reports');
+    process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER = this.reportsFolder();
     process.env.TESTOMATIO_MARKDOWN_FILENAME = `${Stats.sessionLabel()}-tests.md`;
     debugLog('Markdown report pipe configured', {
       folder: process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER,

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -24,12 +24,10 @@ export class Reporter {
   private isRunStarted = false;
   private reporterEnabled: boolean;
   private stateManager?: StateManager;
-  private outputDir?: string;
 
-  constructor(config?: ReporterConfig, stateManager?: StateManager, outputDir?: string) {
+  constructor(config?: ReporterConfig, stateManager?: StateManager) {
     this.reporterEnabled = Reporter.resolveEnabled(config);
     this.stateManager = stateManager;
-    this.outputDir = outputDir;
 
     if (this.reporterEnabled && config?.html) {
       this.configureHtmlPipe();
@@ -69,14 +67,9 @@ export class Reporter {
     return Boolean(process.env.TESTOMATIO);
   }
 
-  private reportsFolder(): string {
-    if (this.outputDir) return join(this.outputDir, 'reports');
-    return outputPath('reports');
-  }
-
   private configureHtmlPipe(): void {
     process.env.TESTOMATIO_HTML_REPORT_SAVE = '1';
-    process.env.TESTOMATIO_HTML_REPORT_FOLDER = this.reportsFolder();
+    process.env.TESTOMATIO_HTML_REPORT_FOLDER = outputPath('reports');
     process.env.TESTOMATIO_HTML_FILENAME = `${Stats.sessionLabel()}.html`;
     debugLog('HTML report pipe configured', {
       folder: process.env.TESTOMATIO_HTML_REPORT_FOLDER,
@@ -86,7 +79,7 @@ export class Reporter {
 
   private configureMarkdownPipe(): void {
     process.env.TESTOMATIO_MARKDOWN_REPORT_SAVE = '1';
-    process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER = this.reportsFolder();
+    process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER = outputPath('reports');
     process.env.TESTOMATIO_MARKDOWN_FILENAME = `${Stats.sessionLabel()}-tests.md`;
     debugLog('Markdown report pipe configured', {
       folder: process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER,

--- a/tests/unit/apibot-config.test.ts
+++ b/tests/unit/apibot-config.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { ApibotConfigParser } from '../../boat/api-tester/src/config.ts';
 import { ConfigParser } from '../../src/config.ts';
 
-const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_API_SPEC'];
+const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_API_SPEC', 'EXPLORBOT_API_HEADERS'];
 
 describe('ApibotConfigParser environment fallback', () => {
   let savedEnv: Record<string, string | undefined> = {};
@@ -73,6 +73,46 @@ describe('ApibotConfigParser environment fallback', () => {
 
     expect(config.api.baseEndpoint).toBe('https://api.example.com/v2');
     expect(config.api.spec).toEqual(['./openapi.yaml']);
+  });
+
+  it('maps the --endpoint option to the base endpoint without a config file', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_OUTPUT = outputRoot;
+
+    const config = await parser.loadConfig({ baseEndpoint: 'https://api.example.com/v1' });
+
+    expect(config.api.baseEndpoint).toBe('https://api.example.com/v1');
+    expect(process.env.EXPLORBOT_URL).toBe('https://api.example.com/v1');
+  });
+
+  it('resolves an absolute endpoint against the base endpoint path without a site', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_OUTPUT = outputRoot;
+
+    await parser.loadConfig({ baseEndpoint: 'https://api.example.com/v1' });
+
+    expect(parser.resolveEndpointPath('https://api.example.com/v1')).toBe('/');
+    expect(parser.resolveEndpointPath('https://api.example.com/v1/users')).toBe('/users');
+    expect(parser.resolveEndpointPath('/users')).toBe('/users');
+  });
+
+  it('maps repeated --header options to api.headers', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_OUTPUT = outputRoot;
+
+    const config = await parser.loadConfig({ baseEndpoint: 'https://api.example.com', header: ['Authorization: Bearer token-123', 'X-Tenant: acme'] });
+
+    expect(config.api.headers).toEqual({ Authorization: 'Bearer token-123', 'X-Tenant': 'acme' });
+  });
+
+  it('merges EXPLORBOT_API_HEADERS onto the config file headers', async () => {
+    const configPath = join(outputRoot, 'apibot.config.js');
+    writeFileSync(configPath, "export default { ai: { model: { modelId: 'test-model' } }, api: { baseEndpoint: 'https://api.example.com', headers: { 'X-Tenant': 'staging', Accept: 'application/json' } } };\n", 'utf8');
+    process.env.EXPLORBOT_API_HEADERS = 'Authorization: Bearer token-123\nX-Tenant: acme';
+
+    const config = await parser.loadConfig({ config: configPath });
+
+    expect(config.api.headers).toEqual({ Accept: 'application/json', 'X-Tenant': 'acme', Authorization: 'Bearer token-123' });
   });
 
   it('throws when EXPLORBOT_URL is unset', async () => {

--- a/tests/unit/config-command.test.ts
+++ b/tests/unit/config-command.test.ts
@@ -1,7 +1,7 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import { ConfigCommand } from '../../src/commands/config-command.js';
 
 let tmpPath = '';
@@ -81,6 +81,15 @@ describe('ConfigCommand.data', () => {
 
     expect(data.env.EXPLORBOT_AI_PROVIDER).toBe('openrouter');
     expect(data.env.EXPLORBOT_KNOWLEDGE).toBeUndefined();
+  });
+
+  it('reports a secret variable as set without printing its value', () => {
+    process.env.EXPLORBOT_API_HEADERS = 'Authorization: Bearer token-123';
+    const data = ConfigCommand.data(config, { configPath, root: tmpPath });
+
+    expect(data.env.EXPLORBOT_API_HEADERS).toBe('set');
+    expect(ConfigCommand.render(config, { configPath, root: tmpPath })).not.toContain('token-123');
+    Reflect.deleteProperty(process.env, 'EXPLORBOT_API_HEADERS');
   });
 
   it('falls back to the API base endpoint when there is no page url', () => {

--- a/tests/unit/reporter.test.ts
+++ b/tests/unit/reporter.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, readFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import type { ReporterConfig } from '../../src/config.ts';
-import { ConfigParser } from '../../src/config.ts';
+import { ConfigParser, setOutputDir } from '../../src/config.ts';
 import { Reporter } from '../../src/reporter.ts';
 import { Stats } from '../../src/stats.ts';
 import { ActiveNote, Plan, Task, Test, TestResult } from '../../src/test-plan.ts';
@@ -498,15 +498,17 @@ describe('Reporter config', () => {
     expect(process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER).toContain('reports');
   });
 
-  test('an explicit output directory is used when no config is loaded', () => {
+  test('reports go to the output dir a boat resolved, without the web config parser', () => {
     const configParser = ConfigParser.getInstance();
     (configParser as any).config = null;
     (configParser as any).configPath = null;
+    setOutputDir('/tmp/apibot-output');
 
-    const reporter = new Reporter({ html: true, markdown: true }, undefined, '/tmp/apibot-output');
+    const reporter = new Reporter({ html: true, markdown: true });
 
     expect(process.env.TESTOMATIO_HTML_REPORT_FOLDER).toBe(join('/tmp/apibot-output', 'reports'));
     expect(process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER).toBe(join('/tmp/apibot-output', 'reports'));
+    ConfigParser.resetForTesting();
   });
 
   test('markdown unset does not set markdown env vars', () => {

--- a/tests/unit/reporter.test.ts
+++ b/tests/unit/reporter.test.ts
@@ -498,6 +498,17 @@ describe('Reporter config', () => {
     expect(process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER).toContain('reports');
   });
 
+  test('an explicit output directory is used when no config is loaded', () => {
+    const configParser = ConfigParser.getInstance();
+    (configParser as any).config = null;
+    (configParser as any).configPath = null;
+
+    const reporter = new Reporter({ html: true, markdown: true }, undefined, '/tmp/apibot-output');
+
+    expect(process.env.TESTOMATIO_HTML_REPORT_FOLDER).toBe(join('/tmp/apibot-output', 'reports'));
+    expect(process.env.TESTOMATIO_MARKDOWN_REPORT_FOLDER).toBe(join('/tmp/apibot-output', 'reports'));
+  });
+
   test('markdown unset does not set markdown env vars', () => {
     const reporter = new Reporter({ enabled: true });
     expect(process.env.TESTOMATIO_MARKDOWN_REPORT_SAVE).toBeUndefined();


### PR DESCRIPTION
`explorbot api explore <base-endpoint> --spec <path-or-url>` now works on its own — no config file anywhere.

```bash
explorbot api explore https://api.example.com/v1 \
  --spec ./openapi.yaml \
  -H "Authorization: Bearer $TOKEN"
```

## What was broken

Three separate things stopped that line from working. Each was verified before and after against a local API server.

| | Before | After |
|---|---|---|
| Env-only (`EXPLORBOT_AI_PROVIDER`, no config file) | `No API endpoint to test. Pass --endpoint` | runs |
| Global config (`~/.explorbot/config.js`) | dropped the path prefix — `https://api.example.com/v1` became `https://api.example.com`, so every request hit the wrong path | keeps `/v1` |
| Any config with local reports on | crashed at startup with `Configuration not loaded` | runs |

The third was the widest. `explorbot init --global` writes `reporter: { html: true, markdown: true }`, and `Reporter` resolves its output folder through `outputPath()`, which hardcodes the **web** `ConfigParser` singleton — a different singleton from the one the API boat loads. Every `api plan`, `api test` and `api explore` run from a global config died before it began.

Reporter was only the first call site to hit this; the `outputPath('states', ...)` calls beside it have the same latent bug, as do the other 30 across the codebase. So the fix is in `outputPath()`, not in Reporter: `src/config.ts` gains `setOutputDir()` next to it, `ApibotConfigParser` calls that once its config resolves, and `outputPath()` falls back to `ConfigParser` when no boat has named a directory. `src/reporter.ts` is unchanged from main.

## Auth headers

`api.headers` was config-file-only, which was the last thing forcing a config file. Adds `-H, --header "Name: value"` (repeatable, curl convention) and its twin `EXPLORBOT_API_HEADERS`, merged over any config-file headers on both the config-file and env-only paths.

Headers reach the HTTP client rather than being left to AI judgment per request, so the startup health check is authenticated too — a bad token fails immediately instead of on the first test.

`EnvVar` gains a `secret` flag, and `explorbot config` renders such a variable as `set` rather than its value, keeping tokens out of terminal and CI output. `help-json` already prints names and descriptions only, so nothing leaks there.

## Where the base-endpoint rule lives

An absolute positional argument means different things per command, so the CLI decides, not the config parser:

- `api explore` and `api config` read a full URL as the **base endpoint** (same `URL.canParse` idiom as the prima boat)
- `api plan` keeps **target** semantics — `api plan https://api.example.com/users` still plans that resource, taking its base from `--endpoint`

An earlier pass put this in `ApibotConfigParser` and broke the second case; `tests/unit/global-config.test.ts` caught it.

`resolveEndpointPath` now resolves against the base endpoint whether or not a site is registered, and `loadEnvConfig` strips a trailing slash like the other two paths already did.

## Also

Plan filenames in `api explore` come from the resolved endpoint, so a full URL no longer writes `https___api_example_com_v1_normal.md` — it writes `root_normal.md`. The sanitizing is no longer duplicated between the CLI and `ApiBot`.

## Verification

- 1315 unit + 111 integration tests pass; build and `bunosh docs:sync --check` clean
- End-to-end against a local API server: base path preserved (`GET /api/v1/users`), both headers on the wire, plan target resolved to `/`
- The new `Reporter` test fails if its fix is reverted
- Strict `tsc` clean on the files touched — worth noting the build runs `tsc --noCheck`, so nothing in CI typechecks; a `string | undefined` passed to `URL.canParse` passed every green check and was caught by running `tsc` directly

Docs and CHANGELOG updated. `origin/main` merged in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqxExZnFvxSw8rNVYiJGBS

