### PR TITLE
List the ARIA diff in document order instead of by duplicate count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@
   `api test` and `api explore` run from a global config stop before it began.
 - Plan files from `api explore` are named after the endpoint again. Pointing it at a full URL wrote
   `https___api_example_com_v1_normal.md`; it now writes `root_normal.md`.
+- The page diff now lists changed elements in the order they appear on the page. It ranked repeated
+  elements first, so opening a long list — a user picker, a dropdown of seventy options — put whichever
+  entry the page happened to render twice at the very top and hid the rest behind "+ 63 more interactive
+  elements". Agents read that first line as the obvious choice and picked the duplicate over the options
+  a person would actually see.
 
 ## 2026-09-04
 

--- a/src/utils/aria.ts
+++ b/src/utils/aria.ts
@@ -431,9 +431,9 @@ const formatDiffSection = (label: string, items: string[]): string[] => {
   const summary = countBy(items);
   if (summary.size === 0) return [`  ${label}: []`];
 
-  const sorted = Array.from(summary.entries()).sort(([aItem, aCount], [bItem, bCount]) => bCount - aCount || aItem.localeCompare(bItem));
-  const top = sorted.slice(0, TOP_DIFF_ITEMS);
-  const rest = sorted.slice(TOP_DIFF_ITEMS);
+  const ordered = Array.from(summary.entries());
+  const top = ordered.slice(0, TOP_DIFF_ITEMS);
+  const rest = ordered.slice(TOP_DIFF_ITEMS);
 
   const lines = [`  ${label}:`];
   for (const [item, count] of top) {


### PR DESCRIPTION
## What

`formatDiffSection` ranked `added`/`removed` entries by how many times each appeared. That hands the slot the model reads first to an accident of the DOM — a repeated placeholder, a double-rendered row — while `TOP_DIFF_ITEMS` hides the entries a person sees first behind `+ N more interactive elements`.

```diff
-  const sorted = Array.from(summary.entries()).sort(([aItem, aCount], [bItem, bCount]) => bCount - aCount || aItem.localeCompare(bItem));
-  const top = sorted.slice(0, TOP_DIFF_ITEMS);
-  const rest = sorted.slice(TOP_DIFF_ITEMS);
+  const ordered = Array.from(summary.entries());
+  const top = ordered.slice(0, TOP_DIFF_ITEMS);
+  const rest = ordered.slice(TOP_DIFF_ITEMS);
```

`added`/`removed` already arrive in document order for newly appearing nodes — Map insertion order from `countBy` over the pre-order `flatten` walk — so dropping the sort restores the order a person sees when a list opens.

## Why

Found in a failed session (Langfuse trace `7010df390ea8c75371c75c1eedc68525`), scenario *"Assign the current suite to a visible user and verify the assignment persists."*

Opening the Assign-to combobox added 74 ARIA nodes; the app itself reported `72 results`. The tester's entire view of those options was the diff inside the click result:

```
ariaDiff:
  added:
    - option "John Doe" (x2)
    - combobox "Search" [expanded]
    - option "aadrian"
    ...
    + 63 more interactive elements
```

That entry sat at #1 only because the a11y tree carried it twice. It outranked 71 real names, 63 of which collapsed into the overflow line. The tester picked it, hit `MultipleElementsFound: Multiple elements (2)` from the very duplication that promoted it, and burned three more clicks reaching `step.opts({elementIndex: 1})` to work around it — 5 `click` calls to select one option.

## Trade-off

A change repeated many times (20 identical row buttons) is no longer guaranteed a top-10 slot; it earns one only if its first instance lands early in the document, which is the common case but not a guarantee. `(xN)` still reports frequency.

## Safety

Nothing consumes the diff text as an equality key — `pilot.ts:1078` interpolates it into a prompt, `navigator.ts:514` and `researcher/deep-analysis.ts` read it as prose or truthiness. Dead-loop detection uses `state.hash`, and `ariaChangeCount` is computed from array lengths, untouched by formatting.

## Testing

- `bun test tests/unit/` — 1315 pass, 0 fail
- `bun test tests/integration/` — 110 pass, 1 fail (`prima-smoke`, needs a live playwright-cli session; fails identically on clean `main`)
- No test asserted diff ordering; the two existing cases that could have (`produces YAML diff with counts`, `truncates added/removed sections to top 10`) pass unchanged.

This touches what every agent reads after each action, so it is worth regression coverage — flagging rather than labelling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q7SGR86b67yiTCpFceDNnb