### PR TITLE
Take the ARIA role from the diff that reported the element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-08
+
+### Changes
+
+- Locators: elements that appear in response to an action — a menu that opens, a panel that slides in —
+  can now be clicked using the role reported for them when they appeared, instead of a guessed one.
+  Guessing was silent rather than loud: a control named the same thing elsewhere on the page absorbed
+  the click and reported success, so a run could walk into the wrong part of the app and spend the rest
+  of its time looking for a button that was never there.
+
 ## 2026-09-05
 
 ### Changes

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -8,8 +8,9 @@ const locatorPriorityRule = dedent`
 
   1. ARIA locators (first choice) - target browser's accessibility tree, most reliable
      Use JSON format: { "role": "button", "text": "Login" }
-     Copy role and text VERBATIM from the ARIA snapshot or UI map — never guess the pair.
-     If the element is absent from the snapshot, do not invent one; use text or CSS instead.
+     Copy role and text VERBATIM from the ARIA snapshot, UI map, or the page diff that
+     reported the element — never guess the pair; a guessed role can silently match a
+     different element with the same text. If named nowhere, use text or CSS instead.
 
   2. Text locators (second choice) - exact visible text, use only when unique on the page
      Example: 'Login', 'Submit', 'Username'


### PR DESCRIPTION
Session `ParliamentaryRoyalAquamarine681` (trace `8c8f6546500ba1bb025ff1bd8f866fbb`) failed a suite-creation scenario, and the run went wrong at one click.

The tester opened a **New** menu. The click result's diff told it what appeared:

```
ariaDiff:
  added:
    - button "New suite"
```

Its next call was `I.click({"role":"link","text":"New suite"})` — same text, wrong role.

CodeceptJS turns a role object into `getByRole(role, {name})` (`lib/helper/Playwright.js:4214`), which is strict on role, so this could not have hit the menu button. It hit a separate `link "New suite"` elsewhere on the page — one that appears in that same click's `removed` list. The click reported `success: true`, `urlChanged: false`.

That left the tester on a path with no submit control, and the remaining 15 tool calls (~45s) hunted for a "Create"/"Add" button that does not exist there. The run ended `fail`. The sibling test in the same session (`437a2cff…`, "Create a new folder from the New menu") clicked the same menu by text, got `urlChanged: true` to a real form page, and passed.

## The cause

`src/ai/rules.ts:11` named the sources for a verbatim ARIA pair as "the ARIA snapshot or UI map". The menu items were in neither — they existed only in the previous action's diff, which is exactly what the tools' own `suggestion` strings tell the model to act on ("Use the container as context when clicking elements from the diff"). So the model took the text from the diff and guessed the role.

A guessed role does not fail loudly. It matches a different element with the same text and reports success.

## The change

Three lines in `src/ai/rules.ts`: name the page diff as a source, and say what guessing costs.

## Not fixed here

Two conflicts found while reading the surrounding prompts. Neither caused this failure, so neither is in this PR:

- `src/ai/tools.ts:592` — `see` returns `suggestion: 'Visual confirmation is valid evidence for test results.'` on every call, contradicting its own description ("Do NOT use it to confirm an action landed"). The `fail` verdict here was correct, but the line rewards treating absence-from-screenshot as proof of absence.
- The `form` tool attributes a later command's error to the first one — `FAILED I.fillField(...) NOT RUN 1 more` — while the diff shows the fill succeeded.

## Verification

- `bun test tests/integration/` — 110 pass, 1 skip, 0 fail
- `bun test tests/unit/` — 1315 pass, 0 fail
- `bun run lint`, `bun run format` — clean

Prompt-only change, so the real check is a replay of the scenario: the second click should report `urlChanged: true` and the run should finish in well under the 15 tool calls it burned. That needs a regression run, which I have not started — apply the `regression` label if you want it covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hnum8HkPviwU1h6e2xx94a
