### PR TITLE
Let Pilot judge a deletion by the page, not by a name marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-08
+
+### Changes
+
+- [Pilot] A test that creates an item and then deletes it can now pass. Pilot was checking deletions
+  against a list of names carried over from earlier tests in the plan, and the name of the test being
+  run was never on that list — so a "create it, then delete it" scenario was failed at the final
+  verdict even when the item was visibly gone from the page and every check had passed. Pilot now
+  judges the deletion on what the page actually shows.
+
 ## 2026-09-05
 
 ### Changes

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -363,8 +363,6 @@ export class Pilot implements Agent {
     return dedent`
       SCENARIO: ${task.scenario}
 
-      ${this.buildDeletionScope(task)}
-
       EXPECTED RESULTS (milestones):
       ${task.expected.map((e) => `- ${e}`).join('\n')}
     `;
@@ -1100,23 +1098,6 @@ export class Pilot implements Agent {
         return line;
       })
       .join('\n\n');
-  }
-
-  private buildDeletionScope(task: Test): string {
-    const deletableItems = task.plan
-      ? task.plan
-          .listTests()
-          .filter((t) => t.isSuccessful && t.sessionName)
-          .map((t) => t.sessionName!)
-      : [];
-    const scenarioLower = task.scenario.toLowerCase();
-    if (deletableItems.length > 0) {
-      return `For deletion scenarios, items can only be deleted if their title contains: ${deletableItems.join(', ')}`;
-    }
-    if (scenarioLower.includes('delete') || scenarioLower.includes('remove')) {
-      return 'No items available for deletion — test should create an item first';
-    }
-    return '';
   }
 
   private getSystemPrompt(task: Test, initialState: ActionResult): string {


### PR DESCRIPTION
## The bug

Pilot's reset and verdict prompts carried a line naming which items were allowed to be deleted:

> For deletion scenarios, items can only be deleted if their title contains: …

That list was built from `listTests().filter((t) => t.isSuccessful && t.sessionName)`. The test currently running is by definition not yet successful, so **its own session name was never on the list**. Any scenario that creates its own fixture and then deletes it was structurally unpassable whenever the plan held at least one earlier successful test.

## What it did to a real run

Session `DelightedParallelIvory449`, scenario *"Delete a folder created during the scenario and verify it is removed from the suite tree."*

The tester created the folder, deleted it, confirmed the modal, searched for the name and got "0 tests found". `verify()` passed. Pilot's own review at 00:57:21 agreed:

> PROGRESS: Deletion succeeded; the dialog closed, the folder was removed, and exact-name search returned no match.

Five seconds later the final verdict flipped:

```json
{"decision":"fail","reason":"The deleted folder name lacks the required MolecularConsiderableYellow967 title marker."}
```

`MolecularConsiderableYellow967` is a **different** test's session name, and the marker was the verdict's sole cited reason.

## The fix

Delete the injected line (`pilot.ts:366`) and the method that built it (`pilot.ts:1105-1119`). 19 lines removed, one file, pure deletion.

Adding the running test's own name to the list would not have rescued this run — the folder was named `PilotDisposableFolder2026-unique` and carries no marker at all, so the gate would simply have failed it against `DelightedParallelIvory449` instead. Only removing the gate lets the correct reading stand.

The verdict prompt already states the general form of this rule under PROVENANCE:

> the entity you cite as proof must appear by name in `<notes>` or `<session_log>` tool inputs for THIS run

That anchors the deleted entity to the run without depending on a naming convention the tester may not have followed. Action-time scoping stays in the tester's prompt (`tester.ts:878`), where it can still *prevent* a deletion; a check at verdict time could only punish one after the fact.

## Trade-off

Pilot loses the ability to flag "the test deleted something none of our runs created" at verdict time. PROVENANCE covers the entity-appears-in-this-run half, and the tester keeps the action-time scope.

## Follow-ups, not in this PR

- `tester.ts:914` holds a near-duplicate `buildDeletionScope` with the same self-exclusion bug. Its wording — *"ONLY delete items whose title contains one of these session names… These were created by previous tests"* — directly contradicts a "delete what you just created" scenario. The tester ignored it this run; a more obedient model would stall.
- Both copies branch on `scenario.includes('delete') || scenario.includes('remove')` — keyword matching on open-ended scenario prose, which CLAUDE.md's Regex-vs-AI table routes to AI judgment. The Pilot copy goes away here; the tester copy remains.
- The same session burned 10 failed delete clicks (00:55:18→00:56:38) before `interact()` solved it in one call. Separate cause: experience recipe A.3 stored a positional `I.click('Delete', step.opts({ elementIndex: 2 }))` plus a literal folder name from a prior session, and the real Delete button is hover-revealed. That is experience-recording quality, untouched here.

## Verification

- `bun test tests/unit/` — 1315 pass, 0 fail
- `bun test tests/integration/` — 110 pass, 1 skip, 0 fail
- `bun run format`, `bun run lint:fix` — clean
- `tsc -p tsconfig.json` — no new errors in `pilot.ts`
- Replaying the scenario should now end in `pass` with `requestVerification` naming the folder's absence. The 10 wasted delete clicks are untouched by this change and should still appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0124rYQEcL5fehu6qt5J4oNm