### PR TITLE
Stop the click tool accepting a coordinate click as a locator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - [Tester] A click that runs without error but leaves the page untouched is now reported as failed
   rather than succeeded, the same way a form command already was. The tester is told the element may be
   covered, disabled, or that the locator matched something that does not respond, and to check it with
-  `xpathCheck` before retrying.
+  `xpathCheck` before retrying. A click the page answers only with an API call still counts as landed,
+  so a Save that stores something without redrawing anything is not retried into a duplicate record.
 
 ## 2026-09-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2026-09-08
+
+### Changes
+
+- [Tester] Clicking by coordinates is no longer accepted as a locator. A coordinate click always runs,
+  even on an empty corner of the page, so offering one at the end of a locator list turned "I could not
+  find this element" into a reported success — the test then carried on believing it had pressed a
+  control that was never there. The click tool now refuses these commands and points at `visualClick`,
+  which finds the target in a screenshot first. Dismissing a layer by clicking beside it still works;
+  it goes through `form()` now, and Escape is tried before it.
+- [Tester] A click that runs without error but leaves the page untouched is now reported as failed
+  rather than succeeded, the same way a form command already was. The tester is told the element may be
+  covered, disabled, or that the locator matched something that does not respond, and to check it with
+  `xpathCheck` before retrying.
+
 ## 2026-09-05
 
 ### Changes

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -238,10 +238,10 @@ export const unexpectedPopupRule = dedent`
   If buttons are disabled unexpectedly, check if a popup is blocking interaction or if required form fields are empty.
 
   Dismiss strategy (try in order):
-  1. I.clickXY(0, 0) — click outside the popup to close it
-  2. I.pressKey('Escape') — press Escape to dismiss
-  3. I.click('Cancel') — click Cancel button if present
-  4. I.click({ role: 'button', text: 'Close' }) — click X/close button if present
+  1. I.pressKey('Escape') — press Escape to dismiss
+  2. I.click('Cancel') — click Cancel button if present
+  3. I.click({ role: 'button', text: 'Close' }) — click X/close button if present
+  4. Click a point outside the layer — a deliberate coordinate click, so run it through form(), not click()
   </unexpected_popup_rule>
 `;
 
@@ -335,7 +335,7 @@ export const actionRule = dedent`
   Prefer text/ARIA locators with context over complex CSS/XPath selectors.
   For inline create/edit flows, after filling a field verify it contains the value, then confirm using the nearest explicit button/link, an adjacent icon-only confirm control in the same row/form, or Enter if the field remains focused.
   If locator doesn't work, try CSS or XPath locators.
-  If nothing works, use I.clickXY(x, y) as last resort.
+  If nothing works, use visualClick() — it locates the target in a screenshot before clicking it.
 
   When a click result reports several matches, pick one from its numbered list by position rather than guessing a new locator.
   Reuse the same locator with step.opts({ elementIndex: N }) as the LAST argument. N is the "Element N" number.

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -241,7 +241,7 @@ export const unexpectedPopupRule = dedent`
   1. I.pressKey('Escape') — press Escape to dismiss
   2. I.click('Cancel') — click Cancel button if present
   3. I.click({ role: 'button', text: 'Close' }) — click X/close button if present
-  4. Click a point outside the layer — a deliberate coordinate click, so run it through form(), not click()
+  4. I.clickXY(x, y) on the backdrop beside the layer — run it through form(), not click(), and avoid page corners, which usually hold their own links
   </unexpected_popup_rule>
 `;
 

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -241,7 +241,7 @@ export const unexpectedPopupRule = dedent`
   1. I.pressKey('Escape') — press Escape to dismiss
   2. I.click('Cancel') — click Cancel button if present
   3. I.click({ role: 'button', text: 'Close' }) — click X/close button if present
-  4. I.clickXY(x, y) on the backdrop beside the layer — run it through form(), not click(), and avoid page corners, which usually hold their own links
+  4. I.clickXY(0, 0) via form() tool and check if page diff changed
   </unexpected_popup_rule>
 `;
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -66,7 +66,7 @@ export function createCodeceptJSTools({ explorer, stateManager }: ToolDeps, task
           2. I.click(ARIA, container) - e.g. I.click({"role":"button","text":"Save"}, ".modal")
           3. I.click(CSS, container) - e.g. I.click("#btn", ".modal")
           4. I.click(CSS) or I.click(XPath) - when locator already includes context (ID, XPath)
-          5. I.clickXY(x, y) - coordinates fallback
+          Every command must name an element. Coordinates are not a locator — use visualClick() when you can see the target but cannot address it.
           After a result reporting multiple matches, reuse that locator with step.opts({ elementIndex: N }) as the last argument.
         `),
         explanation: z.string().describe('Why you are clicking this element'),
@@ -79,11 +79,21 @@ export function createCodeceptJSTools({ explorer, stateManager }: ToolDeps, task
           return failedToolResult('click', 'No commands provided');
         }
 
-        const invalidCommands = rawCommands.map((cmd) => cmd.trim()).filter((cmd) => cmd.startsWith('I.') && !cmd.startsWith('I.click'));
+        const trimmedCommands = rawCommands.map((cmd) => cmd.trim());
+        const coordinateCommands = trimmedCommands.filter((cmd) => cmd.startsWith('I.clickXY'));
+
+        if (coordinateCommands.length > 0) {
+          activeNote.commit(TestResult.FAILED);
+          return failedToolResult('click', `Coordinate commands are not locators: ${coordinateCommands.join(', ')}. A coordinate click always runs, so it cannot tell you whether the element was there.`, {
+            suggestion: 'Name the element instead. Use visualClick() when you can see the target but cannot address it, or form() for a deliberate coordinate click such as dismissing a layer.',
+          });
+        }
+
+        const invalidCommands = trimmedCommands.filter((cmd) => cmd.startsWith('I.') && !cmd.startsWith('I.click'));
 
         if (invalidCommands.length > 0) {
           activeNote.commit(TestResult.FAILED);
-          return failedToolResult('click', `Invalid commands: ${invalidCommands.join(', ')}. Click tool only accepts I.click() or I.clickXY() commands.`, {
+          return failedToolResult('click', `Invalid commands: ${invalidCommands.join(', ')}. Click tool only accepts I.click() commands.`, {
             suggestion: 'Use form() tool for typing text or multiple actions, or exitIframe() to leave iframe context.',
           });
         }
@@ -111,6 +121,17 @@ export function createCodeceptJSTools({ explorer, stateManager }: ToolDeps, task
 
           if (success) {
             const toolResult = await ActionResult.fromState(stateManager.getCurrentState()!).toToolResult(previousState, command);
+
+            if (!hasObservablePageChange(toolResult)) {
+              activeNote.commit(TestResult.FAILED);
+              return failedToolResult('click', 'Click executed, but no observable page change was captured.', {
+                ...toolResult,
+                attempts,
+                code: command,
+                suggestion: 'Treat the element as not clicked. It may be covered by another layer, disabled, or the locator may have matched a non-interactive ancestor. Re-locate via xpathCheck(), which reports whether the element is covered or offscreen, before retrying.',
+              });
+            }
+
             await commitNote(activeNote, TestResult.PASSED, toolResult, action);
             return successToolResult('click', { ...toolResult, attempts, code: command }, action);
           }

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -1259,6 +1259,7 @@ function hasObservablePageChange(data?: Record<string, any>): boolean {
   if (data.pageDiff.urlChanged === true) return true;
   if (data.pageDiff.ariaChanges) return true;
   if (data.pageDiff.messages?.length) return true;
+  if (data.pageDiff.requests?.length) return true;
   return Array.isArray(data.pageDiff.htmlParts) && data.pageDiff.htmlParts.length > 0;
 }
 

--- a/src/ai/tools.ts
+++ b/src/ai/tools.ts
@@ -66,7 +66,6 @@ export function createCodeceptJSTools({ explorer, stateManager }: ToolDeps, task
           2. I.click(ARIA, container) - e.g. I.click({"role":"button","text":"Save"}, ".modal")
           3. I.click(CSS, container) - e.g. I.click("#btn", ".modal")
           4. I.click(CSS) or I.click(XPath) - when locator already includes context (ID, XPath)
-          Every command must name an element. Coordinates are not a locator — use visualClick() when you can see the target but cannot address it.
           After a result reporting multiple matches, reuse that locator with step.opts({ elementIndex: N }) as the last argument.
         `),
         explanation: z.string().describe('Why you are clicking this element'),

--- a/tests/unit/click-coordinates.test.ts
+++ b/tests/unit/click-coordinates.test.ts
@@ -89,3 +89,35 @@ describe('click that changes nothing', () => {
     expect(result.suggestion).toContain('xpathCheck');
   });
 });
+
+describe('click that only reaches the server', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  it('treats an app request as evidence the click landed', async () => {
+    const state: any = { url: '/runs', html: '<html><body><div>runs</div></body></html>', ariaSnapshot: '- list', id: 'before' };
+    const action: any = {
+      lastError: null,
+      executedSteps: [],
+      saveScreenshot: async () => undefined,
+      attempt: async () => {
+        state.id = 'after';
+        state.networkRequests = [{ method: 'POST', path: '/api/runs', status: 200 }];
+        return true;
+      },
+    };
+    const deps: any = {
+      explorer: { action: () => action },
+      stateManager: { getCurrentState: () => ({ ...state }) },
+      ai: { getModelForAgent: () => ({}), generateObject: async () => ({ object: { position: 1 } }) },
+    };
+    const tools = createCodeceptJSTools(deps, fakeTask());
+
+    const result = await tools.click.execute({ commands: [`I.click('Save')`], explanation: 'Save the run' }, {} as any);
+
+    expect(result.success).toBe(true);
+    expect(result.pageDiff.requests).toHaveLength(1);
+  });
+});

--- a/tests/unit/click-coordinates.test.ts
+++ b/tests/unit/click-coordinates.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { createCodeceptJSTools } from '../../src/ai/tools.ts';
+import { ConfigParser } from '../../src/config.ts';
+
+function fakeDeps(idAfterClick?: string) {
+  const state = { url: '/runs', html: '<html><body><div>runs</div></body></html>', ariaSnapshot: '- list', id: 'before' };
+  const action: any = {
+    lastError: null,
+    executedSteps: [],
+    ran: [] as string[],
+    saveScreenshot: async () => undefined,
+    attempt: async (command: string) => {
+      action.ran.push(command);
+      action.lastError = null;
+      if (idAfterClick) state.id = idAfterClick;
+      return true;
+    },
+  };
+  const deps: any = {
+    explorer: { action: () => action },
+    stateManager: { getCurrentState: () => state },
+    ai: { getModelForAgent: () => ({}), generateObject: async () => ({ object: { position: 1 } }) },
+  };
+  return { deps, action };
+}
+
+function fakeTask(): any {
+  return { startNote: () => ({ commit: () => {}, screenshot: undefined }) };
+}
+
+describe('click with coordinates', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  it('refuses a coordinate command without touching the page', async () => {
+    const { deps, action } = fakeDeps();
+    const tools = createCodeceptJSTools(deps, fakeTask());
+
+    const result = await tools.click.execute({ commands: ['I.clickXY(0, 0)'], explanation: 'Click Load more' }, {} as any);
+
+    expect(result.success).toBe(false);
+    expect(action.ran).toEqual([]);
+    expect(result.suggestion).toContain('visualClick');
+  });
+
+  it('refuses coordinates offered as the last fallback of a locator list', async () => {
+    const { deps, action } = fakeDeps();
+    const tools = createCodeceptJSTools(deps, fakeTask());
+
+    const result = await tools.click.execute({ commands: [`I.click('Load more')`, 'I.clickXY(0, 0)'], explanation: 'Click Load more' }, {} as any);
+
+    expect(result.success).toBe(false);
+    expect(action.ran).toEqual([]);
+    expect(result.message).toContain('I.clickXY(0, 0)');
+  });
+});
+
+describe('click that changes nothing', () => {
+  beforeEach(() => {
+    ConfigParser.resetForTesting();
+    ConfigParser.setupTestConfig();
+  });
+
+  it('reports a command that left the state identical as failed', async () => {
+    const { deps, action } = fakeDeps();
+    const tools = createCodeceptJSTools(deps, fakeTask());
+
+    const result = await tools.click.execute({ commands: [`I.click('Load more')`], explanation: 'Click Load more' }, {} as any);
+
+    expect(action.ran).toEqual([`I.click('Load more')`]);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('no observable page change');
+    expect(result.pageDiff).toBeNull();
+  });
+
+  it('reports a command whose diff carries no url, aria or html change as failed', async () => {
+    const { deps } = fakeDeps('after');
+    const tools = createCodeceptJSTools(deps, fakeTask());
+
+    const result = await tools.click.execute({ commands: [`I.click('2')`], explanation: 'Click pagination link 2' }, {} as any);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('no observable page change');
+    expect(result.pageDiff.urlChanged).toBe(false);
+    expect(result.pageDiff.ariaChanges).toBeUndefined();
+    expect(result.pageDiff.htmlParts).toBeUndefined();
+    expect(result.suggestion).toContain('xpathCheck');
+  });
+});


### PR DESCRIPTION
Found while looking at sessions `AlertMeanAmethyst509` and `JustParentalOrange422`, where the tester kept acting on controls it had never pressed.

## What went wrong

`I.clickXY(0, 0)` cannot fail. With a numeric first argument, CodeceptJS's Playwright helper goes straight to `page.mouse.click(0, 0)` — no `_locateElement`, no `assertElementExists`, no bounding box. The `click` tool returns on the first command that doesn't throw, so a coordinate click at the end of a fallback list converts "none of my locators matched" into `success: true`.

In `AlertMeanAmethyst509` that happened twice. The model offered four real locators for "Load more" plus `I.clickXY(0, 0)`; the four failed, the corner click "succeeded", and the tool reported it as the working locator. The tester then recorded *"New rows appended to list per page diff"* as evidence the feature worked. Eleven seconds earlier `xpathCheck` had told it the truth — `hit: "offscreen"`, *"Element exists in DOM but its interaction point is outside the viewport"* — and the success report overrode it.

The model didn't invent the idea. It was in the prompts three times: as the first dismiss step in `unexpectedPopupRule`, as "If nothing works, use I.clickXY(x, y) as last resort" in `actionRule`, and as item 5 in the click tool's own schema.

## Changes

- The click tool refuses `I.clickXY` commands and names the alternatives: `visualClick`, which locates the target in a screenshot before clicking it, and `form()` for a deliberate coordinate click.
- Its schema drops coordinates from the fallback ladder.
- `unexpectedPopupRule` leads with Escape, then Cancel and Close. **Clicking outside a layer to dismiss it is kept** — it's a real pattern, and the harm was never the coordinate click itself, it was one sitting in a *locator* list where "didn't throw" reads as "found the element". As a deliberate act it goes through `form()`, which already gates on an observable page change.
- A click that runs without error but leaves URL, ARIA and HTML untouched is now reported as failed, reusing the `hasObservablePageChange` gate the `form` tool already applies. The suggestion points at `xpathCheck`, which reports whether an element is covered or offscreen.

## Coverage, honestly

`hasObservablePageChange` now also counts `pageDiff.requests`. Network calls are already filtered to same-origin xhr/fetch, so they are a clean signal of the app doing work — without this, a Save that stores a record without redrawing anything came back failed and the model would retry it into a duplicate. The change is in the shared helper, so `form()` gets it too. Neither `clickXY(0, 0)` in the session produced any request, so the fix above is unaffected.

The no-change gate catches the second bad click in that session — the pagination one, whose diff was completely empty. It would **not** have caught the first: that diff carried `messages: ["And 31 items after"]` and an `htmlParts` entry, both of which count as observable change. Those 31 rows were a real change the app made on its own, and the tool has no way to know the click didn't cause them. That call is fixed only by removing coordinates from the click tool.

## Not touched

- **Driller / Researcher** still use coordinate clicks. `researcher/deep-analysis.ts` and `researcher.ts` run them through `action.attempt()` directly, not this tool, so they're unaffected.
- **Overlay detection.** Neither session's panel was ever detected: `overlay.ts` finds a region either as an added subtree in a diff or by an ARIA `dialog` role, and both tests began with `I.amOnPage` straight onto a route whose panel was already rendered — no opening to diff, and zero `dialog` roles in either initial snapshot. That cost `JustParentalOrange422` five attempts and 65 seconds on a "New" button duplicated between the panel and the page behind it; the same selector worked instantly once Cancel closed the panel. Worth fixing separately.
- **Click-to-focus.** `focused_element_actions` tells the model to click a field before `type()`. Focus is captured on `ActionResult` but never compared in `diff()`, so a click whose only effect is moving focus is now reported failed. Fixing it means plumbing `focusedElement` into `pageDiff`; called out here rather than widened into this PR.
- **`action-result.ts:563`**, which fills `pageDiff.htmlParts` with a region snapshot carrying `added: []` / `removed: []`. That entry masks the no-change check. A newly opened region genuinely is a change, so this is only wrong when the detection itself was a false positive — follow-up, not this PR.

## Tests

`tests/unit/click-coordinates.test.ts` — four cases: a bare coordinate command, coordinates as the last fallback of a locator list, and both no-change shapes (identical state id, and a diff with no url/aria/html change). Five cases including a click answered only by an API call. Unit suite 1320 pass / 0 fail; integration 110 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uQPf49i79cxZS7ZQseDSS

