### PR TITLE
Let a run delete the item it just created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changes
 
+- [Pilot] A test that creates an item and then deletes it can now pass. The set of items a run was
+  allowed to delete was built only from tests that had already finished successfully, so it could never
+  contain the item the running test had just created — Pilot failed the run over the item's name even
+  when the deletion had visibly worked and the item was gone after a reload. The current run is now part
+  of that set, and Pilot is told the naming rule while it plans, so the titles it hands the tester carry
+  the session name the deletion check looks for.
+
 - Locators: elements that appear in response to an action — a menu that opens, a panel that slides in —
   can now be clicked using the role reported for them when they appeared, instead of a guessed one.
   Guessing was silent rather than loud: a control named the same thing elsewhere on the page absorbed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2026-09-08
+
+### Changes
+
+- Locators: elements that appear in response to an action — a menu that opens, a panel that slides in —
+  can now be clicked using the role reported for them when they appeared, instead of a guessed one.
+  Guessing was silent rather than loud: a control named the same thing elsewhere on the page absorbed
+  the click and reported success, so a run could walk into the wrong part of the app and spend the rest
+  of its time looking for a button that was never there.
+
 ## 2026-09-05
 
 ### Changes

--- a/src/ai/pilot.ts
+++ b/src/ai/pilot.ts
@@ -22,7 +22,7 @@ import { createAskApiTool } from './fisherman/tools.ts';
 import type { Navigator } from './navigator.ts';
 import type { Provider } from './provider.ts';
 import type { Researcher } from './researcher.ts';
-import { capabilityGroundingRule, dataProtectionRules } from './rules.ts';
+import { capabilityGroundingRule, dataProtectionRules, deletionScopeRule } from './rules.ts';
 import { isInteractive } from './task-agent.ts';
 import { withdrawVisionTools } from './tools.ts';
 
@@ -363,7 +363,7 @@ export class Pilot implements Agent {
     return dedent`
       SCENARIO: ${task.scenario}
 
-      ${this.buildDeletionScope(task)}
+      ${deletionScopeRule(task.sessionName!, task.deletableSessionNames)}
 
       EXPECTED RESULTS (milestones):
       ${task.expected.map((e) => `- ${e}`).join('\n')}
@@ -1102,23 +1102,6 @@ export class Pilot implements Agent {
       .join('\n\n');
   }
 
-  private buildDeletionScope(task: Test): string {
-    const deletableItems = task.plan
-      ? task.plan
-          .listTests()
-          .filter((t) => t.isSuccessful && t.sessionName)
-          .map((t) => t.sessionName!)
-      : [];
-    const scenarioLower = task.scenario.toLowerCase();
-    if (deletableItems.length > 0) {
-      return `For deletion scenarios, items can only be deleted if their title contains: ${deletableItems.join(', ')}`;
-    }
-    if (scenarioLower.includes('delete') || scenarioLower.includes('remove')) {
-      return 'No items available for deletion — test should create an item first';
-    }
-    return '';
-  }
-
   private getSystemPrompt(task: Test, initialState: ActionResult): string {
     const interactive = isInteractive();
     const stepsText = task.plannedSteps.length > 0 ? task.plannedSteps.map((s, i) => `${i + 1}. ${s}`).join('\n') : 'No planned steps';
@@ -1194,6 +1177,8 @@ export class Pilot implements Agent {
       - Scenario tests navigation, search UI, or viewing.
 
       ${dataProtectionRules}
+
+      ${deletionScopeRule(task.sessionName!, task.deletableSessionNames)}
 
       Describe WHAT to create, not what exists. RIGHT: precondition("1 post"). WRONG:
       precondition("1 post named Updated Post with existing comments"). Keep descriptions short.

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -486,3 +486,10 @@ export const actionRule = dedent`
 
   </actions>
   `;
+
+export function deletionScopeRule(sessionName: string, deletableSessionNames: string[]): string {
+  return dedent`
+    Deletable items are only those whose title contains one of these session names: ${deletableSessionNames.join(', ')}.
+    ${sessionName} is the current run — items it creates must carry it in the title to be deletable.
+  `;
+}

--- a/src/ai/rules.ts
+++ b/src/ai/rules.ts
@@ -8,8 +8,9 @@ const locatorPriorityRule = dedent`
 
   1. ARIA locators (first choice) - target browser's accessibility tree, most reliable
      Use JSON format: { "role": "button", "text": "Login" }
-     Copy role and text VERBATIM from the ARIA snapshot or UI map — never guess the pair.
-     If the element is absent from the snapshot, do not invent one; use text or CSS instead.
+     Copy role and text VERBATIM from the ARIA snapshot, UI map, or the page diff that
+     reported the element — never guess the pair; a guessed role can silently match a
+     different element with the same text. If named nowhere, use text or CSS instead.
 
   2. Text locators (second choice) - exact visible text, use only when unique on the page
      Example: 'Login', 'Submit', 'Username'

--- a/src/ai/tester.ts
+++ b/src/ai/tester.ts
@@ -22,7 +22,7 @@ import { Navigator } from './navigator.ts';
 import type { Pilot } from './pilot.ts';
 import { Provider } from './provider.ts';
 import { Researcher } from './researcher.ts';
-import { actionRule, capabilityGroundingRule, dataProtectionRules, focusedElementRule, formRequirementsRule, locatorRule, multipleTabsRule, sectionContextRule } from './rules.ts';
+import { actionRule, capabilityGroundingRule, dataProtectionRules, deletionScopeRule, focusedElementRule, formRequirementsRule, locatorRule, multipleTabsRule, sectionContextRule } from './rules.ts';
 import { TaskAgent } from './task-agent.ts';
 import { createCodeceptJSTools, createIframeTools, withdrawVisionTools } from './tools.ts';
 
@@ -875,20 +875,12 @@ export class Tester extends TaskAgent implements Agent {
       When creating or editing items via form() or type() you should include ${task.sessionName} in the value (if it is not restricted by the application logic)
       Initial page URL: ${actionResult.url}
 
-      ${this.buildDeletionScope(task)}
+      ${deletionScopeRule(task.sessionName!, task.deletableSessionNames)}
 
       ${this.buildAvailableFiles()}
 
       ${knowledge}
     `;
-  }
-
-  private getDeletableSessionNames(task: Test): string[] {
-    if (!task.plan) return [];
-    return task.plan
-      .listTests()
-      .filter((t) => t.isSuccessful && t.sessionName)
-      .map((t) => t.sessionName!);
   }
 
   private buildAvailableFiles(): string {
@@ -909,18 +901,6 @@ export class Tester extends TaskAgent implements Agent {
       ${lines.join('\n')}
       </available_files>
     `;
-  }
-
-  private buildDeletionScope(task: Test): string {
-    const deletableItems = this.getDeletableSessionNames(task);
-    if (deletableItems.length > 0) {
-      return `When deleting items, ONLY delete items whose title contains one of these session names: ${deletableItems.join(', ')}. These were created by previous tests.`;
-    }
-    const scenarioLower = task.scenario.toLowerCase();
-    if (scenarioLower.includes('delete') || scenarioLower.includes('remove')) {
-      return 'No items from previous tests are available for deletion. You need to create an item first before deleting it.';
-    }
-    return '';
   }
 
   private createTestFlowTools(task: Test, currentState: ActionResult, conversation: Conversation) {

--- a/src/test-plan.ts
+++ b/src/test-plan.ts
@@ -295,6 +295,16 @@ export class Test extends Task {
     return this.hasFinished && this.result === TestResult.SKIPPED;
   }
 
+  get deletableSessionNames(): string[] {
+    const previous =
+      this.plan
+        ?.listTests()
+        .filter((t) => t !== this && t.isSuccessful && t.sessionName)
+        .map((t) => t.sessionName!) ?? [];
+    if (!this.sessionName) return previous;
+    return [this.sessionName, ...previous];
+  }
+
   getCheckedNotes(): Note[] {
     return Object.values(this.notes).filter((n) => !!n.status);
   }

--- a/tests/unit/test-plan.test.ts
+++ b/tests/unit/test-plan.test.ts
@@ -3,7 +3,7 @@ import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:
 import os, { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { registerSite } from '../../src/global-config.ts';
-import { Plan, Test } from '../../src/test-plan.ts';
+import { Plan, Test, TestResult, TestStatus } from '../../src/test-plan.ts';
 
 describe('Plan', () => {
   const testFilePath = join('/tmp', 'test-plan.md');
@@ -508,6 +508,50 @@ priority: normal
 
     test('returns null for a missing name', () => {
       expect(Plan.resolveFile('missing')).toBeNull();
+    });
+  });
+
+  describe('deletableSessionNames', () => {
+    const buildPlan = () => {
+      const plan = new Plan('Suite');
+      const passed = new Test('Passed scenario', 'high', [], '/page');
+      passed.status = TestStatus.DONE;
+      passed.result = TestResult.PASSED;
+      const failed = new Test('Failed scenario', 'high', [], '/page');
+      failed.status = TestStatus.DONE;
+      failed.result = TestResult.FAILED;
+      const pending = new Test('Pending scenario', 'high', [], '/page');
+      const current = new Test('Current scenario', 'high', [], '/page');
+      for (const test of [passed, failed, pending, current]) plan.addTest(test);
+      return { passed, failed, pending, current };
+    };
+
+    test('lists the current session first', () => {
+      const { current } = buildPlan();
+      expect(current.deletableSessionNames[0]).toBe(current.sessionName);
+    });
+
+    test('includes session names of passed tests', () => {
+      const { current, passed } = buildPlan();
+      expect(current.deletableSessionNames).toContain(passed.sessionName);
+    });
+
+    test('excludes failed and pending tests', () => {
+      const { current, failed, pending } = buildPlan();
+      expect(current.deletableSessionNames).not.toContain(failed.sessionName);
+      expect(current.deletableSessionNames).not.toContain(pending.sessionName);
+    });
+
+    test('lists the current session once after it passes', () => {
+      const { current } = buildPlan();
+      current.status = TestStatus.DONE;
+      current.result = TestResult.PASSED;
+      expect(current.deletableSessionNames.filter((name) => name === current.sessionName)).toHaveLength(1);
+    });
+
+    test('falls back to the current session without a plan', () => {
+      const orphan = new Test('Orphan scenario', 'high', [], '/page');
+      expect(orphan.deletableSessionNames).toEqual([orphan.sessionName!]);
     });
   });
 });


### PR DESCRIPTION
## The bug

Trace [`7a41ea3849e807d9cdf905fcffb7aaf7`](https://cloud.langfuse.com) (session `UltimateQualifiedLime411`), scenario *"Delete a suite created during the scenario and verify that it is removed from the hierarchy."*

The deletion worked:

```
visualClick 'trash can icon'            -> OK   (modal "Delete suite?")
click 'Accept deletion confirmation'    -> OK
see  "...'DeleteTarget 98765' in hierarchy?"       -> "No."
click 'Click Tests link in sidebar to reload page' -> OK
see  "...in the hierarchy after reload?"           -> "No."
```

Pilot failed it anyway:

```json
{"decision":"fail","reason":"The deleted suite was named “DeleteTarget 98765,” which does not contain an allowed deletion title."}
```

## Why

**1. The allowlist could not contain the item this run created.** Both copies of `buildDeletionScope` built the list from `plan.listTests().filter(t => t.isSuccessful && t.sessionName)`. `isSuccessful` is `hasFinished && result === PASSED`, and the running test is not PASSED while the verdict that sets it is being made. So the current run's own session name was always missing, and a self-contained create-then-delete scenario could never satisfy the gate. This also contradicted `dataProtectionRules`, which already says destructive actions are allowed against data created by the current scenario.

**2. Pilot authored the name it later rejected.** `buildDeletionScope` fed the reset and verdict prompts but not Pilot's planning system prompt. `planTest` proposed *"Enter a unique title, e.g. `DeleteTarget <unique suffix>`"*, Tester followed it literally, and the verdict prompt then failed the run for that title.

## The change

- `Test.deletableSessionNames` (`src/test-plan.ts`) is the single owner of the derivation — current session first, previously passed siblings after, self excluded from the "previous" half so it never appears twice.
- `deletionScopeRule(sessionName, deletableSessionNames)` in `src/ai/rules.ts` replaces the two private copies that had drifted apart in wording (`"These were created by previous tests"` vs `"items can only be deleted if their title contains"`).
- Pilot's planning system prompt now carries the rule, next to `dataProtectionRules`, so the titles it proposes satisfy the gate it later enforces.

Two branches are gone with the old copies:

- the `"No items available for deletion — create an item first"` fallback is unreachable now that the current session is always in the list, and the rule's second line already says items must be created before they can be deleted;
- the `scenario.includes('delete') || scenario.includes('remove')` gate that guarded it — keyword matching over scenario prose, which CLAUDE.md's regex-vs-AI table puts on the wrong side of the line.

The soft `"you should include <session name> in the value"` line in the Tester prompt is left alone: it covers editing and non-title fields, while the new rule covers the deletion gate.

## Verification

`bun test tests/unit` (1315 pass) and `bun test tests/integration` (111 pass) are green; `bun run lint` clean. Five unit tests cover the new getter: current session first, passed siblings included, failed and pending excluded, no duplicate once the current test passes, and the no-plan fallback.

What tests cannot confirm: both halves of this are prompt-behavior bets. The trace's own title, `DeleteTarget 98765`, would still fail the gate under the new rule — the fix works by making the gate satisfiable *and* by putting the naming convention in front of Pilot while it plans. Only a real run shows whether Pilot now proposes titles that carry the session name. A regression run would validate it; I have not applied the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC5amRQpCtHVzZrcHp1G8g
