### PR TITLE
apibot: endpoint patterns, the command pattern, and an init that writes a usable config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,25 @@
   covered, disabled, or that the locator matched something that does not respond, and to check it with
   `xpathCheck` before retrying. A click the page answers only with an API call still counts as landed,
   so a Save that stores something without redrawing anything is not retried into a duplicate record.
+- API testing: an endpoint with real values in it now finds its spec. Specs write paths as templates, so
+  asking for `/api/v2/acme/tests` when the spec says `/api/v2/{project_id}/tests` matched nothing and the
+  run stopped before it planned anything. The endpoint is matched against the templates now, and the paths
+  under it come along, so planning a collection also sees the create, read, update and delete beneath it.
+
+- `api explore` takes a pattern instead of a single endpoint. `*` stands for one path segment, and a
+  pattern covers the paths below it, so `'/users/*'` and `/users` both reach `/users/{id}`. Pass `/` to
+  take every collection the spec describes, with the path parameters coming from the base endpoint.
+
+  ```bash
+  npx explorbot api explore /users                  # one endpoint, planned in every style
+  npx explorbot api explore '/projects/acme/*'      # every collection of one project
+  npx explorbot api explore / --endpoint https://api.example.com/v2/acme   # the whole API
+  ```
+
+  Explorbot explores collections rather than raw paths, so `/users/{id}` folds into `/users`. When a
+  pattern matches several collections they share the planning styles, one each, so a wide run costs about
+  what a narrow one does. A parameter no pattern can fill stops the run and is named, rather than requests
+  going out to a literal `{project_id}`.
 - Locators: elements that appear in response to an action — a menu that opens, a panel that slides in —
   can now be clicked using the role reported for them when they appeared, instead of a guessed one.
   Guessing was silent rather than loud: a control named the same thing elsewhere on the page absorbed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@
   no longer sends the run into an element it can never act on.
 - [Tester] An element that is present but not visible now also suggests targeting an on-screen copy of the
   same control, alongside the existing advice to scroll to it or open the panel holding it.
+- `apibot init` writes a config you can run. It used to hardcode `openai('gpt-4o')` and an
+  `@ai-sdk/openai` import, so a fresh project pointed at a model nobody here uses and failed unless
+  that package happened to be installed. Models now come from the recommendations for your provider,
+  written as `provider/model-id` strings that need no import. The commented-out `bootstrap` and
+  `teardown` blocks, the empty `headers` block and the `dirs` block that only restated the defaults
+  are gone. A `.env` with the provider keys is written alongside, as `explorbot init` does.
+
+  ```bash
+  apibot init                                            # asks for the endpoint and spec
+  apibot init --endpoint https://api.example.com/v1 --spec openapi.yaml   # no questions
+  apibot init --provider openai                          # models for another provider
+  ```
+
+- The generated config is `apibot.config.js`. It was written as `apibot.config.ts`, which is third in
+  the list of files apibot looks for and is not the name its own "config missing" error tells you to
+  create.
 
 ## 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,8 +76,8 @@
   ```
 
   Explorbot explores collections rather than raw paths, so `/users/{id}` folds into `/users`. When a
-  pattern matches several collections they share the planning styles, one each, so a wide run costs about
-  what a narrow one does. A parameter no pattern can fill stops the run and is named, rather than requests
+  pattern matches several collections they share the planning styles, one per collection, so covering a
+  whole API stays one plan per collection rather than one per style. A parameter no pattern can fill stops the run and is named, rather than requests
   going out to a literal `{project_id}`.
 - Locators: elements that appear in response to an action — a menu that opens, a panel that slides in —
   can now be clicked using the role reported for them when they appeared, instead of a guessed one.

--- a/boat/api-tester/src/apibot.ts
+++ b/boat/api-tester/src/apibot.ts
@@ -5,7 +5,7 @@ import { RequestStore } from '../../../src/api/request-store.ts';
 import { extractEndpointDefinition, loadSpec, resolveEndpoints, searchEndpoints, validateSpecs } from '../../../src/api/spec-reader.ts';
 import { KnowledgeTracker } from '../../../src/knowledge-tracker.ts';
 import { Reporter } from '../../../src/reporter.ts';
-import { Plan } from '../../../src/test-plan.ts';
+import { Plan, type Test } from '../../../src/test-plan.ts';
 import { setVerboseMode, tag } from '../../../src/utils/logger.ts';
 import { Chief } from './ai/chief.ts';
 import { Curler } from './ai/curler.ts';
@@ -168,6 +168,18 @@ export class ApiBot {
 
   getConfigParser(): ApibotConfigParser {
     return this.configParser;
+  }
+
+  getOptions(): ApibotOptions {
+    return this.options;
+  }
+
+  async runTest(test: Test): Promise<{ success: boolean }> {
+    return this.agentCurler().test(test, {
+      specDefinition: this.tryGetEndpointDefinition(test.startUrl!),
+      baseEndpoint: this.config.api.baseEndpoint,
+      searchSpec: (query: string) => this.searchSpec(query),
+    });
   }
 
   getRequestState(): RequestStore {

--- a/boat/api-tester/src/apibot.ts
+++ b/boat/api-tester/src/apibot.ts
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { AIProvider } from '../../../src/ai/provider.ts';
 import { RequestStore } from '../../../src/api/request-store.ts';
-import { extractEndpointDefinition, loadSpec, searchEndpoints, validateSpecs } from '../../../src/api/spec-reader.ts';
+import { extractEndpointDefinition, loadSpec, resolveEndpoints, searchEndpoints, validateSpecs } from '../../../src/api/spec-reader.ts';
 import { KnowledgeTracker } from '../../../src/knowledge-tracker.ts';
 import { Reporter } from '../../../src/reporter.ts';
 import { Plan } from '../../../src/test-plan.ts';
@@ -176,6 +176,10 @@ export class ApiBot {
 
   getEndpointDefinition(endpoint: string): string {
     return extractEndpointDefinition(this.apiSpec, endpoint, this.config.api.baseEndpoint);
+  }
+
+  expandEndpoints(pattern: string): string[] {
+    return resolveEndpoints(this.apiSpec, this.configParser.resolveEndpointPath(pattern), this.config.api.baseEndpoint);
   }
 
   searchSpec(query: string): string {

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -73,7 +73,7 @@ export function createApiCommands(name = 'api'): Command {
     .option('-f, --force', 'Overwrite existing config file')
     .option('-p, --path <path>', 'Working directory for initialization')
     .option('--provider <name>', 'AI provider written into the config')
-    .option('--endpoint <url>', 'Base API endpoint, skips the questions')
+    .option('--endpoint <url>', 'Base API endpoint, with --spec skips the questions')
     .option('--spec <path>', 'OpenAPI spec file or URL')
     .action(async (options) => {
       await runInit({ ...options, baseEndpoint: options.endpoint, prefix: name });

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -5,8 +5,8 @@ import { ConfigCommand } from '../../../src/commands/config-command.ts';
 import { RecommendedModelsCommand } from '../../../src/commands/recommended-models-command.ts';
 import { listSites } from '../../../src/global-config.ts';
 import { setPreserveConsoleLogs } from '../../../src/utils/logger.ts';
-import { getStyles } from './ai/chief/styles.ts';
 import { ApiBot, type ApibotOptions } from './apibot.ts';
+import { ExploreCommand } from './commands/explore-command.ts';
 import { ApibotConfigParser } from './config.ts';
 
 function buildOptions(options: any): ApibotOptions {
@@ -159,47 +159,10 @@ export function createApiCommands(name = 'api'): Command {
       const bot = new ApiBot({ ...buildOptions(options), endpoint });
       await bot.start();
 
-      const styles = Object.keys(getStyles());
-      const endpoints = bot.expandEndpoints(endpoint);
-      let totalPassed = 0;
-      let totalFailed = 0;
-      let totalTests = 0;
+      const { failed } = await new ExploreCommand(bot).execute(endpoint);
 
-      for (const [index, target] of endpoints.entries()) {
-        let runStyles = [styles[index % styles.length]];
-        if (endpoints.length === 1) runStyles = styles;
-        if (endpoints.length > 1) console.log(`\n=== Endpoint ${index + 1}/${endpoints.length}: ${target} ===`);
-
-        for (const style of runStyles) {
-          console.log(`\n=== Style: ${style} ===\n`);
-
-          const plan = await bot.plan(target, { style, fresh: true });
-          if (!plan?.tests.length) {
-            console.log(`No tests generated for style: ${style}`);
-            continue;
-          }
-
-          const pending = plan.getPendingTests();
-          for (const test of pending) {
-            const specDefinition = bot.tryGetEndpointDefinition(test.startUrl);
-            const result = await bot.agentCurler().test(test, {
-              specDefinition,
-              baseEndpoint: bot.getConfig().api.baseEndpoint,
-              searchSpec: (query) => bot.searchSpec(query),
-            });
-            totalTests++;
-            if (result.success) totalPassed++;
-            else totalFailed++;
-          }
-
-          bot.savePlan(style);
-        }
-      }
-
-      console.log('\n=== Final Results ===');
-      console.log(`Total: ${totalTests} tests, ${totalPassed} passed, ${totalFailed} failed`);
       await bot.stop();
-      process.exit(totalFailed > 0 ? 1 : 0);
+      process.exit(failed > 0 ? 1 : 0);
     } catch (error) {
       console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
       process.exit(1);

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -152,7 +152,7 @@ export function createApiCommands(name = 'api'): Command {
     }
   });
 
-  addCommonOptions(cmd.command('explore <endpoint>').description('Full cycle: plan all styles, execute tests, re-plan. The endpoint may be the base endpoint itself')).action(async (endpoint, options) => {
+  addCommonOptions(cmd.command('explore <endpoint>').description('Full cycle: plan, execute tests, re-plan. Use * to cover many endpoints, or the base endpoint for all of them')).action(async (endpoint, options) => {
     setPreserveConsoleLogs(true);
     try {
       if (URL.canParse(endpoint)) options.endpoint ||= endpoint;
@@ -160,33 +160,40 @@ export function createApiCommands(name = 'api'): Command {
       await bot.start();
 
       const styles = Object.keys(getStyles());
+      const endpoints = bot.expandEndpoints(endpoint);
       let totalPassed = 0;
       let totalFailed = 0;
       let totalTests = 0;
 
-      for (const style of styles) {
-        console.log(`\n=== Style: ${style} ===\n`);
+      for (const [index, target] of endpoints.entries()) {
+        let runStyles = [styles[index % styles.length]];
+        if (endpoints.length === 1) runStyles = styles;
+        if (endpoints.length > 1) console.log(`\n=== Endpoint ${index + 1}/${endpoints.length}: ${target} ===`);
 
-        const plan = await bot.plan(endpoint, { style, fresh: true });
-        if (!plan?.tests.length) {
-          console.log(`No tests generated for style: ${style}`);
-          continue;
+        for (const style of runStyles) {
+          console.log(`\n=== Style: ${style} ===\n`);
+
+          const plan = await bot.plan(target, { style, fresh: true });
+          if (!plan?.tests.length) {
+            console.log(`No tests generated for style: ${style}`);
+            continue;
+          }
+
+          const pending = plan.getPendingTests();
+          for (const test of pending) {
+            const specDefinition = bot.tryGetEndpointDefinition(test.startUrl);
+            const result = await bot.agentCurler().test(test, {
+              specDefinition,
+              baseEndpoint: bot.getConfig().api.baseEndpoint,
+              searchSpec: (query) => bot.searchSpec(query),
+            });
+            totalTests++;
+            if (result.success) totalPassed++;
+            else totalFailed++;
+          }
+
+          bot.savePlan(style);
         }
-
-        const pending = plan.getPendingTests();
-        for (const test of pending) {
-          const specDefinition = bot.tryGetEndpointDefinition(test.startUrl);
-          const result = await bot.agentCurler().test(test, {
-            specDefinition,
-            baseEndpoint: bot.getConfig().api.baseEndpoint,
-            searchSpec: (query) => bot.searchSpec(query),
-          });
-          totalTests++;
-          if (result.success) totalPassed++;
-          else totalFailed++;
-        }
-
-        bot.savePlan(style);
       }
 
       console.log('\n=== Final Results ===');

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -1,5 +1,3 @@
-import fs from 'node:fs';
-import path from 'node:path';
 import { Command } from 'commander';
 import { ConfigCommand } from '../../../src/commands/config-command.ts';
 import { RecommendedModelsCommand } from '../../../src/commands/recommended-models-command.ts';
@@ -7,94 +5,29 @@ import { listSites } from '../../../src/global-config.ts';
 import { setPreserveConsoleLogs } from '../../../src/utils/logger.ts';
 import { ApiBot, type ApibotOptions } from './apibot.ts';
 import { ExploreCommand } from './commands/explore-command.ts';
+import { runInit } from './commands/init-command.ts';
+import { KnowCommand } from './commands/know-command.ts';
+import { PlanCommand } from './commands/plan-command.ts';
+import { TestCommand } from './commands/test-command.ts';
 import { ApibotConfigParser } from './config.ts';
-
-function buildOptions(options: any): ApibotOptions {
-  return {
-    verbose: options.verbose || options.debug,
-    config: options.config,
-    path: options.path,
-    baseEndpoint: options.endpoint,
-    spec: options.spec,
-    header: options.header,
-  };
-}
-
-function addCommonOptions(cmd: Command): Command {
-  return cmd
-    .option('-v, --verbose', 'Enable verbose logging')
-    .option('--debug', 'Enable debug logging')
-    .option('-c, --config <path>', 'Path to configuration file')
-    .option('-p, --path <path>', 'Working directory path')
-    .option('--endpoint <url>', 'Base API endpoint to test (env: EXPLORBOT_URL)')
-    .option('--spec <path>', 'OpenAPI spec file or URL (env: EXPLORBOT_API_SPEC)')
-    .option('-H, --header <header>', 'Header sent with every request, as "Name: value". Repeatable (env: EXPLORBOT_API_HEADERS)', (value: string, previous: string[] = []) => [...previous, value]);
-}
-
-function selectTests(tests: any[], index?: string): any[] {
-  if (!index || index === '*' || index === 'all') {
-    return tests.filter((t) => t.status === 'pending');
-  }
-
-  const rangeMatch = index.match(/^(\d+)-(\d+)$/);
-  if (rangeMatch) {
-    const start = Number.parseInt(rangeMatch[1]) - 1;
-    const end = Number.parseInt(rangeMatch[2]);
-    return tests.slice(start, end);
-  }
-
-  if (index.includes(',')) {
-    const indices = index.split(',').map((i) => Number.parseInt(i.trim()) - 1);
-    return indices.map((i) => tests[i]).filter(Boolean);
-  }
-
-  const num = Number.parseInt(index);
-  if (!Number.isNaN(num) && tests[num - 1]) {
-    return [tests[num - 1]];
-  }
-
-  return tests.filter((t) => t.status === 'pending');
-}
 
 export function createApiCommands(name = 'api'): Command {
   const cmd = new Command(name);
   cmd.description('AI-powered API testing tool');
 
-  addCommonOptions(cmd.command('plan <endpoint>').description('Generate test plan for an API endpoint').option('--style <style>', 'Planning style: basename of a file in rules/chief/styles/').option('--fresh', 'Start planning from scratch')).action(async (endpoint, options) => {
-    setPreserveConsoleLogs(true);
-    try {
-      const bot = new ApiBot({ ...buildOptions(options), endpoint });
-      await bot.start();
-
-      await bot.plan(endpoint, { style: options.style, fresh: options.fresh });
-
-      const plan = bot.getCurrentPlan();
-      if (!plan?.tests.length) {
-        console.error('No test scenarios generated.');
-        process.exit(1);
-      }
-
-      console.log(`\nPlan: ${plan.title} (${plan.tests.length} tests)\n`);
-      plan.tests.forEach((test, i) => {
-        console.log(`  ${i + 1}. [${test.priority}] ${test.scenario}`);
+  addCommonOptions(cmd.command('plan <endpoint>').description('Generate test plan for an API endpoint'))
+    .option('--style <style>', 'Planning style: basename of a file in rules/chief/styles/')
+    .option('--fresh', 'Start planning from scratch')
+    .action(async (endpoint, options) => {
+      await run(name, options, endpoint, async (bot) => {
+        const command = new PlanCommand(bot);
+        command.prefix = name;
+        command.style = options.style;
+        command.fresh = !!options.fresh;
+        await command.execute(endpoint);
+        return 0;
       });
-
-      const savedPath = bot.savePlan();
-      if (savedPath) {
-        console.log(`\nSaved to: ${savedPath}`);
-        console.log('\nRun tests:');
-        console.log(`  ${name} test ${savedPath} 1       # run first test`);
-        console.log(`  ${name} test ${savedPath} 1-3     # run tests 1 to 3`);
-        console.log(`  ${name} test ${savedPath} *       # run all tests`);
-      }
-
-      await bot.stop();
-      process.exit(0);
-    } catch (error) {
-      console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
-      process.exit(1);
-    }
-  });
+    });
 
   addCommonOptions(cmd.command('config [endpoint]').description('Show models, config file and paths used by this run'))
     .option('--json', 'Print the resolved config as JSON')
@@ -116,57 +49,22 @@ export function createApiCommands(name = 'api'): Command {
   RecommendedModelsCommand.register(cmd);
 
   addCommonOptions(cmd.command('test <planfile> [index]').description('Execute tests from a plan file. Index: 1, 1-3, *')).action(async (planfile, index, options) => {
-    setPreserveConsoleLogs(true);
-    try {
-      const bot = new ApiBot(buildOptions(options));
-      await bot.start();
-
-      const plan = bot.loadPlan(planfile);
-      console.log(`Plan loaded: "${plan.title}" (${plan.tests.length} tests)`);
-
-      const tests = selectTests(plan.tests, index);
-      console.log(`Running ${tests.length} test(s)\n`);
-
-      let passed = 0;
-      let failed = 0;
-
-      for (const test of tests) {
-        const specDefinition = bot.tryGetEndpointDefinition(test.startUrl);
-        const result = await bot.agentCurler().test(test, {
-          specDefinition,
-          baseEndpoint: bot.getConfig().api.baseEndpoint,
-          searchSpec: (query) => bot.searchSpec(query),
-        });
-        if (result.success) passed++;
-        else failed++;
-      }
-
-      bot.savePlan();
-
-      console.log(`\nResults: ${passed} passed, ${failed} failed out of ${tests.length}`);
-      await bot.stop();
-      process.exit(failed > 0 ? 1 : 0);
-    } catch (error) {
-      console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
-      process.exit(1);
-    }
+    await run(name, options, undefined, async (bot) => {
+      const command = new TestCommand(bot);
+      command.index = index;
+      await command.execute(planfile);
+      if (command.failed) return 1;
+      return 0;
+    });
   });
 
   addCommonOptions(cmd.command('explore <endpoint>').description('Full cycle: plan, execute tests, re-plan. Use * to cover many endpoints, or the base endpoint for all of them')).action(async (endpoint, options) => {
-    setPreserveConsoleLogs(true);
-    try {
-      if (URL.canParse(endpoint)) options.endpoint ||= endpoint;
-      const bot = new ApiBot({ ...buildOptions(options), endpoint });
-      await bot.start();
-
-      const { failed } = await new ExploreCommand(bot).execute(endpoint);
-
-      await bot.stop();
-      process.exit(failed > 0 ? 1 : 0);
-    } catch (error) {
-      console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
-      process.exit(1);
-    }
+    await run(name, options, endpoint, async (bot) => {
+      const command = new ExploreCommand(bot);
+      await command.execute(endpoint);
+      if (command.result.failed) return 1;
+      return 0;
+    });
   });
 
   cmd
@@ -174,87 +72,11 @@ export function createApiCommands(name = 'api'): Command {
     .description('Initialize a new apibot project with configuration')
     .option('-f, --force', 'Overwrite existing config file')
     .option('-p, --path <path>', 'Working directory for initialization')
+    .option('--provider <name>', 'AI provider written into the config')
+    .option('--endpoint <url>', 'Base API endpoint, skips the questions')
+    .option('--spec <path>', 'OpenAPI spec file or URL')
     .action(async (options) => {
-      const originalCwd = process.cwd();
-      if (options.path) {
-        const resolvedPath = path.resolve(options.path);
-        fs.mkdirSync(resolvedPath, { recursive: true });
-        process.chdir(resolvedPath);
-        console.log(`Working in: ${resolvedPath}`);
-      }
-
-      const configPath = path.resolve('apibot.config.ts');
-
-      if (fs.existsSync(configPath) && !options.force) {
-        console.log(`Config file already exists: ${configPath}`);
-        console.log('Use --force to overwrite.');
-        process.exit(1);
-      }
-
-      const rl = await import('node:readline');
-      const iface = rl.createInterface({ input: process.stdin, output: process.stdout });
-      const ask = (q: string, fallback = ''): Promise<string> => new Promise((resolve) => iface.question(q, (a: string) => resolve(a.trim() || fallback)));
-
-      console.log('Apibot — API Testing Tool Setup\n');
-
-      const baseEndpoint = await ask('Base API endpoint (e.g., https://api.example.com/v1): ');
-      if (!baseEndpoint) {
-        console.error('Base endpoint is required.');
-        iface.close();
-        process.exit(1);
-      }
-
-      const spec = await ask('OpenAPI spec file or URL (e.g., openapi.yaml or https://.../ — or press Enter to skip): ');
-      const knowledge = await ask('Describe your API (auth method, data formats, special rules — or press Enter to skip): ');
-
-      iface.close();
-
-      const specLine = spec ? `\n    spec: ['${spec}'],` : '';
-
-      const configContent = `import { openai } from '@ai-sdk/openai';
-
-export default {
-  ai: {
-    model: openai('gpt-4o'),
-  },
-  api: {
-    baseEndpoint: '${baseEndpoint}',${specLine}
-    headers: {
-      // 'Authorization': 'Bearer <token>',
-    },
-    // bootstrap: async ({ headers, baseEndpoint }) => {
-    //   // Run before tests — e.g. obtain auth token
-    //   // Return headers to merge: { Authorization: 'Bearer ...' }
-    // },
-    // teardown: async ({ headers, baseEndpoint }) => {
-    //   // Run after tests — e.g. cleanup test data
-    // },
-  },
-  dirs: {
-    output: 'output',
-    knowledge: 'knowledge',
-  },
-};
-`;
-
-      fs.writeFileSync(configPath, configContent, 'utf8');
-      console.log(`\nCreated: ${configPath}`);
-
-      fs.mkdirSync('output', { recursive: true });
-      fs.mkdirSync('knowledge', { recursive: true });
-
-      if (knowledge) {
-        const knowledgePath = path.resolve('knowledge', 'general.md');
-        fs.writeFileSync(knowledgePath, `---\nendpoint: "*"\n---\n${knowledge}\n`, 'utf8');
-        console.log(`Created: ${knowledgePath}`);
-      }
-
-      console.log('\nNext steps:');
-      console.log('1. Edit apibot.config.ts — set your AI provider and API headers');
-      console.log(`2. Add API knowledge: ${name} know /users "CRUD endpoint for user management"`);
-      console.log(`3. Plan tests: ${name} plan /users`);
-
-      if (process.cwd() !== originalCwd) process.chdir(originalCwd);
+      await runInit({ ...options, baseEndpoint: options.endpoint, prefix: name });
     });
 
   cmd
@@ -264,42 +86,61 @@ export default {
     .option('-c, --config <path>', 'Path to configuration file')
     .option('-p, --path <path>', 'Working directory path')
     .action(async (endpoint, description, options) => {
-      if (!description) {
-        const rl = await import('node:readline');
-        const iface = rl.createInterface({ input: process.stdin, output: process.stdout });
-        description = await new Promise<string>((resolve) => iface.question(`Describe ${endpoint}: `, (a: string) => resolve(a.trim())));
-        iface.close();
-      }
-
-      if (!description) {
-        console.error('Description is required.');
-        process.exit(1);
-      }
-
-      let knowledgeDir = 'knowledge';
+      const command = new KnowCommand(new ApiBot(buildOptions(options)));
+      command.prefix = name;
+      command.knowledge = description || (await askDescription(endpoint));
       try {
-        const { ApibotConfigParser } = await import('./config.ts');
-        await ApibotConfigParser.getInstance().loadConfig({ config: options.config, path: options.path });
-        knowledgeDir = ApibotConfigParser.getInstance().getKnowledgeDir();
-      } catch {
-        if (options.path) knowledgeDir = path.join(path.resolve(options.path), 'knowledge');
-      }
-
-      fs.mkdirSync(knowledgeDir, { recursive: true });
-
-      const filename = endpoint.replace(/^\//, '').replace(/[^a-zA-Z0-9]/g, '_') || 'general';
-      const filePath = path.join(knowledgeDir, `${filename}.md`);
-
-      const content = `---\nendpoint: "${endpoint}"\n---\n${description}\n`;
-
-      if (fs.existsSync(filePath)) {
-        fs.appendFileSync(filePath, `\n---\n${description}\n`, 'utf8');
-        console.log(`Updated: ${filePath}`);
-      } else {
-        fs.writeFileSync(filePath, content, 'utf8');
-        console.log(`Created: ${filePath}`);
+        await command.execute(endpoint);
+      } catch (error) {
+        console.error(error instanceof Error ? error.message : 'Unknown error');
+        process.exit(1);
       }
     });
 
   return cmd;
+}
+
+async function run(name: string, options: any, endpoint: string | undefined, body: (bot: ApiBot) => Promise<number>): Promise<void> {
+  setPreserveConsoleLogs(true);
+  try {
+    if (endpoint && URL.canParse(endpoint)) options.endpoint ||= endpoint;
+    const bot = new ApiBot({ ...buildOptions(options), endpoint });
+    await bot.start();
+    const code = await body(bot);
+    await bot.stop();
+    process.exit(code);
+  } catch (error) {
+    console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
+    process.exit(1);
+  }
+}
+
+async function askDescription(endpoint: string): Promise<string> {
+  const rl = await import('node:readline');
+  const iface = rl.createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise<string>((resolve) => iface.question(`Describe ${endpoint}: `, (text: string) => resolve(text.trim())));
+  iface.close();
+  return answer;
+}
+
+function buildOptions(options: any): ApibotOptions {
+  return {
+    verbose: options.verbose || options.debug,
+    config: options.config,
+    path: options.path,
+    baseEndpoint: options.endpoint,
+    spec: options.spec,
+    header: options.header,
+  };
+}
+
+function addCommonOptions(cmd: Command): Command {
+  return cmd
+    .option('-v, --verbose', 'Enable verbose logging')
+    .option('--debug', 'Enable debug logging')
+    .option('-c, --config <path>', 'Path to configuration file')
+    .option('-p, --path <path>', 'Working directory path')
+    .option('--endpoint <url>', 'Base API endpoint to test (env: EXPLORBOT_URL)')
+    .option('--spec <path>', 'OpenAPI spec file or URL (env: EXPLORBOT_API_SPEC)')
+    .option('-H, --header <header>', 'Header sent with every request, as "Name: value". Repeatable (env: EXPLORBOT_API_HEADERS)', (value: string, previous: string[] = []) => [...previous, value]);
 }

--- a/boat/api-tester/src/commands/api-command.ts
+++ b/boat/api-tester/src/commands/api-command.ts
@@ -1,0 +1,10 @@
+import { BaseCommand } from '../../../../src/commands/base-command.ts';
+import type { ApiBot } from '../apibot.ts';
+
+export abstract class ApiCommand extends BaseCommand<ApiBot> {
+  prefix = 'apibot';
+
+  protected get bot(): ApiBot {
+    return this.explorBot;
+  }
+}

--- a/boat/api-tester/src/commands/explore-command.ts
+++ b/boat/api-tester/src/commands/explore-command.ts
@@ -1,17 +1,14 @@
 import { getStyles } from '../ai/chief/styles.ts';
-import type { ApiBot } from '../apibot.ts';
+import { ApiCommand } from './api-command.ts';
 
-export class ExploreCommand {
-  private bot: ApiBot;
+export class ExploreCommand extends ApiCommand {
+  name = 'explore';
+  description = 'Full cycle: plan, execute tests, re-plan. Use * to cover many endpoints, or the base endpoint for all of them';
+  result: ExploreResult = { tests: 0, passed: 0, failed: 0 };
 
-  constructor(bot: ApiBot) {
-    this.bot = bot;
-  }
-
-  async execute(endpoint: string): Promise<ExploreResult> {
+  async execute(endpoint: string): Promise<void> {
     const styles = Object.keys(getStyles());
     const endpoints = this.bot.expandEndpoints(endpoint);
-    const result: ExploreResult = { tests: 0, passed: 0, failed: 0 };
 
     for (const [index, target] of endpoints.entries()) {
       let runStyles = [styles[index % styles.length]];
@@ -19,17 +16,15 @@ export class ExploreCommand {
       if (endpoints.length > 1) console.log(`\n=== Endpoint ${index + 1}/${endpoints.length}: ${target} ===`);
 
       for (const style of runStyles) {
-        await this.runStyle(target, style, result);
+        await this.runStyle(target, style);
       }
     }
 
     console.log('\n=== Final Results ===');
-    console.log(`Total: ${result.tests} tests, ${result.passed} passed, ${result.failed} failed`);
-
-    return result;
+    console.log(`Total: ${this.result.tests} tests, ${this.result.passed} passed, ${this.result.failed} failed`);
   }
 
-  private async runStyle(endpoint: string, style: string, result: ExploreResult): Promise<void> {
+  private async runStyle(endpoint: string, style: string): Promise<void> {
     console.log(`\n=== Style: ${style} ===\n`);
 
     const plan = await this.bot.plan(endpoint, { style, fresh: true });
@@ -39,15 +34,10 @@ export class ExploreCommand {
     }
 
     for (const test of plan.getPendingTests()) {
-      const specDefinition = this.bot.tryGetEndpointDefinition(test.startUrl!);
-      const outcome = await this.bot.agentCurler().test(test, {
-        specDefinition,
-        baseEndpoint: this.bot.getConfig().api.baseEndpoint,
-        searchSpec: (query: string) => this.bot.searchSpec(query),
-      });
-      result.tests++;
-      if (outcome.success) result.passed++;
-      else result.failed++;
+      const outcome = await this.bot.runTest(test);
+      this.result.tests++;
+      if (outcome.success) this.result.passed++;
+      else this.result.failed++;
     }
 
     this.bot.savePlan(style);

--- a/boat/api-tester/src/commands/explore-command.ts
+++ b/boat/api-tester/src/commands/explore-command.ts
@@ -1,0 +1,61 @@
+import { getStyles } from '../ai/chief/styles.ts';
+import type { ApiBot } from '../apibot.ts';
+
+export class ExploreCommand {
+  private bot: ApiBot;
+
+  constructor(bot: ApiBot) {
+    this.bot = bot;
+  }
+
+  async execute(endpoint: string): Promise<ExploreResult> {
+    const styles = Object.keys(getStyles());
+    const endpoints = this.bot.expandEndpoints(endpoint);
+    const result: ExploreResult = { tests: 0, passed: 0, failed: 0 };
+
+    for (const [index, target] of endpoints.entries()) {
+      let runStyles = [styles[index % styles.length]];
+      if (endpoints.length === 1) runStyles = styles;
+      if (endpoints.length > 1) console.log(`\n=== Endpoint ${index + 1}/${endpoints.length}: ${target} ===`);
+
+      for (const style of runStyles) {
+        await this.runStyle(target, style, result);
+      }
+    }
+
+    console.log('\n=== Final Results ===');
+    console.log(`Total: ${result.tests} tests, ${result.passed} passed, ${result.failed} failed`);
+
+    return result;
+  }
+
+  private async runStyle(endpoint: string, style: string, result: ExploreResult): Promise<void> {
+    console.log(`\n=== Style: ${style} ===\n`);
+
+    const plan = await this.bot.plan(endpoint, { style, fresh: true });
+    if (!plan?.tests.length) {
+      console.log(`No tests generated for style: ${style}`);
+      return;
+    }
+
+    for (const test of plan.getPendingTests()) {
+      const specDefinition = this.bot.tryGetEndpointDefinition(test.startUrl!);
+      const outcome = await this.bot.agentCurler().test(test, {
+        specDefinition,
+        baseEndpoint: this.bot.getConfig().api.baseEndpoint,
+        searchSpec: (query: string) => this.bot.searchSpec(query),
+      });
+      result.tests++;
+      if (outcome.success) result.passed++;
+      else result.failed++;
+    }
+
+    this.bot.savePlan(style);
+  }
+}
+
+export interface ExploreResult {
+  tests: number;
+  passed: number;
+  failed: number;
+}

--- a/boat/api-tester/src/commands/explore-command.ts
+++ b/boat/api-tester/src/commands/explore-command.ts
@@ -1,3 +1,5 @@
+import figureSet from 'figures';
+import { tag } from '../../../../src/utils/logger.ts';
 import { getStyles } from '../ai/chief/styles.ts';
 import { ApiCommand } from './api-command.ts';
 
@@ -13,23 +15,22 @@ export class ExploreCommand extends ApiCommand {
     for (const [index, target] of endpoints.entries()) {
       let runStyles = [styles[index % styles.length]];
       if (endpoints.length === 1) runStyles = styles;
-      if (endpoints.length > 1) console.log(`\n=== Endpoint ${index + 1}/${endpoints.length}: ${target} ===`);
+      if (endpoints.length > 1) tag('info').log(`Endpoint ${index + 1}/${endpoints.length}: ${target}`);
 
       for (const style of runStyles) {
         await this.runStyle(target, style);
       }
     }
 
-    console.log('\n=== Final Results ===');
-    console.log(`Total: ${this.result.tests} tests, ${this.result.passed} passed, ${this.result.failed} failed`);
+    tag('info').log(`${figureSet.tick} ${this.result.tests} tests completed: ${this.result.passed} passed, ${this.result.failed} failed`);
   }
 
   private async runStyle(endpoint: string, style: string): Promise<void> {
-    console.log(`\n=== Style: ${style} ===\n`);
+    tag('info').log(`Planning style: ${style}`);
 
     const plan = await this.bot.plan(endpoint, { style, fresh: true });
     if (!plan?.tests.length) {
-      console.log(`No tests generated for style: ${style}`);
+      tag('warning').log(`No tests generated for style: ${style}`);
       return;
     }
 

--- a/boat/api-tester/src/commands/init-command.ts
+++ b/boat/api-tester/src/commands/init-command.ts
@@ -1,0 +1,116 @@
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import chalk from 'chalk';
+import { envTemplate, modelLines } from '../../../../src/commands/init-command.ts';
+import { missingModelRoles } from '../../../../src/config.ts';
+import { log, tag } from '../../../../src/utils/logger.ts';
+
+export async function runInit(options: InitOptions): Promise<void> {
+  const provider = options.provider || 'openrouter';
+  const originalCwd = process.cwd();
+
+  if (options.path) {
+    const dir = path.resolve(options.path);
+    mkdirSync(dir, { recursive: true });
+    process.chdir(dir);
+    log(`Working in directory: ${dir}`);
+  }
+
+  const configPath = path.resolve('apibot.config.js');
+  if (existsSync(configPath) && !options.force) {
+    log(`Config file already exists: ${configPath}`);
+    log('Use --force to overwrite existing file');
+    process.exit(1);
+  }
+
+  const answers = await ask(options);
+  if (!answers.baseEndpoint) {
+    tag('error').log('Base endpoint is required.');
+    process.exit(1);
+  }
+
+  writeFileSync(configPath, configTemplate(provider, answers.baseEndpoint, answers.spec), 'utf8');
+  log(`Created config file: ${configPath}`);
+
+  const envPath = path.resolve('.env');
+  if (!existsSync(envPath)) {
+    writeFileSync(envPath, `${envTemplate(provider)}\n`, 'utf8');
+    log(`Created env file: ${envPath}`);
+  }
+
+  mkdirSync('output', { recursive: true });
+  mkdirSync('knowledge', { recursive: true });
+
+  if (answers.knowledge) {
+    const knowledgePath = path.resolve('knowledge', 'general.md');
+    writeFileSync(knowledgePath, `---\nendpoint: "*"\n---\n${answers.knowledge}\n`, 'utf8');
+    log(`Created knowledge file: ${knowledgePath}`);
+  }
+
+  const missing = missingModelRoles(provider);
+  if (missing.length) {
+    tag('warning').log(`No recommended ${missing.join(' and ')} for ${provider} — set the model ids in ${configPath}`);
+  }
+
+  log('');
+  log('Next steps:');
+  log('1. Add your provider API key to .env');
+  log('2. Describe the API so the plans match it');
+  tag('substep').log(chalk.yellow(`${options.prefix} know /users "CRUD endpoint for user management"`));
+  log('3. Plan and run tests for one endpoint');
+  tag('substep').log(chalk.yellow(`${options.prefix} explore /users`));
+
+  if (process.cwd() !== originalCwd) process.chdir(originalCwd);
+}
+
+function configTemplate(provider: string, baseEndpoint: string, spec: string): string {
+  let specLine = '';
+  if (spec) specLine = `\n    spec: ['${spec}'],`;
+
+  return `// Models are written as 'provider/model-id' so they resolve without a local node_modules.
+// https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
+
+export default {
+  ai: {
+${modelLines(provider, ['model', 'agenticModel'])}
+  },
+
+  api: {
+    baseEndpoint: '${baseEndpoint}',${specLine}
+  },
+};
+`;
+}
+
+async function ask(options: InitOptions): Promise<Answers> {
+  if (options.baseEndpoint) {
+    return { baseEndpoint: options.baseEndpoint, spec: options.spec || '', knowledge: '' };
+  }
+
+  const rl = await import('node:readline');
+  const iface = rl.createInterface({ input: process.stdin, output: process.stdout });
+  const question = (text: string): Promise<string> => new Promise((resolve) => iface.question(text, (answer: string) => resolve(answer.trim())));
+
+  log('Apibot — API Testing Tool Setup\n');
+  const baseEndpoint = await question('Base API endpoint (e.g. https://api.example.com/v1): ');
+  const spec = await question('OpenAPI spec file or URL (Enter to skip): ');
+  const knowledge = await question('Describe your API, its auth and its rules (Enter to skip): ');
+  iface.close();
+
+  return { baseEndpoint, spec, knowledge };
+}
+
+interface InitOptions {
+  force?: boolean;
+  path?: string;
+  provider?: string;
+  baseEndpoint?: string;
+  spec?: string;
+  prefix: string;
+}
+
+interface Answers {
+  baseEndpoint: string;
+  spec: string;
+  knowledge: string;
+}

--- a/boat/api-tester/src/commands/init-command.ts
+++ b/boat/api-tester/src/commands/init-command.ts
@@ -29,6 +29,11 @@ export async function runInit(options: InitOptions): Promise<void> {
     process.exit(1);
   }
 
+  if (!answers.spec) {
+    tag('error').log('OpenAPI spec is required. Chief plans from it and Curler looks up schemas in it.');
+    process.exit(1);
+  }
+
   writeFileSync(configPath, configTemplate(provider, answers.baseEndpoint, answers.spec), 'utf8');
   log(`Created config file: ${configPath}`);
 
@@ -64,9 +69,6 @@ export async function runInit(options: InitOptions): Promise<void> {
 }
 
 function configTemplate(provider: string, baseEndpoint: string, spec: string): string {
-  let specLine = '';
-  if (spec) specLine = `\n    spec: ['${spec}'],`;
-
   return `// Models are written as 'provider/model-id' so they resolve without a local node_modules.
 // https://github.com/testomatio/explorbot/blob/main/docs/basics/providers.md
 
@@ -76,7 +78,8 @@ ${modelLines(provider, ['model', 'agenticModel'])}
   },
 
   api: {
-    baseEndpoint: '${baseEndpoint}',${specLine}
+    baseEndpoint: '${baseEndpoint}',
+    spec: ['${spec}'],
   },
 };
 `;
@@ -93,7 +96,7 @@ async function ask(options: InitOptions): Promise<Answers> {
 
   log('Apibot — API Testing Tool Setup\n');
   const baseEndpoint = await question('Base API endpoint (e.g. https://api.example.com/v1): ');
-  const spec = await question('OpenAPI spec file or URL (Enter to skip): ');
+  const spec = await question('OpenAPI spec file or URL: ');
   const knowledge = await question('Describe your API, its auth and its rules (Enter to skip): ');
   iface.close();
 

--- a/boat/api-tester/src/commands/know-command.ts
+++ b/boat/api-tester/src/commands/know-command.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { ApiCommand } from './api-command.ts';
+
+export class KnowCommand extends ApiCommand {
+  name = 'know';
+  aliases = ['add-knowledge'];
+  description = 'Add API knowledge for an endpoint';
+  knowledge = '';
+
+  async execute(endpoint: string): Promise<void> {
+    if (!this.knowledge) {
+      throw new Error('Description is required.');
+    }
+
+    const knowledgeDir = await this.resolveKnowledgeDir();
+    fs.mkdirSync(knowledgeDir, { recursive: true });
+
+    const filename = endpoint.replace(/^\//, '').replace(/[^a-zA-Z0-9]/g, '_') || 'general';
+    const filePath = path.join(knowledgeDir, `${filename}.md`);
+
+    if (fs.existsSync(filePath)) {
+      fs.appendFileSync(filePath, `\n---\n${this.knowledge}\n`, 'utf8');
+      console.log(`Updated: ${filePath}`);
+      return;
+    }
+
+    fs.writeFileSync(filePath, `---\nendpoint: "${endpoint}"\n---\n${this.knowledge}\n`, 'utf8');
+    console.log(`Created: ${filePath}`);
+  }
+
+  private async resolveKnowledgeDir(): Promise<string> {
+    const parser = this.bot.getConfigParser();
+    const options = this.bot.getOptions();
+    try {
+      await parser.loadConfig(options);
+      return parser.getKnowledgeDir();
+    } catch {
+      if (options.path) return path.join(path.resolve(options.path), 'knowledge');
+      return 'knowledge';
+    }
+  }
+}

--- a/boat/api-tester/src/commands/know-command.ts
+++ b/boat/api-tester/src/commands/know-command.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { tag } from '../../../../src/utils/logger.ts';
 import { ApiCommand } from './api-command.ts';
 
 export class KnowCommand extends ApiCommand {
@@ -21,12 +22,12 @@ export class KnowCommand extends ApiCommand {
 
     if (fs.existsSync(filePath)) {
       fs.appendFileSync(filePath, `\n---\n${this.knowledge}\n`, 'utf8');
-      console.log(`Updated: ${filePath}`);
+      tag('success').log(`Updated: ${filePath}`);
       return;
     }
 
     fs.writeFileSync(filePath, `---\nendpoint: "${endpoint}"\n---\n${this.knowledge}\n`, 'utf8');
-    console.log(`Created: ${filePath}`);
+    tag('success').log(`Created: ${filePath}`);
   }
 
   private async resolveKnowledgeDir(): Promise<string> {

--- a/boat/api-tester/src/commands/plan-command.ts
+++ b/boat/api-tester/src/commands/plan-command.ts
@@ -1,4 +1,5 @@
-import path from 'node:path';
+import { tag } from '../../../../src/utils/logger.ts';
+import { type NextStepSection, printNextSteps, relativeToCwd } from '../../../../src/utils/next-steps.ts';
 import { ApiCommand } from './api-command.ts';
 
 export class PlanCommand extends ApiCommand {
@@ -15,19 +16,27 @@ export class PlanCommand extends ApiCommand {
       throw new Error('No test scenarios generated.');
     }
 
-    console.log(`\nPlan: ${plan.title} (${plan.tests.length} tests)\n`);
-    plan.tests.forEach((test, i) => {
-      console.log(`  ${i + 1}. [${test.priority}] ${test.scenario}`);
-    });
+    const lines = [`Plan: ${plan.title} (${plan.tests.length} tests)`];
+    for (const [i, test] of plan.tests.entries()) {
+      lines.push(`  ${String(i + 1).padStart(2)}. [${test.priority}] ${test.scenario}`);
+    }
+    tag('multiline').log(lines.join('\n'), { maxLines: 24 });
 
     const savedPath = this.bot.savePlan();
     if (!savedPath) return;
 
-    const relative = path.relative(process.cwd(), savedPath);
-    console.log(`\nSaved to: ${relative}`);
-    console.log('\nRun tests:');
-    console.log(`  ${this.prefix} test ${relative} 1       # run first test`);
-    console.log(`  ${this.prefix} test ${relative} 1-3     # run tests 1 to 3`);
-    console.log(`  ${this.prefix} test ${relative} *       # run all tests`);
+    const relative = relativeToCwd(savedPath);
+    const sections: NextStepSection[] = [
+      {
+        label: 'Plan',
+        path: savedPath,
+        commands: [
+          { label: 'Run first', command: `${this.prefix} test ${relative} 1` },
+          { label: 'Run all', command: `${this.prefix} test ${relative} *` },
+          { label: 'Run range', command: `${this.prefix} test ${relative} 1-3` },
+        ],
+      },
+    ];
+    printNextSteps(sections);
   }
 }

--- a/boat/api-tester/src/commands/plan-command.ts
+++ b/boat/api-tester/src/commands/plan-command.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import { ApiCommand } from './api-command.ts';
+
+export class PlanCommand extends ApiCommand {
+  name = 'plan';
+  description = 'Generate a test plan for an API endpoint';
+  style?: string;
+  fresh = false;
+
+  async execute(endpoint: string): Promise<void> {
+    await this.bot.plan(endpoint, { style: this.style, fresh: this.fresh });
+
+    const plan = this.bot.getCurrentPlan();
+    if (!plan?.tests.length) {
+      throw new Error('No test scenarios generated.');
+    }
+
+    console.log(`\nPlan: ${plan.title} (${plan.tests.length} tests)\n`);
+    plan.tests.forEach((test, i) => {
+      console.log(`  ${i + 1}. [${test.priority}] ${test.scenario}`);
+    });
+
+    const savedPath = this.bot.savePlan();
+    if (!savedPath) return;
+
+    const relative = path.relative(process.cwd(), savedPath);
+    console.log(`\nSaved to: ${relative}`);
+    console.log('\nRun tests:');
+    console.log(`  ${this.prefix} test ${relative} 1       # run first test`);
+    console.log(`  ${this.prefix} test ${relative} 1-3     # run tests 1 to 3`);
+    console.log(`  ${this.prefix} test ${relative} *       # run all tests`);
+  }
+}

--- a/boat/api-tester/src/commands/test-command.ts
+++ b/boat/api-tester/src/commands/test-command.ts
@@ -1,4 +1,6 @@
+import figureSet from 'figures';
 import type { Test } from '../../../../src/test-plan.ts';
+import { tag } from '../../../../src/utils/logger.ts';
 import { ApiCommand } from './api-command.ts';
 
 export class TestCommand extends ApiCommand {
@@ -9,10 +11,10 @@ export class TestCommand extends ApiCommand {
 
   async execute(planfile: string): Promise<void> {
     const plan = this.bot.loadPlan(planfile);
-    console.log(`Plan loaded: "${plan.title}" (${plan.tests.length} tests)`);
+    tag('info').log(`Plan loaded: "${plan.title}" (${plan.tests.length} tests)`);
 
     const tests = selectTests(plan.tests, this.index);
-    console.log(`Running ${tests.length} test(s)\n`);
+    tag('info').log(`Running ${tests.length} test(s)`);
 
     let passed = 0;
     for (const test of tests) {
@@ -22,7 +24,7 @@ export class TestCommand extends ApiCommand {
     }
 
     this.bot.savePlan();
-    console.log(`\nResults: ${passed} passed, ${this.failed} failed out of ${tests.length}`);
+    tag('info').log(`${figureSet.tick} ${tests.length} tests completed: ${passed} passed, ${this.failed} failed`);
   }
 }
 

--- a/boat/api-tester/src/commands/test-command.ts
+++ b/boat/api-tester/src/commands/test-command.ts
@@ -1,0 +1,52 @@
+import type { Test } from '../../../../src/test-plan.ts';
+import { ApiCommand } from './api-command.ts';
+
+export class TestCommand extends ApiCommand {
+  name = 'test';
+  description = 'Execute tests from a plan file. Index: 1, 1-3, *';
+  index?: string;
+  failed = 0;
+
+  async execute(planfile: string): Promise<void> {
+    const plan = this.bot.loadPlan(planfile);
+    console.log(`Plan loaded: "${plan.title}" (${plan.tests.length} tests)`);
+
+    const tests = selectTests(plan.tests, this.index);
+    console.log(`Running ${tests.length} test(s)\n`);
+
+    let passed = 0;
+    for (const test of tests) {
+      const result = await this.bot.runTest(test);
+      if (result.success) passed++;
+      else this.failed++;
+    }
+
+    this.bot.savePlan();
+    console.log(`\nResults: ${passed} passed, ${this.failed} failed out of ${tests.length}`);
+  }
+}
+
+export function selectTests(tests: Test[], index?: string): Test[] {
+  if (!index || index === '*' || index === 'all') {
+    return tests.filter((t) => t.status === 'pending');
+  }
+
+  const rangeMatch = index.match(/^(\d+)-(\d+)$/);
+  if (rangeMatch) {
+    const start = Number.parseInt(rangeMatch[1]) - 1;
+    const end = Number.parseInt(rangeMatch[2]);
+    return tests.slice(start, end);
+  }
+
+  if (index.includes(',')) {
+    const indices = index.split(',').map((i) => Number.parseInt(i.trim()) - 1);
+    return indices.map((i) => tests[i]).filter(Boolean);
+  }
+
+  const num = Number.parseInt(index);
+  if (!Number.isNaN(num) && tests[num - 1]) {
+    return [tests[num - 1]];
+  }
+
+  return tests.filter((t) => t.status === 'pending');
+}

--- a/docs/api-testing/basics.md
+++ b/docs/api-testing/basics.md
@@ -66,7 +66,7 @@ npx explorbot api explore https://api.example.com/v1 \
   -H "Authorization: Bearer $TOKEN"
 ```
 
-`api explore` takes the base endpoint as its argument, so one line covers the whole run: it plans in every style, executes each plan, and reports the totals. The other commands take a path within the API and read the base from `--endpoint`:
+`api explore` takes an endpoint or a pattern as its argument, so one line covers the whole run: it plans, executes each plan, and reports the totals. Passing the base endpoint covers every collection the spec describes. The other commands take a path within the API and read the base from `--endpoint`:
 
 ```bash
 npx explorbot api plan /users \
@@ -98,6 +98,30 @@ npx explorbot api test output/plans/users.md
 ```
 
 Curler runs the scenarios and prints how many passed and failed.
+
+### Covering many endpoints
+
+`api explore` runs the whole loop for you: plan, test, re-plan. Given one endpoint it plans in every style.
+
+```bash
+npx explorbot api explore /users
+```
+
+The endpoint may be a pattern. `*` stands for one path segment, and a pattern also covers the paths below it, so `/users` and `/users/*` both cover `/users/{id}`. Quote it, or your shell will try to expand it first.
+
+```bash
+npx explorbot api explore '/projects/acme/*'
+```
+
+Explorbot explores collections, not raw paths: `/users/{id}` and `/users/{id}/posts` fold into `/users`, whose spec lookup brings them along anyway. When a pattern matches several collections the planning styles spread across them, one style each, so a wide run costs about what a narrow one does.
+
+Pass `/` to take every collection in the spec. The path parameters have to come from somewhere, so put them in the base endpoint.
+
+```bash
+npx explorbot api explore / --endpoint https://api.example.com/v2/acme
+```
+
+If a parameter is left with no value the run stops and names it, rather than sending requests to a literal `{project_id}`. Collections whose own parameters no pattern can fill, like `/analytics/stats/{kind}`, are listed and skipped.
 
 ## Output files
 

--- a/docs/api-testing/basics.md
+++ b/docs/api-testing/basics.md
@@ -113,7 +113,7 @@ The endpoint may be a pattern. `*` stands for one path segment, and a pattern al
 npx explorbot api explore '/projects/acme/*'
 ```
 
-Explorbot explores collections, not raw paths: `/users/{id}` and `/users/{id}/posts` fold into `/users`, whose spec lookup brings them along anyway. When a pattern matches several collections the planning styles spread across them, one style each, so a wide run costs about what a narrow one does.
+Explorbot explores collections, not raw paths: `/users/{id}` and `/users/{id}/posts` fold into `/users`, whose spec lookup brings them along anyway. When a pattern matches several collections the planning styles spread across them, one style per collection, so covering a whole API stays one plan per collection rather than one per style.
 
 Pass `/` to take every collection in the spec. The path parameters have to come from somewhere, so put them in the base endpoint.
 

--- a/docs/api-testing/basics.md
+++ b/docs/api-testing/basics.md
@@ -81,7 +81,7 @@ The base endpoint keeps its path prefix: given `https://api.example.com/v1`, ste
 
 ### A dedicated API project
 
-If you don't have a web `explorbot.config.js`, run `npx explorbot api init`. It asks for your base endpoint, spec, and a one-line description of the API, then writes a standalone `apibot.config.ts` (with an `ai` and `api` section) plus `output/` and `knowledge/` directories. When both files exist, `apibot.config.*` takes precedence over `explorbot.config.*`.
+If you don't have a web `explorbot.config.js`, run `npx explorbot api init`. It asks for your base endpoint, spec, and a one-line description of the API, then writes a standalone `apibot.config.js` (with an `ai` and `api` section) plus `output/` and `knowledge/` directories. When both files exist, `apibot.config.*` takes precedence over `explorbot.config.*`.
 
 ## Your first run
 

--- a/src/api/spec-reader.ts
+++ b/src/api/spec-reader.ts
@@ -74,8 +74,8 @@ export function resolveEndpoints(schema: any, pattern: string, baseEndpoint?: st
     throw new Error(`Endpoint "${pattern}" not found in spec. Available: ${listNormalizedPaths(schema, basePath)}`);
   }
 
-  const roots = [...new Set(matched.map((specPath) => toCollection(specPath, normalized)))];
-  const resolved = roots.map((root) => fillParameters(root, pattern));
+  const roots = matched.map((specPath) => toCollection(specPath, normalized, pattern));
+  const resolved = [...new Set(roots.map((root) => fillParameters(root, pattern)))];
   const endpoints = resolved.filter((specPath) => !specPath.includes('{'));
 
   if (!endpoints.length) {
@@ -230,12 +230,19 @@ function segmentsMatch(segments: string[], wanted: string[]): boolean {
   return wanted.every((want, i) => want === '*' || segments[i] === want || segments[i].startsWith('{'));
 }
 
-function toCollection(specPath: string, specPaths: string[]): string {
+function toCollection(specPath: string, specPaths: string[], pattern: string): string {
   const segments = toSegments(specPath);
-  for (let i = 1; i < segments.length; i++) {
+  const filled = toSegments(fillParameters(specPath, pattern));
+
+  let deepest = segments.length;
+  const unfilled = filled.findIndex((segment) => segment.startsWith('{'));
+  if (unfilled >= 0) deepest = unfilled;
+
+  for (let i = Math.max(1, Math.min(toSegments(pattern).length, deepest)); i <= deepest; i++) {
     const prefix = `/${segments.slice(0, i).join('/')}`;
     if (specPaths.includes(prefix)) return prefix;
   }
+
   return specPath;
 }
 

--- a/src/api/spec-reader.ts
+++ b/src/api/spec-reader.ts
@@ -51,7 +51,7 @@ export function extractEndpointDefinition(schema: any, endpoint: string, baseEnd
   }
 
   const basePath = toBasePath(baseEndpoint);
-  const matched = collectMatchingPaths(schema, basePath, (normalized) => matchesEndpoint(normalized, endpoint));
+  const matched = collectEndpointPaths(schema, basePath, endpoint);
 
   if (!Object.keys(matched).length) {
     const available = listNormalizedPaths(schema, basePath);
@@ -59,6 +59,35 @@ export function extractEndpointDefinition(schema: any, endpoint: string, baseEnd
   }
 
   return safeStringify(matched);
+}
+
+export function resolveEndpoints(schema: any, pattern: string, baseEndpoint?: string): string[] {
+  if (!schema?.paths) {
+    throw new Error('OpenAPI spec has no paths defined');
+  }
+
+  const basePath = toBasePath(baseEndpoint);
+  const normalized = Object.keys(schema.paths).map((specPath) => stripBasePath(specPath, basePath));
+  const matched = normalized.filter((specPath) => matchesPattern(specPath, pattern));
+
+  if (!matched.length) {
+    throw new Error(`Endpoint "${pattern}" not found in spec. Available: ${listNormalizedPaths(schema, basePath)}`);
+  }
+
+  const roots = [...new Set(matched.map((specPath) => toCollection(specPath, normalized)))];
+  const resolved = roots.map((root) => fillParameters(root, pattern));
+  const endpoints = resolved.filter((specPath) => !specPath.includes('{'));
+
+  if (!endpoints.length) {
+    throw new Error(`Endpoint "${pattern}" leaves ${listParameters(resolved)} unresolved. Give the value in the endpoint or in the base endpoint.`);
+  }
+
+  const skipped = resolved.filter((specPath) => specPath.includes('{'));
+  if (skipped.length) {
+    tag('warning').log(`Skipped, no value for their parameters: ${skipped.join(', ')}`);
+  }
+
+  return endpoints;
 }
 
 export function searchEndpoints(schema: any, query: string, baseEndpoint?: string): string {
@@ -164,6 +193,75 @@ function stripBasePath(specPath: string, basePath: string): string {
   }
 
   return `/${specSegments.slice(i).join('/')}`;
+}
+
+function collectEndpointPaths(schema: any, basePath: string, endpoint: string): Record<string, any> {
+  const normalized = Object.keys(schema.paths).map((specPath) => stripBasePath(specPath, basePath));
+  const roots = resolveEndpoint(normalized, endpoint);
+
+  if (!roots.length) return collectMatchingPaths(schema, basePath, (path) => matchesEndpoint(path, endpoint));
+
+  return collectMatchingPaths(schema, basePath, (path) => roots.some((root) => path === root || path.startsWith(`${root}/`)));
+}
+
+function resolveEndpoint(specPaths: string[], endpoint: string): string[] {
+  const wanted = toSegments(endpoint);
+  if (!wanted.length) return [];
+
+  const matched = specPaths.filter((specPath) => {
+    const segments = toSegments(specPath);
+    if (segments.length !== wanted.length) return false;
+    return segmentsMatch(segments, wanted);
+  });
+
+  const literals = matched.map((specPath) => toSegments(specPath).filter((segment, i) => segment === wanted[i]).length);
+  const best = Math.max(0, ...literals);
+  return matched.filter((_, i) => literals[i] === best);
+}
+
+function matchesPattern(specPath: string, pattern: string): boolean {
+  const wanted = toSegments(pattern);
+  const segments = toSegments(specPath);
+  if (segments.length < wanted.length) return false;
+  return segmentsMatch(segments, wanted);
+}
+
+function segmentsMatch(segments: string[], wanted: string[]): boolean {
+  return wanted.every((want, i) => want === '*' || segments[i] === want || segments[i].startsWith('{'));
+}
+
+function toCollection(specPath: string, specPaths: string[]): string {
+  const segments = toSegments(specPath);
+  for (let i = 1; i < segments.length; i++) {
+    const prefix = `/${segments.slice(0, i).join('/')}`;
+    if (specPaths.includes(prefix)) return prefix;
+  }
+  return specPath;
+}
+
+function fillParameters(specPath: string, pattern: string): string {
+  const wanted = toSegments(pattern);
+  const segments = toSegments(specPath);
+  for (let i = 0; i < wanted.length && i < segments.length; i++) {
+    if (wanted[i] === '*') continue;
+    if (!segments[i].startsWith('{')) continue;
+    segments[i] = wanted[i];
+  }
+  return `/${segments.join('/')}`;
+}
+
+function listParameters(specPaths: string[]): string {
+  const found = new Set<string>();
+  for (const specPath of specPaths) {
+    for (const segment of toSegments(specPath)) {
+      if (segment.startsWith('{')) found.add(segment);
+    }
+  }
+  return [...found].join(', ');
+}
+
+function toSegments(path: string): string[] {
+  return path.split('/').filter(Boolean);
 }
 
 function matchesEndpoint(specPath: string, endpoint: string): boolean {

--- a/src/commands/base-command.ts
+++ b/src/commands/base-command.ts
@@ -15,7 +15,7 @@ export interface Suggestion {
   hint: string;
 }
 
-export abstract class BaseCommand {
+export abstract class BaseCommand<T = ExplorBot> {
   abstract name: string;
   abstract description: string;
   aliases: string[] = [];
@@ -23,9 +23,9 @@ export abstract class BaseCommand {
   tuiEnabled = true;
   suggestions: Suggestion[] = [];
 
-  protected explorBot: ExplorBot;
+  protected explorBot: T;
 
-  constructor(explorBot: ExplorBot) {
+  constructor(explorBot: T) {
     this.explorBot = explorBot;
   }
 

--- a/src/commands/init-command.ts
+++ b/src/commands/init-command.ts
@@ -39,7 +39,7 @@ ${moduleExport}
 `;
 }
 
-function envTemplate(provider: string): string {
+export function envTemplate(provider: string): string {
   const keyLines = Object.entries(PROVIDERS).map(([name, { envKey }]) => {
     if (name === provider) return `${envKey}=`;
     return `# ${envKey}=`;
@@ -253,7 +253,7 @@ async function renderLocalProviderWizard(): Promise<string | null> {
   });
 }
 
-function modelLines(provider: string): string {
+export function modelLines(provider: string, only?: ModelRole[]): string {
   const recommended = ConfigParser.recommendedModels()[provider] || {};
   const roles: Array<[ModelRole, string]> = [
     ['model', 'fast model with tool calling capabilities'],
@@ -261,7 +261,10 @@ function modelLines(provider: string): string {
     ['agenticModel', 'agentic model for decision making'],
   ];
 
-  return roles.map(([role, comment]) => `    // ${comment}\n    ${role}: '${provider}/${recommended[role] || '<model-id>'}',`).join('\n');
+  let selected = roles;
+  if (only) selected = roles.filter(([role]) => only.includes(role));
+
+  return selected.map(([role, comment]) => `    // ${comment}\n    ${role}: '${provider}/${recommended[role] || '<model-id>'}',`).join('\n');
 }
 
 function globalConfigTemplate(provider: string): string {

--- a/tests/unit/apibot-explore.test.ts
+++ b/tests/unit/apibot-explore.test.ts
@@ -19,17 +19,12 @@ function fakeBot(endpoints: string[], planned: Planned[], results: boolean[] = [
       plan.addTest(new Test(`check ${endpoint}`, 'normal', ['200 OK'], endpoint, []));
       return plan;
     },
-    agentCurler: () => ({
-      test: async () => {
-        const success = results[attempt % results.length];
-        attempt++;
-        return { success };
-      },
-    }),
-    tryGetEndpointDefinition: () => undefined,
-    searchSpec: () => '',
+    runTest: async () => {
+      const success = results[attempt % results.length];
+      attempt++;
+      return { success };
+    },
     savePlan: () => null,
-    getConfig: () => ({ api: { baseEndpoint: 'https://api.example.com' } }),
   } as unknown as ApiBot;
 }
 
@@ -61,8 +56,9 @@ describe('ExploreCommand', () => {
   });
 
   it('counts every test it ran', async () => {
-    const result = await new ExploreCommand(fakeBot(['/a', '/b'], [], [true, false])).execute('/*');
+    const command = new ExploreCommand(fakeBot(['/a', '/b'], [], [true, false]));
+    await command.execute('/*');
 
-    expect(result).toEqual({ tests: 2, passed: 1, failed: 1 });
+    expect(command.result).toEqual({ tests: 2, passed: 1, failed: 1 });
   });
 });

--- a/tests/unit/apibot-explore.test.ts
+++ b/tests/unit/apibot-explore.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+import type { ApiBot } from '../../boat/api-tester/src/apibot.ts';
+import { ExploreCommand } from '../../boat/api-tester/src/commands/explore-command.ts';
+import { Plan, Test } from '../../src/test-plan.ts';
+
+interface Planned {
+  endpoint: string;
+  style: string;
+}
+
+function fakeBot(endpoints: string[], planned: Planned[], results: boolean[] = [true]): ApiBot {
+  let attempt = 0;
+  return {
+    expandEndpoints: () => endpoints,
+    plan: async (endpoint: string, opts: { style: string }) => {
+      planned.push({ endpoint, style: opts.style });
+      const plan = new Plan(`Plan for ${endpoint}`);
+      plan.url = endpoint;
+      plan.addTest(new Test(`check ${endpoint}`, 'normal', ['200 OK'], endpoint, []));
+      return plan;
+    },
+    agentCurler: () => ({
+      test: async () => {
+        const success = results[attempt % results.length];
+        attempt++;
+        return { success };
+      },
+    }),
+    tryGetEndpointDefinition: () => undefined,
+    searchSpec: () => '',
+    savePlan: () => null,
+    getConfig: () => ({ api: { baseEndpoint: 'https://api.example.com' } }),
+  } as unknown as ApiBot;
+}
+
+describe('ExploreCommand', () => {
+  it('plans one endpoint in every style', async () => {
+    const planned: Planned[] = [];
+    await new ExploreCommand(fakeBot(['/users'], planned)).execute('/users');
+
+    expect(planned).toEqual([
+      { endpoint: '/users', style: 'normal' },
+      { endpoint: '/users', style: 'curious' },
+      { endpoint: '/users', style: 'psycho' },
+      { endpoint: '/users', style: 'hacker' },
+    ]);
+  });
+
+  it('gives each endpoint one style, wrapping around', async () => {
+    const planned: Planned[] = [];
+    const endpoints = ['/a', '/b', '/c', '/d', '/e'];
+    await new ExploreCommand(fakeBot(endpoints, planned)).execute('/*');
+
+    expect(planned).toEqual([
+      { endpoint: '/a', style: 'normal' },
+      { endpoint: '/b', style: 'curious' },
+      { endpoint: '/c', style: 'psycho' },
+      { endpoint: '/d', style: 'hacker' },
+      { endpoint: '/e', style: 'normal' },
+    ]);
+  });
+
+  it('counts every test it ran', async () => {
+    const result = await new ExploreCommand(fakeBot(['/a', '/b'], [], [true, false])).execute('/*');
+
+    expect(result).toEqual({ tests: 2, passed: 1, failed: 1 });
+  });
+});

--- a/tests/unit/apibot-init.test.ts
+++ b/tests/unit/apibot-init.test.ts
@@ -16,7 +16,7 @@ describe('apibot init', () => {
   });
 
   const init = async (extra: Record<string, unknown> = {}) => {
-    await runInit({ path: dir, baseEndpoint: 'https://api.example.com/v1', prefix: 'apibot', ...extra });
+    await runInit({ path: dir, baseEndpoint: 'https://api.example.com/v1', spec: 'openapi.yaml', prefix: 'apibot', ...extra });
     return readFileSync(join(dir, 'apibot.config.js'), 'utf8');
   };
 
@@ -44,8 +44,8 @@ describe('apibot init', () => {
     expect(config).not.toContain('headers');
   });
 
-  it('writes the spec when there is one', async () => {
-    const config = await init({ spec: 'openapi.yaml' });
+  it('writes the spec the run cannot start without', async () => {
+    const config = await init();
 
     expect(config).toContain("spec: ['openapi.yaml']");
   });

--- a/tests/unit/apibot-init.test.ts
+++ b/tests/unit/apibot-init.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInit } from '../../boat/api-tester/src/commands/init-command.ts';
+
+describe('apibot init', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'apibot-init-'));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const init = async (extra: Record<string, unknown> = {}) => {
+    await runInit({ path: dir, baseEndpoint: 'https://api.example.com/v1', prefix: 'apibot', ...extra });
+    return readFileSync(join(dir, 'apibot.config.js'), 'utf8');
+  };
+
+  it('writes a config the loader looks for', async () => {
+    const config = await init();
+
+    expect(config).toContain("baseEndpoint: 'https://api.example.com/v1'");
+  });
+
+  it('takes models from the provider recommendations', async () => {
+    const config = await init();
+
+    expect(config).toContain("model: 'openrouter/");
+    expect(config).toContain("agenticModel: 'openrouter/");
+    expect(config).not.toContain('gpt-4o');
+    expect(config).not.toContain('@ai-sdk');
+  });
+
+  it('leaves out defaults and commented-out blocks', async () => {
+    const config = await init();
+
+    expect(config).not.toContain('dirs');
+    expect(config).not.toContain('bootstrap');
+    expect(config).not.toContain('teardown');
+    expect(config).not.toContain('headers');
+  });
+
+  it('writes the spec when there is one', async () => {
+    const config = await init({ spec: 'openapi.yaml' });
+
+    expect(config).toContain("spec: ['openapi.yaml']");
+  });
+
+  it('writes an env file with the provider keys', async () => {
+    await init();
+
+    expect(readFileSync(join(dir, '.env'), 'utf8')).toContain('OPENROUTER_API_KEY=');
+  });
+});

--- a/tests/unit/spec-reader.test.ts
+++ b/tests/unit/spec-reader.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'bun:test';
+import { extractEndpointDefinition, listAllEndpoints, resolveEndpoints } from '../../src/api/spec-reader.ts';
+
+const schema = {
+  paths: {
+    '/api/v2/{project_id}/info': { get: { summary: 'Project info' } },
+    '/api/v2/{project_id}/tests': { get: { summary: 'List tests' }, post: { summary: 'Create test' } },
+    '/api/v2/{project_id}/tests/{id}': { get: { summary: 'Get test' } },
+    '/api/v2/{project_id}/suites': { get: { summary: 'List suites' } },
+    '/api/v2/{project_id}/suites/markdown_import': { post: { summary: 'Import markdown' } },
+    '/api/v2/{project_id}/suites/{id}': { get: { summary: 'Get suite' } },
+    '/api/v2/{project_id}/runs': { get: { summary: 'List runs' } },
+    '/api/v2/{project_id}/runs/{id}/stats/{dimension}': { get: { summary: 'Run stats' } },
+    '/api/v2/{project_id}/analytics/tests/{kind}': { get: { summary: 'Test analytics' } },
+  },
+};
+
+const matchedPaths = (endpoint: string, baseEndpoint?: string) => Object.keys(JSON.parse(extractEndpointDefinition(schema, endpoint, baseEndpoint)));
+
+describe('extractEndpointDefinition', () => {
+  it('matches a real path against a templated spec path', () => {
+    expect(matchedPaths('/api/v2/zyntra-don-t-touch-cloned/tests')).toEqual(['/api/v2/{project_id}/tests', '/api/v2/{project_id}/tests/{id}']);
+  });
+
+  it('matches a real path with every parameter filled in', () => {
+    expect(matchedPaths('/api/v2/zyntra/tests/42')).toEqual(['/api/v2/{project_id}/tests/{id}']);
+  });
+
+  it('prefers a literal segment over a parameter', () => {
+    expect(matchedPaths('/api/v2/zyntra/suites/markdown_import')).toEqual(['/api/v2/{project_id}/suites/markdown_import']);
+  });
+
+  it('still matches a templated path written out as is', () => {
+    expect(matchedPaths('/api/v2/{project_id}/tests')).toEqual(['/api/v2/{project_id}/tests', '/api/v2/{project_id}/tests/{id}']);
+  });
+
+  it('strips the base endpoint path', () => {
+    expect(matchedPaths('/zyntra/tests', 'https://beta.testomat.io/api/v2')).toEqual(['/api/v2/{project_id}/tests', '/api/v2/{project_id}/tests/{id}']);
+  });
+
+  it('throws when a segment is missing', () => {
+    expect(() => matchedPaths('/api/v2/tests')).toThrow('not found in spec');
+  });
+
+  it('throws for an unknown endpoint', () => {
+    expect(() => matchedPaths('/api/v2/zyntra/nope')).toThrow('not found in spec');
+  });
+});
+
+describe('listAllEndpoints', () => {
+  it('lists every method with its summary', () => {
+    expect(listAllEndpoints(schema)).toContain('GET /api/v2/{project_id}/tests - List tests');
+  });
+});
+
+describe('resolveEndpoints', () => {
+  it('folds a wildcard leaf back into its collection', () => {
+    expect(resolveEndpoints(schema, '/api/v2/zyntra/tests/*')).toEqual(['/api/v2/zyntra/tests']);
+  });
+
+  it('returns one endpoint per collection, in spec order', () => {
+    expect(resolveEndpoints(schema, '/api/v2/zyntra/*')).toEqual(['/api/v2/zyntra/info', '/api/v2/zyntra/tests', '/api/v2/zyntra/suites', '/api/v2/zyntra/runs']);
+  });
+
+  it('folds a deep path into its collection over a gap in the spec', () => {
+    expect(resolveEndpoints(schema, '/api/v2/zyntra/runs/*')).toEqual(['/api/v2/zyntra/runs']);
+  });
+
+  it('takes every collection when the base endpoint carries the parameters', () => {
+    expect(resolveEndpoints(schema, '/', 'https://beta.testomat.io/api/v2/zyntra')).toEqual(['/info', '/tests', '/suites', '/runs']);
+  });
+
+  it('reports the parameter it cannot fill in', () => {
+    expect(() => resolveEndpoints(schema, '/', 'https://beta.testomat.io')).toThrow('{project_id}');
+  });
+
+  it('returns a plain endpoint as it is', () => {
+    expect(resolveEndpoints(schema, '/api/v2/zyntra/tests')).toEqual(['/api/v2/zyntra/tests']);
+  });
+
+  it('throws for an unknown endpoint', () => {
+    expect(() => resolveEndpoints(schema, '/api/v2/zyntra/nope')).toThrow('not found in spec');
+  });
+});

--- a/tests/unit/spec-reader.test.ts
+++ b/tests/unit/spec-reader.test.ts
@@ -15,6 +15,17 @@ const schema = {
   },
 };
 
+const nested = {
+  paths: {
+    '/projects': { get: { summary: 'List projects' } },
+    '/projects/{id}': { get: { summary: 'Get project' } },
+    '/projects/{id}/tests': { get: { summary: 'List tests' } },
+    '/projects/{id}/tests/latest': { get: { summary: 'Latest test' } },
+    '/projects/{id}/tests/{test_id}': { get: { summary: 'Get test' } },
+    '/projects/{id}/suites': { get: { summary: 'List suites' } },
+  },
+};
+
 const matchedPaths = (endpoint: string, baseEndpoint?: string) => Object.keys(JSON.parse(extractEndpointDefinition(schema, endpoint, baseEndpoint)));
 
 describe('extractEndpointDefinition', () => {
@@ -80,5 +91,13 @@ describe('resolveEndpoints', () => {
 
   it('throws for an unknown endpoint', () => {
     expect(() => resolveEndpoints(schema, '/api/v2/zyntra/nope')).toThrow('not found in spec');
+  });
+
+  it('keeps nested collections apart when their parent is an endpoint of its own', () => {
+    expect(resolveEndpoints(nested, '/projects/acme/*')).toEqual(['/projects/acme/tests', '/projects/acme/suites']);
+  });
+
+  it('returns one endpoint when a literal path and a templated one fill in the same', () => {
+    expect(resolveEndpoints(nested, '/projects/acme/tests/latest')).toEqual(['/projects/acme/tests/latest']);
   });
 });


### PR DESCRIPTION
## The bug

apibot could not find a real path in its own spec. Specs write paths as templates, so `explore /api/v2/zyntra-don-t-touch-cloned/tests` against `/api/v2/{project_id}/tests` matched nothing and the run died before planning:

```
Failed: Endpoint "/api/v2/zyntra-don-t-touch-cloned/tests" not found in spec.
Available: /api/v2/{project_id}/info, /api/v2/{project_id}/tests, ...
```

`matchesEndpoint` compared strings. It is segment matching now: a template segment stands for any value, a literal segment wins over a template, and the paths below the match come along. So one collection hands the planner its create, read, update and delete. When nothing resolves it falls back to the old literal prefix match, so a wrong endpoint still gets the same error rather than the whole spec.

## Endpoint patterns

`api explore` takes a pattern instead of a single endpoint.

```bash
npx explorbot api explore /users                # one endpoint, every planning style
npx explorbot api explore '/projects/acme/*'    # every collection of one project
npx explorbot api explore / --endpoint https://api.example.com/v2/acme
```

`*` stands for one segment. Matches fold into their collection, so `/users/{id}` and `/users/{id}/posts` explore as `/users` and the deeper paths ride along in the spec lookup. `/` takes everything, with path parameters coming from the base endpoint.

One endpoint behaves exactly as before, every style. Several collections share the styles, one per collection, so covering a whole API is one plan per collection rather than one per style. Parameters the pattern cannot fill are named: a collection or two get skipped with a warning, and a run with nothing left stops and says which parameter is missing instead of sending requests to a literal `{project_id}`.

Against the Testomat.io v2 spec: `/tests` and `/tests/*` both resolve to one endpoint, `/<project>/*` to 19, skipping `/analytics/tests/{kind}` and `/analytics/stats/{kind}`.

## The command pattern

Every apibot command was a closure inside `cli.ts`, so none of them could be tested. They are `BaseCommand` classes now, one file each under `boat/api-tester/src/commands/`, and `cli.ts` drops from 325 lines to 146: build the bot, run the command, pick an exit code.

`BaseCommand` takes its collaborator as a type parameter, `BaseCommand<T = ExplorBot>`, so the thirty-five explorbot commands compile untouched and apibot's extend `BaseCommand<ApiBot>` through a small `ApiCommand` base that names the field `bot`. `init` stays a plain exported function, as `explorbot init` is, since there is no bot to hang it on.

The duplicated Curler invocation that `explore` and `test` both carried is now `ApiBot.runTest`.

## Init

The generated config named a model nobody here uses, behind an import of a package the project never installs:

```js
import { openai } from '@ai-sdk/openai';
export default {
  ai: { model: openai('gpt-4o') },
  api: { baseEndpoint: '...', headers: { /* 'Authorization': 'Bearer <token>' */ } },
  dirs: { output: 'output', knowledge: 'knowledge' },
};
```

Models now come from `ConfigParser.recommendedModels()` as `provider/model-id` strings, the way `explorbot init` writes them. The commented-out `bootstrap`/`teardown` blocks, the empty `headers` block and the `dirs` block that only restated the defaults are gone, a `.env` with the provider keys is written alongside, and the file is `apibot.config.js`, which is what the loader looks for first and what its own "config missing" error names. New `--provider`, `--endpoint` and `--spec` options skip the questions.

## Tests

`tests/unit/spec-reader.test.ts` (15), `tests/unit/apibot-explore.test.ts` (3, covering the style cycling the CLI could not reach), `tests/unit/apibot-init.test.ts` (5, asserting the template stays clean). Full unit suite: 1361 pass.

## Notes

- `plan` and `test` still take a single endpoint. `*` there stays undefined.
- No cap on a wide run, by choice.
- Chief already dedupes scenarios across a session, so the collections in one run will not repeat an identical scenario sentence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZkcbkiidWcYj4Cpo69pGL
