### PR TITLE
Give a dialog's own edge as its scope, and let research use it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@
 - [Tester] When a locator matches both an element and the container wrapping it, the match list now marks
   which one wraps the other. Those are one control listed at two depths rather than two candidates, so
   neither is worth retrying after the other has been clicked.
+- [Researcher] A dialog or panel that opens is now described with the container that bounds it, taken from
+  the area the page capture already worked out. Those sections used to arrive with no container at all, so
+  every step aimed at something inside the dialog had to be written without one, and matched the page
+  behind it just as readily.
+- Region detection: when a dialog cannot be told apart from a similar panel behind it because both carry
+  the same class, no container is reported instead of the largest thing inside the dialog. Naming an inner
+  list as the dialog's edge left its Cancel and confirm buttons outside the very scope meant to hold them.
+  Dialogs wrapped only in unnamed or utility-class layers resolve as before.
 
 ## 2026-09-09
 

--- a/src/ai/researcher/deep-analysis.ts
+++ b/src/ai/researcher/deep-analysis.ts
@@ -116,7 +116,7 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
       );
 
       tag('substep').log(`Researching overlay: ${region.name}`);
-      const sectionMarkdown = await this._analyzeExpandedAction('', region.name, diff, alreadyExpanded);
+      const sectionMarkdown = await this._analyzeExpandedAction('', region.name, diff, alreadyExpanded, region.root);
       if (!sectionMarkdown) {
         debugLog(`Overlay "${region.name}" produced no meaningful expansion`);
         return null;
@@ -421,9 +421,9 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
       await new Promise((r) => setTimeout(r, 500));
 
       let diff: Diff;
+      let currAR: ActionResult;
       try {
-        await this.explorer.capture();
-        const currAR = ActionResult.fromState(this.stateManager.getCurrentState()!);
+        currAR = await this.explorer.capture();
         diff = await currAR.diff(previousState);
       } catch (err) {
         tag('warning').log(`State capture failed after click: ${err instanceof Error ? err.message : err}`);
@@ -444,7 +444,7 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
         return { status: 'none', code: clickCode };
       }
 
-      const sectionMarkdown = await this._analyzeExpandedAction(clickCode, description, diff, alreadyExpanded);
+      const sectionMarkdown = await this._analyzeExpandedAction(clickCode, description, diff, alreadyExpanded, currAR.overlay.root);
       await this._restorePageState(state.url, originalAria);
       if (!sectionMarkdown) return { status: 'none', code: clickCode };
       return { status: 'revealed', code: clickCode, sectionMarkdown };
@@ -467,7 +467,7 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
       }
     }
 
-    private async _analyzeExpandedAction(code: string, description: string, diff: Diff, alreadyExpanded: string[]): Promise<string | null> {
+    private async _analyzeExpandedAction(code: string, description: string, diff: Diff, alreadyExpanded: string[], containerCss: string | null = null): Promise<string | null> {
       const alreadyHint = alreadyExpanded.length > 0 ? `\nAlready expanded sections:\n${alreadyExpanded.join('\n')}` : '';
 
       let intro: string;
@@ -532,7 +532,14 @@ export function WithDeepAnalysis<T extends Constructor>(Base: T) {
       const sections = parseResearchSections(text);
       if (sections.length === 0) return null;
 
-      return sections[0].rawMarkdown;
+      const sectionMarkdown = sections[0].rawMarkdown;
+      if (!containerCss) return sectionMarkdown;
+
+      let heading = mdq(sectionMarkdown).query('h3[0]');
+      if (heading.count() === 0) heading = mdq(sectionMarkdown).query('h2[0]');
+      if (heading.count() === 0) return sectionMarkdown;
+
+      return heading.replace(`${heading.text().trimEnd()}\n\n> Container: '${containerCss}'\n\n`);
     }
 
     private _deduplicateExpandedSections(sections: string[]): string[] {

--- a/src/utils/html-diff.ts
+++ b/src/utils/html-diff.ts
@@ -549,6 +549,8 @@ function semanticSelectorFor(element: ElementNode, allElements: NodeMap): string
   while (current) {
     const selector = buildContainerSelector(current, allElements);
     if (selector) return selector;
+    const classAttr = (current.attrs ?? []).find((a) => a.name === 'class')?.value;
+    if (classAttr && filterContainerClasses(classAttr.split(/\s+/).filter(Boolean)).length > 0) return undefined;
     current = dominantChild(current);
   }
   return undefined;

--- a/test-data/nested_app_modal.html
+++ b/test-data/nested_app_modal.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Plans</title>
+<style>
+  body { margin: 0; font: 14px system-ui, sans-serif; }
+  .main-app { padding: 16px; }
+  .side-nav a { margin-right: 12px; }
+  .panel-wrapper { position: absolute; inset: 0; }
+  .scrim { position: fixed; inset: 0; background: rgba(0, 0, 0, .4); }
+  .panel { position: fixed; top: 8%; left: 20%; width: 60%; height: 70%; background: #fff; overflow: auto; padding: 12px; }
+  #rows { list-style: none; padding: 0; }
+  #rows li { padding: 3px 0; border-bottom: 1px solid #eee; }
+</style>
+</head>
+<body>
+<div class="main-app">
+  <nav class="side-nav">
+    <a href="/tests">Tests</a>
+    <a href="/requirements">Requirements</a>
+    <a href="/plans">Plans</a>
+    <a href="/runs">Runs</a>
+  </nav>
+  <div class="panel-wrapper">
+    <div class="panel">
+      <h3>New Plan</h3>
+      <input id="plan-title" placeholder="Title">
+      <button id="open">Select tests</button>
+      <button id="save">Save</button>
+    </div>
+  </div>
+  <ul id="rows"></ul>
+</div>
+<script>
+  var rows = document.getElementById('rows');
+  for (var i = 1; i <= 300; i++) {
+    var li = document.createElement('li');
+    li.innerHTML = '<a href="/plans/' + i + '">Existing plan ' + i + '</a> <span>12 tests</span> <button>Sep 1, 2026</button>';
+    rows.appendChild(li);
+  }
+
+  document.getElementById('open').addEventListener('click', function () {
+    var app = document.querySelector('.main-app');
+    var wrapper = document.createElement('div');
+    wrapper.className = 'panel-wrapper';
+
+    var scrim = document.createElement('div');
+    scrim.className = 'scrim';
+
+    var panel = document.createElement('div');
+    panel.className = 'panel';
+
+    var items = '';
+    for (var n = 0; n < 60; n++) {
+      items += '<li><input type="checkbox" id="pick-' + n + '"><button>Suite ' + n + ' 1 tests</button></li>';
+    }
+    panel.innerHTML =
+      '<h3>Select tests for plan</h3>' +
+      '<input placeholder="Search">' +
+      '<ul class="test-list">' + items + '</ul>' +
+      '<button>Cancel</button>' +
+      '<button>Select 0 tests</button>';
+
+    wrapper.appendChild(scrim);
+    wrapper.appendChild(panel);
+    app.appendChild(wrapper);
+  });
+</script>
+</body>
+</html>

--- a/tests/integration/overlay-modal-browser.test.ts
+++ b/tests/integration/overlay-modal-browser.test.ts
@@ -181,3 +181,39 @@ describe('picker mounted inside the panel it covers, with no host of its own', (
     expect(region!.root).toBe('div.picker-dialog');
   });
 });
+
+describe('dialog whose wrapper class is shared with the panel behind it', () => {
+  let page: Page;
+  let diff: RegionDiff;
+
+  beforeAll(async () => {
+    page = await openFixture('nested_app_modal.html');
+    const before = await page.evaluate(captureHtmlForSnapshot);
+    await page.locator('#open').click();
+    await page.waitForSelector('.test-list');
+    const after = await page.evaluate(captureHtmlForSnapshot);
+    diff = await diffOf(before, after);
+  });
+
+  afterAll(async () => {
+    await page?.close();
+  });
+
+  it('cannot name the dialog by its own class, because the panel behind it shares one', async () => {
+    expect(diff.parts).toHaveLength(1);
+    expect(await page.locator('div.panel-wrapper').count()).toBe(2);
+  });
+
+  it('is still detected as an overlay, and named', async () => {
+    const region = await new OverlayPage(page).detectRegion(diff);
+    expect(region).not.toBeNull();
+    expect(region!.type).toBe('overlay');
+    expect(region!.name).toBe('Select tests for plan');
+  });
+
+  it('reports no root at all rather than one that misses the dialog controls', async () => {
+    const region = await new OverlayPage(page).detectRegion(diff);
+    expect(region!.root).toBeNull();
+    expect(await page.locator('ul.test-list').count()).toBe(1);
+  });
+});

--- a/tests/integration/researcher.test.ts
+++ b/tests/integration/researcher.test.ts
@@ -8,6 +8,7 @@ import { clearActivity } from '../../src/activity.ts';
 import { Provider } from '../../src/ai/provider.ts';
 import { Researcher } from '../../src/ai/researcher.ts';
 import { clearResearchCache, getCachedResearch, saveResearch } from '../../src/ai/researcher/cache.ts';
+import { parseResearchSections } from '../../src/ai/researcher/parser.ts';
 import { ConfigParser } from '../../src/config.ts';
 
 const UI_MAPS_DIR = join(process.cwd(), 'test-data', 'ui-maps');
@@ -246,5 +247,29 @@ describe('Researcher with aimock', () => {
     expect(htmlChanges).not.toContain('space-x-2');
     expect(htmlChanges).toContain('tree-node');
     expect(htmlChanges).toContain('Folder');
+  });
+
+  const EXPANSION_RESPONSE = "### Select tests for plan\n\nAn overlay appeared.\n\n| Element | ARIA | CSS |\n|---|---|---|\n| 'Cancel' | - | '.cancel' |\n";
+
+  it('stamps the detected region root as the expansion section container', async () => {
+    mock.clearFixtures();
+    mock.on({}, { content: EXPANSION_RESPONSE });
+
+    const section = await (researcher as any)._analyzeExpandedAction('', 'Select tests for plan', await buildExpansionDiff(2), [], '.panel');
+
+    const [parsed] = parseResearchSections(`# Extended Research\n\n${section}`);
+    expect(parsed.containerCss).toBe('.panel');
+    expect(parsed.elements).toHaveLength(1);
+  });
+
+  it('leaves the expansion section without a container when the region has no root', async () => {
+    mock.clearFixtures();
+    mock.on({}, { content: EXPANSION_RESPONSE });
+
+    const section = await (researcher as any)._analyzeExpandedAction('', 'Select tests for plan', await buildExpansionDiff(2), [], null);
+
+    const [parsed] = parseResearchSections(`# Extended Research\n\n${section}`);
+    expect(parsed.containerCss).toBeNull();
+    expect(parsed.elements).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## What

A region detected from a page diff could come back rooted at an element *inside* itself. When a dialog's own wrapper class is shared with a panel already on the page, that wrapper can't be named uniquely, so the search for something nameable kept descending — in the new fixture, all the way to the test list inside the dialog. The dialog's `Cancel` and confirm buttons then sat outside the very scope meant to hold them.

Two changes:

- **`semanticSelectorFor` stops descending** at the first element that has a meaningful class of its own but can't be named uniquely, and the region is reported with **no root** rather than one that isn't its edge. Wrappers with no class, or only utility classes, are still descended through — dialogs that resolved before are unaffected.
- **Deep analysis uses what the capture already worked out.** It now keeps the `ActionResult` that `explorer.capture()` returns instead of rebuilding one from state, and passes the detected region's root into the section it writes. The container is stamped onto the markdown after the model responds, so the model never sees or authors that selector.

Dropping the rebuild also removes a second full `htmlDiff` over the same two pages — the rebuilt `ActionResult` had a cold diff cache, so every drilled component was diffed twice.

## Why

Three sessions (`RadicalMarkedMoccasin667`, `AlertTerritorialGray955`, `DifficultInnovativeTomato394`) failed inside the same "Select tests for plan" dialog, each logging `region "New Plan" opened, scope: div.main-app`. With the app shell as the region's root, `#188`'s htmlParts replacement handed the tester the whole page under that selector while the click tool told it to use the container as context. It guessed containers instead — 9 `Element "<container>" was not found`, 7 `MultipleElementsFound`.

Not a release regression: the same dialog failed identically on 0.4.4 (`BrokenPossibleLime768`), with the same scope.

## Tests

`test-data/nested_app_modal.html` is new — a dialog that mounts inside the app subtree with no dedicated host, beside a panel sharing its wrapper class. No existing fixture covered that shape; `testomat_modal.html` and `dialog_modal.html` both mount into a dedicated empty host, and `inline_picker.html` has a uniquely-named dialog.

- `tests/integration/overlay-modal-browser.test.ts` — the dialog is still detected and named, and reports no root rather than one missing its controls
- `tests/integration/researcher.test.ts` — the section carries the region's container, and carries none when the region has no root

```
tests/unit/          1341 pass  0 fail
tests/integration/    129 pass  0 fail  1 skip
```

The three existing modal fixtures keep their roots (`#modal-overlays`, `#dialog-host`, `div.picker-dialog`), and `tests/unit/overlay-detection.test.ts`'s "descends through anonymous and utility-class wrappers" case still resolves `div.editor-modal`.

## Not covered here

The live `div.main-app` root is a second route to the same defect — the container fallback in `addedSubtrees` when `findStableContainer` walks up to the shell. The new fixture reproduces the too-narrow direction, not that one. Worth its own change once a fixture pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KjMRWNtcrbksR8P3YK33BZ