### PR TITLE
Tell the planner which region is open on the page it plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changes
 
+- [Planner] When a dialog or detail panel is open on the page being planned, the planner is now told which
+  one it is and plans tests for it first. It used to see every section of the page with nothing marking
+  the one on screen, and could fill a plan with controls that panel covers.
 - [Pilot] Text an app shows in a tooltip now reaches Pilot along with alerts and status messages. When a
   page refuses an action and explains why in a hover bubble, that sentence used to stay in the page HTML,
   which Pilot never sees — so a run could be judged, and reported, on a reason the app had already

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -452,12 +452,16 @@ export class Planner extends PlannerBase implements Agent {
       }
     }
 
+    let activeRegion = '';
+    if (state.overlay.isOpen) activeRegion = `Active region: ${state.overlay.describe()} — the user's current focus area. Plan tests for the controls inside it first.`;
+
     conversation.addUserText(dedent`
       ${this.buildApproach(style)}
 
       <context>
       URL: ${state.url || 'Unknown'}
       Title: ${state.title || 'Unknown'}
+      ${activeRegion}
       </context>
     `);
 

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -219,6 +219,22 @@ describe('Planner with aimock', () => {
     expect(prompt).toContain('One section is marked as **Focused**');
   });
 
+  it('names the active region in the planning context', async () => {
+    const state = { ...fakeState, overlay: { type: 'region', name: 'Task details', root: '.task-detail' } };
+    planner = new Planner({ ...createMockDeps(state), ai: provider } as any, { research: async () => taskBoardUiMap } as any);
+
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('Active region: region "Task details" opened, scope: .task-detail');
+  });
+
+  it('leaves the active region out when none is open', async () => {
+    await planner.plan();
+
+    expect(extractPromptText(mock.getLastRequest())).not.toContain('Active region');
+  });
+
   it('scopes one test to one verified operation', async () => {
     await planner.plan();
 


### PR DESCRIPTION
## What

When a region is open on the page being planned, the planning context now names it:

```
<context>
URL: …
Title: …
Active region: region "…" opened, scope: div.detail-view-content — the user's current focus area. Plan tests for the controls inside it first.
</context>
```

The line comes from `state.overlay.describe()`, the same region the capture already works out. With no region open, nothing is added.

## Why

The capture keeps the open dialog or panel on the state, and Tester, Pilot, Driller and the experience tracker all read it. The planner was the one agent left out: its `<context>` carried the URL and title only (`planner.ts:458-461`). Research's own `**Focused**` marker is not written when research runs without a screenshot, which is how the planner calls it. So on a page with a detail panel open, the planner saw every research section with nothing marking the one on screen.

In Langfuse trace `24df572d51603fd73cbe1c92742eee33` the planner ran on a suite page with that suite's detail panel open. The research listed the panel first, but three of the four scenarios began with "Close the suite detail panel" and went on to test quick-filter tabs the panel covers.

## Tests

- `tests/integration/planner.test.ts`: the context names the region when one is open, and has no `Active region` line when none is.

```
tests/unit/          1366 pass  0 fail
tests/integration/    131 pass  0 fail  1 skip
```

## Not covered here

The planner sees a region only when the capture found one. On a page opened by URL with the panel already open, that depends on the previous page: `overlay.ts:43` detects nothing across a URL change when the two pages are less than 50% similar. Two local simulations with the testomat fixtures:

- Arriving from a different capture (`testomat.html` → `testomat_modal.html`): similarity 9, no region.
- The same page with the detail panel removed, then restored: similarity 51, `region "unnamed" opened, scope: div.detail-view-content`. The name is `unnamed` because the panel's title is a textbox, not a heading; the scope is what identifies it.

Whether the traced page clears that bar is not verified. It needs that run's log, or a `DEBUG=explorbot:region,explorbot:overlay` run against the site. So this adds the missing channel; it does not guarantee the traced page gets a region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014x4F9pznfKRUe9zi81vKBA
