### PR TITLE
Let the Planner see how its tests ended

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 ### Changes
 
+- [Planner] The session test list now says how each test ended, and a failed or unfinished test carries the
+  last thing it observed, with a warning not to re-propose the behavior it attempted on another page. The
+  planner used to see only scenario titles, so a pattern that failed on one page — verifying a state the
+  interface never shows — was planned again on every page that had a similar control, all night long. Tests
+  that were started but never finished are named as unfinished rather than left looking unrun.
+- [Planner] Expected outcomes must now name what the page displays when they happen. "Data persistency
+  after page reload" is no longer offered as an outcome in its own right: a persistence check counts
+  only when the scenario names the on-screen evidence that will show it, and outcomes the page cannot
+  display at all — a clipboard write, "the operation succeeds" with nothing shown — are rejected at
+  planning time instead of failing at run time.
+- [Planner] A scenario that edits, deletes, reassigns or reconfigures a record must now act on a record
+  it creates as its own setup. Records the application already had are protected from mutation, so
+  "edit a visible record" scenarios were refused at run time no matter how visible the record was.
 - [Pilot] Text an app shows in a tooltip now reaches Pilot along with alerts and status messages. When a
   page refuses an action and explains why in a hover bubble, that sentence used to stay in the page HTML,
   which Pilot never sees — so a run could be judged, and reported, on a reason the app had already

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -359,7 +359,10 @@ export class Planner extends PlannerBase implements Agent {
       You can't test emails, database, SMS, or any external services.
       Suggest scenarios that can be potentially verified by UI.
       Focus on error or success messages as outcome.
-      Focus on URL page change or data persistency after page reload.
+      Focus on URL page change as outcome.
+      Every expected outcome must name what the page shows when it happens: a message, a list change, a control state, or a URL change.
+      Persistency after a reload counts only when the scenario names the on-screen evidence that will show it — a visible marker, a list entry, a stored setting shown in the interface.
+      An outcome the page cannot display — a clipboard write, an internal state with no visible trace, "the operation succeeds" with nothing shown — is not verifiable and must not be an expected outcome.
       If there are subpages (pages with same URL path) plan testing of those subpages as well
       Plan CRUD operations in order: create, read, update, delete.
       Do not invent specific route names, success messages, validation texts, badge counts, or welcome messages unless they are visible in research, visited pages, or prior observed flows.
@@ -374,6 +377,7 @@ export class Planner extends PlannerBase implements Agent {
       If the list is empty or no concrete item names are visible, do not invent "known" or "existing" items. Prefer empty-state, no-match search, clear-search, or read-only list behavior scenarios.
       Search, filter, sorting, tab, and list scenarios must start from a stable page where those controls are visible; avoid transient create/edit/new URLs unless the scenario tests that form.
       For option values and list items, use only visible or previously observed data; do not add create/update/delete setup unless the user explicitly requests that workflow.
+      A scenario that edits, deletes, reassigns, or reconfigures a record must act on a record the scenario itself creates as its setup — that setup is required, not optional, because records the app already had are protected from mutation. Acting on a pre-existing record makes the scenario unrunnable, however visible the record is.
       Detail-view scenarios must target visible data entities from list rows, cards, tree nodes, or detail links; do not use filter tabs, counters, status tabs, breadcrumbs, or navigation controls as detail targets.
       DO NOT propose "verification-only" tests that merely open a UI element (modal, dropdown, panel) and check it exists.
       Every test must complete a meaningful action that changes application state or produces a business outcome.
@@ -591,7 +595,9 @@ export class Planner extends PlannerBase implements Agent {
     const sessionTests = this.getSessionTestsSummary();
     if (sessionTests) {
       conversation.addUserText(dedent`
-        Tests already planned in this session across all pages. DO NOT duplicate any of these:
+        Tests already planned in this session across all pages, with how each one ended. DO NOT duplicate any of these.
+        A failed test means the app or the harness could not do what it tried: do not re-propose the same behavior on another page unless you can name what makes it work this time.
+        A failed or unfinished test carries the last thing it observed after the dash — read it before deciding that the behavior is worth trying again.
 
         <session_tests>
         ${sessionTests}

--- a/src/ai/planner/session-dedup.ts
+++ b/src/ai/planner/session-dedup.ts
@@ -1,4 +1,4 @@
-import type { Plan } from '../../test-plan.ts';
+import { type Plan, TestResult } from '../../test-plan.ts';
 import type { Constructor } from '../researcher/mixin.ts';
 
 const previousPlans: Plan[] = [];
@@ -18,7 +18,15 @@ export function WithSessionDedup<T extends Constructor>(Base: T) {
       for (const plan of previousPlans) {
         if (plan === this.currentPlan) continue;
         for (const test of plan.tests) {
-          lines.push(`${plan.url || '/'} | ${test.style || 'default'} | ${test.scenario}`);
+          const lastNote = Object.values(test.notes)
+            .filter((note) => note.message)
+            .pop();
+          const outcome = test.result || (lastNote ? 'unfinished' : 'pending');
+          let line = `${plan.url || '/'} | ${test.style || 'default'} | ${outcome} | ${test.scenario}`;
+          if ((outcome === TestResult.FAILED || outcome === 'unfinished') && lastNote) {
+            line += ` — ${lastNote.message.slice(0, 140)}`;
+          }
+          lines.push(line);
         }
       }
       return lines.join('\n');

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -448,8 +448,8 @@ describe('Planner with aimock', () => {
 
     const prompt = extractPromptText(mock.getLastRequest());
     expect(prompt).toContain('with how each one ended');
-    expect(prompt).toContain(`failed | Pin a visible task and verify the pinned state persists — Pin action failed, no pinned indicator`);
-    expect(prompt).toContain(`unfinished | Assign an assignee and verify the assignment persists — Could not find the record in the current list`);
+    expect(prompt).toContain('failed | Pin a visible task and verify the pinned state persists — Pin action failed, no pinned indicator');
+    expect(prompt).toContain('unfinished | Assign an assignee and verify the assignment persists — Could not find the record in the current list');
     expect(prompt).toContain('do not re-propose the same behavior');
     expect(prompt).toContain('read it before deciding');
   });

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -9,7 +9,7 @@ import { clearStyleCache } from '../../src/ai/planner/styles.ts';
 import { clearPlanRegistry, registerPlan } from '../../src/ai/planner/subpages.ts';
 import { Provider } from '../../src/ai/provider.ts';
 import { ConfigParser } from '../../src/config.ts';
-import { Plan, Test } from '../../src/test-plan.ts';
+import { Plan, Test, TestResult } from '../../src/test-plan.ts';
 
 const UI_MAPS_DIR = join(process.cwd(), 'test-data', 'ui-maps');
 
@@ -430,5 +430,43 @@ describe('Planner with aimock', () => {
     }
 
     expect(extractPromptText(mock.getLastRequest())).toContain('roughly 100%');
+  });
+
+  it('tells the planner how session tests ended', async () => {
+    const finished = new Plan('Pin Testing');
+    finished.url = '/tasks/board';
+    const failed = new Test('Pin a visible task and verify the pinned state persists', 'normal', ['Pinned state shown'], '/tasks/board', ['Click Pin']);
+    failed.addNote('Pin action failed, no pinned indicator');
+    failed.finish(TestResult.FAILED);
+    finished.addTest(failed);
+    const aborted = new Test('Assign an assignee and verify the assignment persists', 'normal', ['Assignee shown'], '/tasks/board', ['Open assignee menu']);
+    aborted.addNote('Could not find the record in the current list');
+    finished.addTest(aborted);
+    planner.registerPlanInSession(finished);
+
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('with how each one ended');
+    expect(prompt).toContain(`failed | Pin a visible task and verify the pinned state persists — Pin action failed, no pinned indicator`);
+    expect(prompt).toContain(`unfinished | Assign an assignee and verify the assignment persists — Could not find the record in the current list`);
+    expect(prompt).toContain('do not re-propose the same behavior');
+    expect(prompt).toContain('read it before deciding');
+  });
+
+  it('requires outcomes the page can show', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('must name what the page shows when it happens');
+    expect(prompt).toContain('not verifiable and must not be an expected outcome');
+  });
+
+  it('forbids mutating records the app already had', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('records the app already had are protected from mutation');
+    expect(prompt).toContain('Acting on a pre-existing record makes the scenario unrunnable');
   });
 });


### PR DESCRIPTION
## Summary

 The Planner planned blind. The session test list carried only scenario titles, successful flows were the only experience it ever saw, and one of its own rules asked for "data persistency after page reload" outcomes - so the same doomed patterns were proposed on page after page. In the last night run (13 pages, 57 tests) seven "verify it persists after reload" scenarios produced three failures and four unfinished tests, and zero passes