### PR TITLE
Send apibot traces to Langfuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2026-09-11
+
+### Changes
+
+- [Apibot] Runs now send traces to Langfuse when `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are set in
+  the environment, the same way explorbot runs do. Apibot used to read Langfuse settings only from
+  `ai.langfuse` in its config file, so a run started by a host that passes its environment along produced
+  no traces at all.
+- [Apibot] Traces are sent before the process exits, also when a run fails. The last planning or test trace
+  of a run used to be lost on exit.
+- [Apibot] Each API test is now one trace that includes its final review. The review used to arrive as a
+  separate trace with no link to the test it judged, and its tokens were counted under `unknown`. Settings
+  under `ai.agents.curler` (`providerOptions`, `reasoning`) now apply to the review as well.
+
 ## 2026-09-10
 
 ### Changes

--- a/boat/api-tester/src/ai/curler.ts
+++ b/boat/api-tester/src/ai/curler.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { AIProvider } from '../../../../src/ai/provider.ts';
 import type { RequestStore } from '../../../../src/api/request-store.ts';
 import type { KnowledgeTracker } from '../../../../src/knowledge-tracker.ts';
+import { Observability } from '../../../../src/observability.ts';
 import type { Reporter } from '../../../../src/reporter.ts';
 import { type Test, TestResult } from '../../../../src/test-plan.ts';
 import { createDebug, tag } from '../../../../src/utils/logger.ts';
@@ -46,75 +47,77 @@ export class Curler {
     const initialPrompt = this.buildTestPrompt(test, opts?.specDefinition, opts?.baseEndpoint);
     conversation.addUserText(initialPrompt);
 
-    await loop(
-      async ({ stop, iteration }) => {
-        debugLog(`Iteration ${iteration}`);
-
-        if (iteration > 1) {
-          const requestLog = this.requestState.toLog();
-          const nextStep = dedent`
-            <request_log>
-            ${requestLog || 'No requests made yet'}
-            </request_log>
-
-            <task>
-            Continue testing. Review the request log above and proceed with the next step.
-            </task>
-
-            <notes>
-            ${test.notesToString() || 'No notes yet'}
-            </notes>
-          `;
-          conversation.addUserText(nextStep);
-        }
-
-        const result = await this.provider.invokeConversation(conversation, tools, {
-          maxToolRoundtrips: 5,
-          toolChoice: 'required',
-          agentName: 'curler',
-        });
-
-        if (!result) throw new Error('Failed to get response from provider');
-
-        const toolNames = result.toolExecutions?.map((e: any) => e.toolName) || [];
-        debugLog('Tool calls:', toolNames.join(', '));
-
-        if (test.hasFinished) {
-          stop();
-          return;
-        }
-
-        if (iteration >= MAX_ITERATIONS) {
-          tag('warning').log('Max iterations reached, running final review...');
-          stop();
-        }
-      },
+    await Observability.run(
+      `curler: ${test.scenario}`,
       {
-        maxAttempts: MAX_ITERATIONS,
-        observability: {
-          name: `curler: ${test.scenario}`,
-          agent: 'curler',
-          sessionId: test.sessionName,
-          metadata: {
-            input: {
-              scenario: test.scenario,
-              startUrl: test.startUrl,
-              expected: test.expected,
-            },
+        sessionId: test.sessionName,
+        tags: ['curler'],
+        input: {
+          scenario: test.scenario,
+          startUrl: test.startUrl,
+          expected: test.expected,
+        },
+      },
+      async () => {
+        await loop(
+          async ({ stop, iteration }) => {
+            debugLog(`Iteration ${iteration}`);
+
+            if (iteration > 1) {
+              const requestLog = this.requestState.toLog();
+              const nextStep = dedent`
+                <request_log>
+                ${requestLog || 'No requests made yet'}
+                </request_log>
+
+                <task>
+                Continue testing. Review the request log above and proceed with the next step.
+                </task>
+
+                <notes>
+                ${test.notesToString() || 'No notes yet'}
+                </notes>
+              `;
+              conversation.addUserText(nextStep);
+            }
+
+            const result = await this.provider.invokeConversation(conversation, tools, {
+              maxToolRoundtrips: 5,
+              toolChoice: 'required',
+              agentName: 'curler',
+            });
+
+            if (!result) throw new Error('Failed to get response from provider');
+
+            const toolNames = result.toolExecutions?.map((e: any) => e.toolName) || [];
+            debugLog('Tool calls:', toolNames.join(', '));
+
+            if (test.hasFinished) {
+              stop();
+              return;
+            }
+
+            if (iteration >= MAX_ITERATIONS) {
+              tag('warning').log('Max iterations reached, running final review...');
+              stop();
+            }
           },
-        },
-        catch: async ({ error, stop }) => {
-          tag('error').log(`Test execution error: ${error}`);
-          stop();
-        },
+          {
+            maxAttempts: MAX_ITERATIONS,
+            catch: async ({ error, stop }) => {
+              tag('error').log(`Test execution error: ${error}`);
+              stop();
+            },
+          }
+        );
+
+        try {
+          await this.finalReview(test);
+        } catch (error) {
+          tag('error').log(`Final review failed: ${error}`);
+        }
       }
     );
-
-    try {
-      await this.finalReview(test);
-    } catch (error) {
-      tag('error').log(`Final review failed: ${error}`);
-    }
     this.finishTest(test);
     const meta: Record<string, string | undefined> = {
       endpoint: test.startUrl,
@@ -190,7 +193,8 @@ export class Curler {
         },
       ],
       schema,
-      model
+      model,
+      { agentName: 'curler', telemetryFunctionId: 'curler.finalReview' }
     );
 
     const result = response?.object;

--- a/boat/api-tester/src/apibot.ts
+++ b/boat/api-tester/src/apibot.ts
@@ -85,6 +85,7 @@ export class ApiBot {
   async stop(): Promise<void> {
     await this.reporter?.finishRun();
     await this.apiClient?.teardown();
+    await this.provider?.stop();
   }
 
   createAgent<T>(factory: (deps: { ai: AIProvider; config: ApibotConfig; apiClient: ApiClient; requestState: RequestStore; knowledge: KnowledgeTracker }) => T): T {

--- a/boat/api-tester/src/cli.ts
+++ b/boat/api-tester/src/cli.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { flushTelemetry } from '../../../src/ai/provider.ts';
 import { ConfigCommand } from '../../../src/commands/config-command.ts';
 import { RecommendedModelsCommand } from '../../../src/commands/recommended-models-command.ts';
 import { listSites } from '../../../src/global-config.ts';
@@ -111,6 +112,7 @@ async function run(name: string, options: any, endpoint: string | undefined, bod
     process.exit(code);
   } catch (error) {
     console.error('Failed:', error instanceof Error ? error.message : 'Unknown error');
+    await flushTelemetry();
     process.exit(1);
   }
 }

--- a/boat/api-tester/src/config.ts
+++ b/boat/api-tester/src/config.ts
@@ -2,7 +2,22 @@ import { existsSync, mkdirSync, readFileSync } from 'node:fs';
 import path, { resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { parseEnv } from 'node:util';
-import { type AIConfig, type ApiHookFn, type ApiConfig as BaseApiConfig, ConfigMissingError, EXPLORBOT_CONFIG_PATHS, createModel, envConfigRequested, materializeKnowledge, missingConfigMessage, resolveConfigModels, resolveModel, resolveOutputRoot, setOutputDir } from '../../../src/config.ts';
+import {
+  type AIConfig,
+  type ApiHookFn,
+  type ApiConfig as BaseApiConfig,
+  ConfigMissingError,
+  EXPLORBOT_CONFIG_PATHS,
+  createModel,
+  envConfigRequested,
+  materializeKnowledge,
+  missingConfigMessage,
+  resolveConfigModels,
+  resolveLangfuse,
+  resolveModel,
+  resolveOutputRoot,
+  setOutputDir,
+} from '../../../src/config.ts';
 import { type SiteRecord, findGlobalConfig, globalEnvPath, isGlobalConfigPath, registerSite, resolveSiteTarget } from '../../../src/global-config.ts';
 
 export type { AIConfig };
@@ -101,6 +116,7 @@ export class ApibotConfigParser {
       this.applyEnvHeaders(this.config.api);
       if (options?.baseEndpoint) this.config.api.baseEndpoint = options.baseEndpoint.replace(/\/$/, '');
       await resolveConfigModels(this.config.ai);
+      resolveLangfuse(this.config.ai);
       this.configPath = resolvedPath;
       this.site = null;
 
@@ -236,6 +252,7 @@ export class ApibotConfigParser {
       api,
       dirs: { output: '.', knowledge: 'knowledge' },
     };
+    resolveLangfuse(this.config.ai);
     this.configPath = path.join(outputRoot, 'apibot.config.js');
     this.validateConfig(this.config);
     setOutputDir(this.getOutputDir());

--- a/src/config.ts
+++ b/src/config.ts
@@ -677,17 +677,7 @@ export class ConfigParser {
       config.playwright.url = options.baseUrl;
     }
 
-    if (config.ai) {
-      const langfuse = config.ai.langfuse;
-      const publicKey = langfuse?.publicKey || process.env.LANGFUSE_PUBLIC_KEY;
-      const secretKey = langfuse?.secretKey || process.env.LANGFUSE_SECRET_KEY;
-      config.ai.langfuse = {
-        enabled: langfuse?.enabled ?? Boolean(publicKey && secretKey),
-        publicKey,
-        secretKey,
-        baseUrl: langfuse?.baseUrl || process.env.LANGFUSE_BASE_URL || process.env.LANGFUSE_HOST,
-      };
-    }
+    resolveLangfuse(config.ai);
 
     return config;
   }
@@ -855,6 +845,20 @@ export async function resolveConfigModels(ai?: AIConfig): Promise<void> {
   for (const agent of Object.values(ai.agents || {})) {
     if (typeof agent?.model === 'string') agent.model = await resolveModel(agent.model);
   }
+}
+
+export function resolveLangfuse(ai?: AIConfig): void {
+  if (!ai) return;
+
+  const langfuse = ai.langfuse;
+  const publicKey = langfuse?.publicKey || process.env.LANGFUSE_PUBLIC_KEY;
+  const secretKey = langfuse?.secretKey || process.env.LANGFUSE_SECRET_KEY;
+  ai.langfuse = {
+    enabled: langfuse?.enabled ?? Boolean(publicKey && secretKey),
+    publicKey,
+    secretKey,
+    baseUrl: langfuse?.baseUrl || process.env.LANGFUSE_BASE_URL || process.env.LANGFUSE_HOST,
+  };
 }
 
 export function resolveOutputRoot(baseUrl?: string): string {

--- a/tests/unit/apibot-config.test.ts
+++ b/tests/unit/apibot-config.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { ApibotConfigParser } from '../../boat/api-tester/src/config.ts';
 import { ConfigParser } from '../../src/config.ts';
 
-const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_API_SPEC', 'EXPLORBOT_API_HEADERS'];
+const ENV_KEYS = ['EXPLORBOT_AI_PROVIDER', 'EXPLORBOT_AI_MODEL', 'EXPLORBOT_URL', 'EXPLORBOT_OUTPUT', 'EXPLORBOT_API_SPEC', 'EXPLORBOT_API_HEADERS', 'LANGFUSE_PUBLIC_KEY', 'LANGFUSE_SECRET_KEY', 'LANGFUSE_BASE_URL', 'LANGFUSE_HOST'];
 
 describe('ApibotConfigParser environment fallback', () => {
   let savedEnv: Record<string, string | undefined> = {};
@@ -113,6 +113,41 @@ describe('ApibotConfigParser environment fallback', () => {
     const config = await parser.loadConfig({ config: configPath });
 
     expect(config.api.headers).toEqual({ Accept: 'application/json', 'X-Tenant': 'acme', Authorization: 'Bearer token-123' });
+  });
+
+  it('enables Langfuse from LANGFUSE_* env vars without a config file', async () => {
+    process.env.EXPLORBOT_AI_MODEL = 'openrouter/openai/gpt-oss-120b';
+    process.env.EXPLORBOT_URL = 'https://api.example.com';
+    process.env.EXPLORBOT_OUTPUT = outputRoot;
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-lf-test';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-lf-test';
+    process.env.LANGFUSE_BASE_URL = 'http://localhost:3001';
+
+    const config = await parser.loadConfig({ path: outputRoot });
+
+    expect(config.ai.langfuse).toEqual({ enabled: true, publicKey: 'pk-lf-test', secretKey: 'sk-lf-test', baseUrl: 'http://localhost:3001' });
+  });
+
+  it('enables Langfuse from LANGFUSE_* env vars for a config file without ai.langfuse', async () => {
+    const configPath = join(outputRoot, 'apibot.config.js');
+    writeFileSync(configPath, "export default { ai: { model: { modelId: 'test-model' } }, api: { baseEndpoint: 'https://api.example.com' } };\n", 'utf8');
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-lf-test';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-lf-test';
+
+    const config = await parser.loadConfig({ config: configPath, path: outputRoot });
+
+    expect(config.ai.langfuse?.enabled).toBe(true);
+  });
+
+  it('keeps Langfuse off when the config file disables it', async () => {
+    const configPath = join(outputRoot, 'apibot.config.js');
+    writeFileSync(configPath, "export default { ai: { model: { modelId: 'test-model' }, langfuse: { enabled: false } }, api: { baseEndpoint: 'https://api.example.com' } };\n", 'utf8');
+    process.env.LANGFUSE_PUBLIC_KEY = 'pk-lf-test';
+    process.env.LANGFUSE_SECRET_KEY = 'sk-lf-test';
+
+    const config = await parser.loadConfig({ config: configPath, path: outputRoot });
+
+    expect(config.ai.langfuse?.enabled).toBe(false);
   });
 
   it('throws when EXPLORBOT_URL is unset', async () => {


### PR DESCRIPTION
## What went wrong

`apibot explore` runs started from Testeiya showed up in Langfuse only as the host's own trace: `apibot explore`, tags `bot,testeiya`, one observation holding the transcript (e.g. `b477eb57662dd5454aeb42fb8c235c10`, `8c65b6339b1fcafa27570ac50a74f9b2`). When the same host starts `explorbot explore`, the child's own `planner:` / `test:` / `researcher:` traces arrive next to that host trace. For apibot nothing else arrived. The project's last `chief:` / `curler:` traces date from March.

## Root cause

A regression from a64f814 (2026-08-18). That commit moved the `LANGFUSE_*` env fallback out of `Provider.initLangfuse()` into explorbot's `ConfigParser.resolveConfig`. Apibot builds its provider from `ApibotConfigParser`, which never got the same resolution. So `initLangfuse()` found no keys and returned before registering the span processor. With the same env, `apibot config --json` reported `langfuse: false` and `explorbot config --json` reported `true`.

The resolution is now one exported `resolveLangfuse(ai)` in `src/config.ts`, next to `resolveConfigModels`. Explorbot's parser calls it in place of its inline block, so explorbot's behavior is unchanged. `ApibotConfigParser` calls it for both a config file and env-only mode.

## Two related gaps

- **No flush before exit.** `ApiBot.stop()` never stopped the provider, and the CLI calls `process.exit()` right after, which skips the `beforeExit` flush. Spans still waiting in the batch were dropped, usually the last planning or test trace of a run. `stop()` now calls `provider.stop()`, and the CLI's error path calls `flushTelemetry()`, as explorbot's CLI does.
- **Final review outside the test trace.** Curler put only its loop inside a span, so `finalReview` became a separate top-level trace. Each test now runs inside one `Observability.run` that covers the loop and the review, the same shape Tester uses. The review call is tagged `curler.finalReview` and now passes `agentName: 'curler'`. Its tokens now count toward `curler` instead of `unknown`, and `ai.agents.curler.providerOptions` / `reasoning` now apply to it too.

## Not in scope

- When the host stops a run (SIGTERM, exit 143), a test still in progress never ends its root span. Its observations then land in a nameless trace whose parent never arrives. Explorbot's non-TUI commands have the same gap.
- `Provider.validateConnection()` sends its `"hi"` probe as a separate `invoke_agent` trace on every run, explorbot included.

## Testing

- `tests/unit/apibot-config.test.ts`: `LANGFUSE_*` env enables tracing in env-only and config-file modes, and both tests fail without the fix. An explicit `langfuse: { enabled: false }` stays off.
- `bun test tests/unit/`: 1369 pass, 0 fail.
- `bun test tests/integration/`: 129 pass, 1 skip, 0 fail. `overlay-modal-browser.test.ts` hit its 5s timeouts in 2 of 4 runs; it doesn't touch apibot, Curler or Langfuse.
- Live, against a local Langfuse:
  - `apibot plan /suites` produced `chief: /suites`: root span → agent → generation with prompt and token usage. It arrived even though the process exits right after.
  - `apibot test suites.md 2` produced `curler: Retrieve a suite by ID` with 55 observations and `curler.finalReview` nested inside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018UbyZxgKMUNRgLzmv4KwcT
