### PR TITLE
 Anchor planning to stable pages, not single records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2026-09-11
+
+### Changes
+
+- [Planner] The sub-page picker now prefers stable pages over record forms. A page that edits or
+  configures one specific record is a step inside a feature, not a feature's planning base, and the
+  record it addresses may already have been deleted by another test — so the picker is told to take
+  the page that lists or holds the collection instead. In the last night run the picker visited edit
+  URLs of records earlier tests had deleted, and every scenario planned there died on a 404.
+- [Planner] Scenarios must anchor to the stable page that holds a collection, never to the URL or ID
+  of one specific record; the steps locate the record from the stable page instead. Scenarios pinned
+  to single records kept failing once sibling tests removed those records.
+
 ## 2026-09-10
 
 ### Changes

--- a/src/ai/planner.ts
+++ b/src/ai/planner.ts
@@ -373,6 +373,7 @@ export class Planner extends PlannerBase implements Agent {
       For scenarios that act on existing items or search/filter by existing values, use only item names or values visible in research, visited pages, or prior observed flows.
       If the list is empty or no concrete item names are visible, do not invent "known" or "existing" items. Prefer empty-state, no-match search, clear-search, or read-only list behavior scenarios.
       Search, filter, sorting, tab, and list scenarios must start from a stable page where those controls are visible; avoid transient create/edit/new URLs unless the scenario tests that form.
+      A scenario anchors to a stable page that holds the collection — never to the URL or ID of one specific record, which another test may have deleted by the time this one runs; steps locate the record from the stable page instead.
       For option values and list items, use only visible or previously observed data; do not add create/update/delete setup unless the user explicitly requests that workflow.
       Detail-view scenarios must target visible data entities from list rows, cards, tree nodes, or detail links; do not use filter tabs, counters, status tabs, breadcrumbs, or navigation controls as detail targets.
       DO NOT propose "verification-only" tests that merely open a UI element (modal, dropdown, panel) and check it exists.

--- a/src/ai/planner/subpages.ts
+++ b/src/ai/planner/subpages.ts
@@ -95,6 +95,8 @@ export function WithSubPages<T extends Constructor>(Base: T) {
           Higher visit count means the page was encountered more during testing — likely more important.
           Detect template pages: /users/1 and /users/2 are the same template — if one was planned, skip all others.
           Compare page titles, headings, and URL structure to detect templates.
+          Prefer stable pages over transient ones: a page that edits, creates, or configures one specific record is a step inside a feature, not a feature's planning base — pick the page that lists or holds the collection instead.
+          A URL that addresses one particular record can also name a record the run has already deleted.
           Skip help/docs/about pages if core feature pages remain.
           Return null for url when no more relevant pages remain.
         `,

--- a/tests/integration/planner.test.ts
+++ b/tests/integration/planner.test.ts
@@ -227,6 +227,29 @@ describe('Planner with aimock', () => {
     expect(prompt).not.toContain('merge them into one');
   });
 
+  it('anchors scenarios to a stable page, never a single record', async () => {
+    await planner.plan();
+
+    const prompt = extractPromptText(mock.getLastRequest());
+    expect(prompt).toContain('never to the URL or ID of one specific record');
+    expect(prompt).toContain('another test may have deleted');
+  });
+
+  it('tells the sub-page picker to prefer stable pages over record forms', async () => {
+    mock.clearFixtures();
+    mock.on({}, { content: JSON.stringify({ url: '/tasks/board', reason: 'Stable list page' }) });
+
+    const pick = await planner.pickNextSubPage([
+      { url: '/tasks/board', title: 'Task Board', h1: 'Tasks', visitCount: 3 },
+      { url: '/tasks/42/edit', title: 'Edit task', h1: 'Edit', visitCount: 1 },
+    ]);
+
+    const prompt = extractPromptText(mock.getRequests()[0]);
+    expect(prompt).toContain("not a feature's planning base");
+    expect(prompt).toContain('pick the page that lists or holds the collection instead');
+    expect(pick?.url).toBe('/tasks/board');
+  });
+
   it('does not label test data as disposable', async () => {
     await planner.plan();
 


### PR DESCRIPTION
 ## Summary
 
 When a record dies mid-run, everything planned on it dies with it. In the last night run the sub-page picker visited the edit URL of a record an earlier test had deleted, the planner built five scenarios on that page, and all of them stopped on a 404 - about a quarter of the night's failed tests trace back to this shape.

  Two general rules close it:

  - The sub-page picker prefers stable pages over record forms: a page that edits or configures one specific record is a step inside a feature, not a feature's planning base, and the record it addresses may already be gone — pick the page that lists the collection instead.
  - Scenarios anchor to the stable page holding a collection, never to the URL or ID of one specific record; the steps locate the record from that page.

